### PR TITLE
Add /config/snapshot and /config/apply endpoints

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -12,6 +12,7 @@ import activityRouter from './controllers/activity.js';
 import assetsRouter from './controllers/assets.js';
 import authRouter from './controllers/auth.js';
 import collectionsRouter from './controllers/collections.js';
+import configRouter from './controllers/config.js';
 import dashboardsRouter from './controllers/dashboards.js';
 import extensionsRouter from './controllers/extensions.js';
 import fieldsRouter from './controllers/fields.js';
@@ -246,6 +247,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.use('/activity', activityRouter);
 	app.use('/assets', assetsRouter);
 	app.use('/collections', collectionsRouter);
+	app.use('/config', configRouter);
 	app.use('/dashboards', dashboardsRouter);
 	app.use('/extensions', extensionsRouter);
 	app.use('/fields', fieldsRouter);

--- a/api/src/controllers/config.ts
+++ b/api/src/controllers/config.ts
@@ -1,0 +1,156 @@
+import express from 'express';
+import { load as loadYaml } from 'js-yaml';
+import getDatabase from '../database/index.js';
+import env from '../env.js';
+import { ForbiddenException, InvalidPayloadException, UnsupportedMediaTypeException } from '../exceptions/index.js';
+import { respond } from '../middleware/respond.js';
+import asyncHandler from '../utils/async-handler.js';
+import { applyConfigPlan } from '../utils/apply-config-plan.js';
+import { computeConfigPlan, validateConfigPlan } from '../utils/compute-config-plan.js';
+import { getConfigSnapshot } from '../utils/get-config-snapshot.js';
+import { getSchema } from '../utils/get-schema.js';
+import type { CairnConfig } from '../types/config.js';
+
+const router = express.Router();
+
+router.get(
+	'/snapshot',
+	asyncHandler(async (req, res, next) => {
+		if (req.accountability?.admin !== true) throw new ForbiddenException();
+
+		const config = await getConfigSnapshot();
+
+		res.locals['payload'] = { data: config };
+		res.locals['cache'] = false;
+
+		return next();
+	}),
+	respond
+);
+
+const yamlBodyParser = express.text({
+	type: ['application/x-yaml', 'application/yaml', 'text/yaml'],
+	limit: env['MAX_PAYLOAD_SIZE'],
+});
+
+router.post(
+	'/apply',
+	yamlBodyParser,
+	asyncHandler(async (req, res, next) => {
+		if (req.accountability?.admin !== true) throw new ForbiddenException();
+
+		const desired = parseDesiredConfig(req);
+
+		const dryRun = req.query['dry_run'] === 'true';
+		const destructive = req.query['destructive'] === 'true';
+
+		const database = getDatabase();
+		const schema = await getSchema({ database, bypassCache: true });
+
+		const current = await getConfigSnapshot({ database, schema });
+		const plan = computeConfigPlan(current, desired);
+
+		const currentRoles = new Map(current.roles.map((r) => [r.key, { admin_access: r.admin_access }]));
+		const validation = validateConfigPlan(plan, desired, { currentRoles });
+
+		if (validation.errors.length > 0) {
+			res.status(400).json({ errors: validation.errors });
+			return;
+		}
+
+		const result = await applyConfigPlan(plan, { database, schema, dryRun, destructive });
+
+		res.locals['payload'] = { data: result };
+
+		return next();
+	}),
+	respond
+);
+
+function parseDesiredConfig(req: express.Request): CairnConfig {
+	let parsed: unknown;
+
+	if (req.is('application/json')) {
+		parsed = req.body;
+	} else if (req.is('application/x-yaml') || req.is('application/yaml') || req.is('text/yaml')) {
+		try {
+			parsed = loadYaml(req.body);
+		} catch (err: any) {
+			throw new InvalidPayloadException(`Invalid YAML: ${err.message ?? 'parse error'}`);
+		}
+	} else {
+		throw new UnsupportedMediaTypeException(`Unsupported Content-Type: ${req.headers['content-type'] ?? '(none)'}`);
+	}
+
+	return assertCairnConfigShape(parsed);
+}
+
+function assertCairnConfigShape(value: unknown): CairnConfig {
+	if (!isPlainObject(value)) {
+		throw new InvalidPayloadException(
+			'Request body must be a CairnConfig object with manifest, roles, and permissions.'
+		);
+	}
+
+	if (!isPlainObject(value['manifest'])) {
+		throw new InvalidPayloadException('Request body is missing the required "manifest" object.');
+	}
+
+	if (!Array.isArray(value['roles'])) {
+		throw new InvalidPayloadException('Request body field "roles" must be an array.');
+	}
+
+	if (!Array.isArray(value['permissions'])) {
+		throw new InvalidPayloadException('Request body field "permissions" must be an array.');
+	}
+
+	value['roles'].forEach((role, index) => {
+		if (!isPlainObject(role)) {
+			throw new InvalidPayloadException(`roles[${index}] must be an object.`);
+		}
+
+		if (typeof role['key'] !== 'string') {
+			throw new InvalidPayloadException(`roles[${index}] is missing a string "key".`);
+		}
+	});
+
+	value['permissions'].forEach((set, setIndex) => {
+		if (!isPlainObject(set)) {
+			throw new InvalidPayloadException(`permissions[${setIndex}] must be an object.`);
+		}
+
+		if (typeof set['role'] !== 'string') {
+			throw new InvalidPayloadException(`permissions[${setIndex}] is missing a string "role".`);
+		}
+
+		if (!Array.isArray(set['permissions'])) {
+			throw new InvalidPayloadException(`permissions[${setIndex}].permissions must be an array.`);
+		}
+
+		set['permissions'].forEach((perm: unknown, permIndex: number) => {
+			if (!isPlainObject(perm)) {
+				throw new InvalidPayloadException(`permissions[${setIndex}].permissions[${permIndex}] must be an object.`);
+			}
+
+			if (typeof perm['collection'] !== 'string') {
+				throw new InvalidPayloadException(
+					`permissions[${setIndex}].permissions[${permIndex}] is missing a string "collection".`
+				);
+			}
+
+			if (typeof perm['action'] !== 'string') {
+				throw new InvalidPayloadException(
+					`permissions[${setIndex}].permissions[${permIndex}] is missing a string "action".`
+				);
+			}
+		});
+	});
+
+	return value as unknown as CairnConfig;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export default router;

--- a/api/src/utils/compute-config-plan.test.ts
+++ b/api/src/utils/compute-config-plan.test.ts
@@ -70,6 +70,71 @@ describe('computeConfigPlan', () => {
 		expect(plan.roles.update).toEqual([]);
 	});
 
+	describe('omit-preserve role diff semantics', () => {
+		it('does not emit a role update when desired omits optional fields that exist in current', () => {
+			const current = makeConfig({
+				roles: [makeRole('editor', { icon: 'edit', enforce_tfa: true })],
+			});
+
+			const desired = makeConfig({ roles: [makeRole('editor')] });
+			const plan = computeConfigPlan(current, desired);
+
+			expect(plan.roles.update).toEqual([]);
+		});
+
+		it('does not clear description when desired omits it', () => {
+			const current = makeConfig({
+				roles: [makeRole('editor', { description: 'old description' })],
+			});
+
+			const desired = makeConfig({ roles: [makeRole('editor')] });
+			const plan = computeConfigPlan(current, desired);
+
+			expect(plan.roles.update).toEqual([]);
+		});
+
+		it('does not clear ip_access when desired omits it', () => {
+			const current = makeConfig({
+				roles: [makeRole('editor', { ip_access: ['10.0.0.0/8'] })],
+			});
+
+			const desired = makeConfig({ roles: [makeRole('editor')] });
+			const plan = computeConfigPlan(current, desired);
+
+			expect(plan.roles.update).toEqual([]);
+		});
+
+		it('clears nullable description when desired sets it explicitly to null', () => {
+			const current = makeConfig({
+				roles: [makeRole('editor', { description: 'old description' })],
+			});
+
+			const desired = makeConfig({
+				roles: [makeRole('editor', { description: null })],
+			});
+
+			const plan = computeConfigPlan(current, desired);
+
+			expect(plan.roles.update).toHaveLength(1);
+			expect(plan.roles.update[0]!.diff).toEqual({ description: null });
+		});
+
+		it('emits an ip_access change when desired sets a new value', () => {
+			const current = makeConfig({
+				roles: [makeRole('editor', { ip_access: null })],
+			});
+
+			const desired = makeConfig({
+				roles: [makeRole('editor', { ip_access: ['10.0.0.0/8'] })],
+			});
+
+			const plan = computeConfigPlan(current, desired);
+
+			expect(plan.roles.update).toHaveLength(1);
+			expect(plan.roles.update[0]!.diff).toEqual({ ip_access: ['10.0.0.0/8'] });
+		});
+	});
+
 	it('detects new permissions to create', () => {
 		const current = makeConfig({ roles: [makeRole('editor')] });
 

--- a/api/src/utils/compute-config-plan.ts
+++ b/api/src/utils/compute-config-plan.ts
@@ -10,13 +10,15 @@ function roleChanged(current: ConfigRole, desired: ConfigRole): Partial<ConfigRo
 	let hasChanges = false;
 
 	for (const field of ['name', 'icon', 'description', 'admin_access', 'app_access', 'enforce_tfa'] as const) {
+		if (!Object.hasOwn(desired, field)) continue;
+
 		if (!isEqual(current[field], desired[field])) {
 			(diff as any)[field] = desired[field];
 			hasChanges = true;
 		}
 	}
 
-	if (!isEqual(current.ip_access ?? null, desired.ip_access ?? null)) {
+	if (Object.hasOwn(desired, 'ip_access') && !isEqual(current.ip_access ?? null, desired.ip_access ?? null)) {
 		diff.ip_access = desired.ip_access ?? null;
 		hasChanges = true;
 	}

--- a/tests/blackbox/README.md
+++ b/tests/blackbox/README.md
@@ -1,6 +1,6 @@
 # Blackbox Tests
 
-Integration tests that spin up a real CairnCMS API server and exercise REST and GraphQL endpoints end-to-end. ~9,000 tests across 6 supported database vendors.
+Integration tests that spin up a real CairnCMS API server and exercise REST and GraphQL endpoints end-to-end.
 
 ## Important: Two Docker Compose Files
 
@@ -39,12 +39,20 @@ From the **repo root** (not this folder):
 TEST_DB=postgres pnpm test:blackbox
 ```
 
-This handles the build/deploy step automatically.
+This runs blackbox tests against the currently built server code.
 
 On systems with limited RAM (<8GB), limit parallelism:
 
 ```bash
 TEST_DB=postgres pnpm test:blackbox -- --maxWorkers=2
+```
+
+#### Important: blackbox runs against whatever is already in `dist/`
+
+`pnpm test:blackbox` does NOT rebuild before running. It deploys what each package has already built. If you have changed source in `api/`, `app/`, or any other package since the last build, the deploy will copy stale compiled output and tests will run against the old behavior. Rebuild first when iterating on package source:
+
+```bash
+pnpm build && TEST_DB=postgres pnpm test:blackbox
 ```
 
 ### Testing a specific database
@@ -81,3 +89,55 @@ TEST_DB=postgres TEST_LOCAL=true pnpm test:blackbox
 ```
 
 This uses `127.0.0.1:8055` as the URL. Make sure your instance is connected to the test database container from the docker-compose in this folder.
+
+## Adding a new test file
+
+**Register every new blackbox test file in `setup/sequentialTests.js`.** If you skip this step, filtered runs can hang before the first test starts, and full-suite ordering of your file is not guaranteed.
+
+Add the path under either:
+
+- `before` — runs in the early sequence (typical for new route contract tests; pick a position near similar files)
+- `after` — runs late, used for files that must execute serially after everything else
+
+The framework runs test files through an ordering barrier defined in `setup/customEnvironment.ts`: each file's setup polls a flow-tracking endpoint and waits for prior files to mark themselves complete before its tests start.
+
+Example:
+
+```javascript
+// tests/blackbox/setup/sequentialTests.js
+exports.list = {
+    before: [
+        { testFilePath: '/common/seed-database.test.ts' },
+        { testFilePath: '/common/common.test.ts' },
+        { testFilePath: '/routes/schema/schema.test.ts' },
+        { testFilePath: '/routes/your-feature/your-feature.test.ts' }, // ← add here
+        // ...
+    ],
+};
+```
+
+If you skip registration, the framework defaults the file's index to `before.length`, meaning it waits for that many other files to finish. In a full-suite run this works because enough other files do finish; in a path-filtered run it deadlocks.
+
+### Single-file runs are not supported by default
+
+`jest path/to/your.test.ts` (or `pnpm test:blackbox -- routes/your-feature`) **will hang silently after `globalSetup`** — even for files registered in `before` or `after` because the file's expected ordering position can never be reached when only one file is in the queue.
+
+For local iteration on a single file, temporarily set the `only` array in `setup/sequentialTests.js`:
+
+```javascript
+only: [
+    { testFilePath: '/routes/your-feature/your-feature.test.ts' },
+],
+```
+
+This bypasses the ordering barrier (the file becomes index 0). Revert `only` to an empty array before committing, or CI will run only that one file.
+
+### Verifying a new test file
+
+Run the full blackbox suite for one vendor locally and confirm both that your file passes and that the suite as a whole still passes:
+
+```bash
+pnpm build && TEST_DB=postgres pnpm test:blackbox -- --runInBand
+```
+
+CI runs the full vendor matrix automatically on push to `main`. `--runInBand` matches the CI invocation (see `.github/workflows/blackbox-main.yml`) and avoids worker port collisions.

--- a/tests/blackbox/routes/config/config.test.ts
+++ b/tests/blackbox/routes/config/config.test.ts
@@ -1,0 +1,451 @@
+import request from 'supertest';
+import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
+import { getUrl } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+
+type ConfigSnapshot = {
+	manifest: { version: number; resources: string[] };
+	roles: Array<Record<string, any>>;
+	permissions: Array<{ role: string; permissions: Array<Record<string, any>> }>;
+};
+
+const baselineCache: Record<string, ConfigSnapshot> = {};
+
+async function getBaseline(vendor: string): Promise<ConfigSnapshot> {
+	if (!baselineCache[vendor]) {
+		const response = await request(getUrl(vendor))
+			.get('/config/snapshot')
+			.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+		expect(response.statusCode).toBe(200);
+		baselineCache[vendor] = response.body.data;
+	}
+
+	return JSON.parse(JSON.stringify(baselineCache[vendor]!)) as ConfigSnapshot;
+}
+
+async function applyConfig(
+	vendor: string,
+	desired: ConfigSnapshot,
+	options: { destructive?: boolean; dryRun?: boolean } = {}
+) {
+	const req = request(getUrl(vendor))
+		.post('/config/apply')
+		.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+		.set('Content-Type', 'application/json');
+
+	if (options.destructive) req.query({ destructive: 'true' });
+	if (options.dryRun) req.query({ dry_run: 'true' });
+
+	return req.send(desired);
+}
+
+async function resetToBaseline(vendor: string): Promise<void> {
+	const baseline = await getBaseline(vendor);
+	await applyConfig(vendor, baseline, { destructive: true });
+}
+
+describe('Config-as-Code API', () => {
+	describe('GET /config/snapshot', () => {
+		describe('denies non-admin users', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const noAuth = await request(getUrl(vendor)).get('/config/snapshot');
+				expect(noAuth.statusCode).toBe(403);
+
+				const invalid = await request(getUrl(vendor))
+					.get('/config/snapshot')
+					.set('Authorization', 'Bearer invalid-token');
+
+				expect(invalid.statusCode).toBe(401);
+
+				for (const userKey of ['APP_ACCESS', 'API_ONLY', 'NO_ROLE'] as const) {
+					const response = await request(getUrl(vendor))
+						.get('/config/snapshot')
+						.set('Authorization', `Bearer ${common.USER[userKey]!.TOKEN}`);
+
+					expect(response.statusCode).toBe(403);
+				}
+			});
+		});
+
+		describe('returns snapshot (JSON) for admin', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.get('/config/snapshot')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body).toHaveProperty('data');
+				expect(response.body.data).toHaveProperty('manifest');
+				expect(response.body.data).toHaveProperty('roles');
+				expect(response.body.data).toHaveProperty('permissions');
+				expect(response.body.data.manifest.version).toBe(1);
+				expect(Array.isArray(response.body.data.roles)).toBe(true);
+				expect(Array.isArray(response.body.data.permissions)).toBe(true);
+			});
+		});
+
+		describe('returns snapshot as YAML', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.get('/config/snapshot')
+					.query({ export: 'yaml' })
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.headers['content-type']).toContain('text/yaml');
+
+				const parsed = loadYaml(response.text) as ConfigSnapshot;
+				expect(parsed.manifest.version).toBe(1);
+				expect(Array.isArray(parsed.roles)).toBe(true);
+				expect(Array.isArray(parsed.permissions)).toBe(true);
+			});
+		});
+	});
+
+	describe('POST /config/apply', () => {
+		describe('denies non-admin users', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+
+				const noAuth = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Content-Type', 'application/json')
+					.send(baseline);
+
+				expect(noAuth.statusCode).toBe(403);
+
+				const invalid = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', 'Bearer invalid-token')
+					.set('Content-Type', 'application/json')
+					.send(baseline);
+
+				expect(invalid.statusCode).toBe(401);
+
+				for (const userKey of ['APP_ACCESS', 'API_ONLY', 'NO_ROLE'] as const) {
+					const response = await request(getUrl(vendor))
+						.post('/config/apply')
+						.set('Authorization', `Bearer ${common.USER[userKey]!.TOKEN}`)
+						.set('Content-Type', 'application/json')
+						.send(baseline);
+
+					expect(response.statusCode).toBe(403);
+				}
+			});
+		});
+
+		describe('applies baseline snapshot with no drift (JSON)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const response = await applyConfig(vendor, baseline);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data.roles.created).toEqual([]);
+				expect(response.body.data.roles.updated).toEqual([]);
+				expect(response.body.data.roles.deleted).toEqual([]);
+				expect(response.body.data.permissions.created).toBe(0);
+				expect(response.body.data.permissions.updated).toBe(0);
+				expect(response.body.data.permissions.deleted).toBe(0);
+			});
+		});
+
+		describe('applies baseline snapshot with no drift (YAML)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const yaml = dumpYaml(baseline);
+
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'text/yaml')
+					.send(yaml);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data.roles.created).toEqual([]);
+				expect(response.body.data.roles.updated).toEqual([]);
+			});
+		});
+
+		describe('?dry_run=true does not mutate', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const desired = JSON.parse(JSON.stringify(baseline)) as ConfigSnapshot;
+				const probeKey = `dryrun_${vendor.replace(/[^a-z0-9_]/gi, '_')}`;
+
+				desired.roles.push({
+					key: probeKey,
+					name: 'Dry Run Probe',
+					admin_access: false,
+					app_access: true,
+				});
+
+				const dry = await applyConfig(vendor, desired, { dryRun: true });
+
+				expect(dry.statusCode).toBe(200);
+				expect(dry.body.data.roles.created).toContain(probeKey);
+
+				const snap = await request(getUrl(vendor))
+					.get('/config/snapshot')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+				expect(snap.body.data.roles.find((r: any) => r.key === probeKey)).toBeUndefined();
+			});
+		});
+
+		describe('non-destructive apply preserves orphan roles', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const orphanKey = `orphan_keep_${vendor.replace(/[^a-z0-9_]/gi, '_')}`;
+
+				const desiredCreate = JSON.parse(JSON.stringify(baseline)) as ConfigSnapshot;
+
+				desiredCreate.roles.push({
+					key: orphanKey,
+					name: 'Orphan Keep',
+					admin_access: false,
+					app_access: true,
+				});
+
+				try {
+					const create = await applyConfig(vendor, desiredCreate);
+					expect(create.statusCode).toBe(200);
+					expect(create.body.data.roles.created).toContain(orphanKey);
+
+					const nonDestructive = await applyConfig(vendor, baseline);
+					expect(nonDestructive.statusCode).toBe(200);
+					expect(nonDestructive.body.data.roles.deleted).toEqual([]);
+
+					const snap = await request(getUrl(vendor))
+						.get('/config/snapshot')
+						.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+					expect(snap.body.data.roles.find((r: any) => r.key === orphanKey)).toBeDefined();
+				} finally {
+					await resetToBaseline(vendor);
+				}
+			});
+		});
+
+		describe('?destructive=true removes orphan roles', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const orphanKey = `orphan_destructive_${vendor.replace(/[^a-z0-9_]/gi, '_')}`;
+
+				const desiredCreate = JSON.parse(JSON.stringify(baseline)) as ConfigSnapshot;
+
+				desiredCreate.roles.push({
+					key: orphanKey,
+					name: 'Orphan Destructive',
+					admin_access: false,
+					app_access: true,
+				});
+
+				try {
+					const create = await applyConfig(vendor, desiredCreate);
+					expect(create.statusCode).toBe(200);
+					expect(create.body.data.roles.created).toContain(orphanKey);
+
+					const destructive = await applyConfig(vendor, baseline, { destructive: true });
+					expect(destructive.statusCode).toBe(200);
+					expect(destructive.body.data.roles.deleted).toContain(orphanKey);
+
+					const snap = await request(getUrl(vendor))
+						.get('/config/snapshot')
+						.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+					expect(snap.body.data.roles.find((r: any) => r.key === orphanKey)).toBeUndefined();
+				} finally {
+					await resetToBaseline(vendor);
+				}
+			});
+		});
+
+		describe('rejects malformed JSON', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'application/json')
+					.send('not json {');
+
+				expect(response.statusCode).toBe(400);
+				expect(response.body.errors[0].extensions.code).toBe('INVALID_PAYLOAD');
+			});
+		});
+
+		describe('rejects malformed YAML', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'text/yaml')
+					.send('manifest: [: not valid');
+
+				expect(response.statusCode).toBe(400);
+				expect(response.body.errors[0].extensions.code).toBe('INVALID_PAYLOAD');
+				expect(response.body.errors[0].message).toContain('Invalid YAML');
+			});
+		});
+
+		describe('rejects unsupported Content-Type', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'text/plain')
+					.send('hello');
+
+				expect(response.statusCode).toBe(415);
+				expect(response.body.errors[0].extensions.code).toBe('UNSUPPORTED_MEDIA_TYPE');
+			});
+		});
+
+		describe('structural guard rejects malformed shapes', () => {
+			it.each(vendors)('%s null role entries', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'application/json')
+					.send({
+						manifest: { version: 1, resources: ['roles', 'permissions'] },
+						roles: [null],
+						permissions: [],
+					});
+
+				expect(response.statusCode).toBe(400);
+				expect(response.body.errors[0].extensions.code).toBe('INVALID_PAYLOAD');
+				expect(response.body.errors[0].message).toContain('roles[0]');
+			});
+
+			it.each(vendors)('%s permission set with non-array permissions', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'application/json')
+					.send({
+						manifest: { version: 1, resources: ['roles', 'permissions'] },
+						roles: [],
+						permissions: [{ role: 'x', permissions: null }],
+					});
+
+				expect(response.statusCode).toBe(400);
+				expect(response.body.errors[0].extensions.code).toBe('INVALID_PAYLOAD');
+				expect(response.body.errors[0].message).toContain('permissions[0].permissions');
+			});
+
+			it.each(vendors)('%s role with non-string key', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'application/json')
+					.send({
+						manifest: { version: 1, resources: ['roles', 'permissions'] },
+						roles: [{ key: 1 }],
+						permissions: [],
+					});
+
+				expect(response.statusCode).toBe(400);
+				expect(response.body.errors[0].extensions.code).toBe('INVALID_PAYLOAD');
+				expect(response.body.errors[0].message).toContain('roles[0]');
+				expect(response.body.errors[0].message).toContain('key');
+			});
+		});
+
+		describe('returns flat error array for validation failures', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const response = await request(getUrl(vendor))
+					.post('/config/apply')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`)
+					.set('Content-Type', 'application/json')
+					.send({
+						manifest: { version: 99, resources: ['roles', 'permissions'] },
+						roles: [],
+						permissions: [],
+					});
+
+				expect(response.statusCode).toBe(400);
+				expect(Array.isArray(response.body.errors)).toBe(true);
+				expect(typeof response.body.errors[0]).toBe('string');
+				expect(response.body.errors.some((e: string) => e.includes('Unsupported config version: 99'))).toBe(true);
+			});
+		});
+
+		describe('omit-preserve regression: omitted optional role fields are not cleared', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const desired = JSON.parse(JSON.stringify(baseline)) as ConfigSnapshot;
+				const adminRole = desired.roles.find((r: any) => r.admin_access === true);
+				expect(adminRole).toBeDefined();
+
+				const originalIcon = adminRole!['icon'];
+				const originalDescription = adminRole!['description'];
+				const originalEnforceTfa = adminRole!['enforce_tfa'];
+
+				delete adminRole!['icon'];
+				delete adminRole!['description'];
+				delete adminRole!['enforce_tfa'];
+
+				const response = await applyConfig(vendor, desired);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data.roles.updated).toEqual([]);
+
+				const snap = await request(getUrl(vendor))
+					.get('/config/snapshot')
+					.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+				const snapAdmin = snap.body.data.roles.find((r: any) => r.admin_access === true);
+				expect(snapAdmin.icon).toBe(originalIcon);
+				expect(snapAdmin.description).toBe(originalDescription);
+				expect(snapAdmin.enforce_tfa).toBe(originalEnforceTfa);
+			});
+		});
+
+		describe('public role round-trip', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const baseline = await getBaseline(vendor);
+				const collection = `pub_test_${vendor.replace(/[^a-z0-9_]/gi, '_')}`;
+				const desired = JSON.parse(JSON.stringify(baseline)) as ConfigSnapshot;
+
+				const newPerm = {
+					collection,
+					action: 'read',
+					permissions: null,
+					validation: null,
+					presets: null,
+					fields: ['*'],
+				};
+
+				const publicSet = desired.permissions.find((p) => p.role === 'public');
+
+				if (publicSet) {
+					publicSet.permissions = publicSet.permissions.filter(
+						(p) => !(p['collection'] === collection && p['action'] === 'read')
+					);
+
+					publicSet.permissions.push(newPerm);
+				} else {
+					desired.permissions.push({ role: 'public', permissions: [newPerm] });
+				}
+
+				try {
+					const apply = await applyConfig(vendor, desired);
+					expect(apply.statusCode).toBe(200);
+					expect(apply.body.data.permissions.created).toBeGreaterThanOrEqual(1);
+
+					const snap = await request(getUrl(vendor))
+						.get('/config/snapshot')
+						.set('Authorization', `Bearer ${common.USER.ADMIN!.TOKEN}`);
+
+					const pub = snap.body.data.permissions.find((p: any) => p.role === 'public');
+					expect(pub).toBeDefined();
+					expect(pub.permissions.find((p: any) => p.collection === collection && p.action === 'read')).toBeDefined();
+				} finally {
+					await resetToBaseline(vendor);
+				}
+			});
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -4,6 +4,7 @@ exports.list = {
 		{ testFilePath: '/common/seed-database.test.ts' },
 		{ testFilePath: '/common/common.test.ts' },
 		{ testFilePath: '/routes/schema/schema.test.ts' },
+		{ testFilePath: '/routes/config/config.test.ts' },
 		{ testFilePath: '/routes/collections/crud.test.ts' },
 		{ testFilePath: '/routes/fields/change-fields.test.ts' },
 		{ testFilePath: '/routes/fields/crud.test.ts' },


### PR DESCRIPTION
## Scope

config-as-code v1 was implemented as cli-only. this pr adds endpoints for full http coverage.

in particular:

GET /config/snapshot: returns the current CairnConfig (manifest + rolls + permissions), JSON or YAML via ?export=yaml

POST /config/apply: accepts a CairnConfig and applies it, with ?dry_run=true for preview and ?destructive=true opt-in for orphan deletion

a bug was also fixed from v1 in which roleChanged() in compute-config-plan.ts was emitting diff entries with undefined values when a desired payload omitted optional role fields. it now uses Object.hasOwn checks so omitted fields are preserved (matches /schema/apply semantics... omit means no change, explicit null clears nullable fields).

also updated the blackbox tests readme to be more helpful for others running them locally.

5 new regression tests added, pinning the omit-preserve semantic.