### PR TITLE
Fix/run script isolated vm

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Run tests (SQLite)
         if: matrix.vendor == 'sqlite3'
-        run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox -- --runInBand
+        run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox --runInBand
 
       - name: Run tests (other vendors)
         if: matrix.vendor != 'sqlite3'
-        run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox -- --maxWorkers=2
+        run: TEST_DB=${{ matrix.vendor }} pnpm run test:blackbox --maxWorkers=2

--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -39,4 +39,4 @@ jobs:
           docker compose -f tests/blackbox/docker-compose.yml up auth-saml redis minio minio-mc -d --quiet-pull --wait
 
       - name: Run tests
-        run: TEST_DB=sqlite3 pnpm run test:blackbox -- --maxWorkers=2
+        run: TEST_DB=sqlite3 pnpm run test:blackbox --maxWorkers=2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ CairnCMS 1.0.0 is a fork of Directus v10 relicensed under GPLv3 with telemetry r
 ### Platform changes
 
 - **Node 22 baseline.** Minimum Node 22.0.0. Node 20 reached end-of-life in April 2026 and is no longer supported.
-- **pnpm 9.x baseline.** Minimum pnpm 9.0.0.
+- **pnpm 10.x baseline.** Minimum pnpm 10.0.0.
 - **Supported database vendors in CI.** SQLite, PostgreSQL (current and 10.x LTS), MySQL (8 and 5.7), and MariaDB.
 - **Vendors dropped from CI.** Oracle, Microsoft SQL Server, and CockroachDB still work in code but are no longer covered by automated tests.
 
@@ -39,6 +39,10 @@ CairnCMS 1.0.0 is a fork of Directus v10 relicensed under GPLv3 with telemetry r
 - **First-party JavaScript SDK.** `@cairncms/sdk` is a composable REST and GraphQL client vendored from `@directus/sdk`. Factory: `createCairnCMS`. Client type: `CairnCMSClient`.
 - **Official Docker images.** Multi-arch (`linux/amd64`, `linux/arm64`) on Docker Hub at `cairncms/cairncms` and GHCR at `ghcr.io/cairncms/cairncms`. Channel tags: `:beta`, `:latest`.
 - **Documentation overhaul.** Documentation rewritten end-to-end into six sections (Getting started, Guides, Develop, Manage, API reference, Contributing). 71 pages with consistent structure, code-verified facts, and review applied throughout. The legacy upstream docs at `docs-legacy/` are preserved as an internal reference and not published.
+
+### Breaking changes
+
+- **Run Script capability narrowed.** The `exec` flow operation now runs in an isolated-vm sandbox with no `require()` or host APIs. `FLOWS_EXEC_ALLOWED_MODULES` is removed; pre-1.0 flows that loaded modules need to be rewritten.
 
 ### Migration from Directus 10
 
@@ -58,6 +62,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Multiple rounds of dependency updates resolving published CVEs.
 - Fixed date-only fields shifting by one day in non-UTC timezones.
 - Restored default `DB_CLIENT=sqlite3` bootstrap in the published image.
+- Replaced vm2 with isolated-vm in the Run Script flow operation.
 
 ### Acknowledgements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pnpm install --recursive --offline --frozen-lockfile
 
 RUN : \
 	&& npm_config_workspace_concurrency=1 pnpm run build \
-	&& pnpm --filter cairncms deploy --prod dist \
+	&& pnpm --filter cairncms deploy --legacy --prod dist \
 	&& cd dist \
 	&& pnpm pack \
 	&& tar -zxvf *.tgz package/package.json \
@@ -49,6 +49,6 @@ ENV \
 COPY --from=builder --chown=node:node /cairncms/dist .
 
 CMD : \
-	&& node /cairncms/cli.js bootstrap \
-	&& node /cairncms/cli.js start \
+	&& node --no-node-snapshot /cairncms/cli.js bootstrap \
+	&& node --no-node-snapshot /cairncms/cli.js start \
 	;

--- a/api/package.json
+++ b/api/package.json
@@ -106,6 +106,7 @@
 		"icc": "3.0.0",
 		"inquirer": "9.1.5",
 		"ioredis": "5.3.2",
+		"isolated-vm": "5.0.3",
 		"joi": "17.9.1",
 		"js-yaml": "4.1.1",
 		"js2xmlparser": "5.0.0",
@@ -145,7 +146,6 @@
 		"tsx": "3.12.6",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
-		"vm2": "3.10.2",
 		"wellknown": "0.5.0"
 	},
 	"devDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -50,8 +50,8 @@
 	},
 	"scripts": {
 		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid,md,txt}\" -u 1 dist",
-		"cli": "NODE_ENV=development SERVE_APP=false tsx src/cli/run.ts",
-		"dev": "NODE_ENV=development SERVE_APP=false tsx watch --clear-screen=false src/start.ts",
+		"cli": "NODE_ENV=development SERVE_APP=false NODE_OPTIONS=--no-node-snapshot tsx src/cli/run.ts",
+		"dev": "NODE_ENV=development SERVE_APP=false NODE_OPTIONS=--no-node-snapshot tsx watch --clear-screen=false src/start.ts",
 		"test": "vitest --watch=false"
 	},
 	"dependencies": {
@@ -75,7 +75,7 @@
 		"@rollup/plugin-alias": "5.0.0",
 		"@rollup/plugin-node-resolve": "15.0.2",
 		"@rollup/plugin-virtual": "3.0.1",
-		"argon2": "0.30.3",
+		"argon2": "0.40.3",
 		"async": "3.2.4",
 		"axios": "1.15.0",
 		"busboy": "1.6.0",

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -187,7 +187,8 @@ const allowedEnvironmentVars = [
 	'RELATIONAL_BATCH_SIZE',
 	'EXPORT_BATCH_SIZE',
 	// flows
-	'FLOWS_EXEC_ALLOWED_MODULES',
+	'FLOWS_RUN_SCRIPT_MAX_MEMORY',
+	'FLOWS_RUN_SCRIPT_TIMEOUT',
 	'FLOWS_ENV_ALLOW_LIST',
 ].map((name) => new RegExp(`^${name}$`));
 
@@ -285,7 +286,8 @@ const defaults: Record<string, any> = {
 
 	GRAPHQL_INTROSPECTION: true,
 
-	FLOWS_EXEC_ALLOWED_MODULES: false,
+	FLOWS_RUN_SCRIPT_MAX_MEMORY: 32,
+	FLOWS_RUN_SCRIPT_TIMEOUT: 10000,
 	FLOWS_ENV_ALLOW_LIST: false,
 };
 
@@ -314,6 +316,9 @@ const typeMap: Record<string, string> = {
 	MAX_BATCH_MUTATION: 'number',
 
 	SERVER_SHUTDOWN_TIMEOUT: 'number',
+
+	FLOWS_RUN_SCRIPT_MAX_MEMORY: 'number',
+	FLOWS_RUN_SCRIPT_TIMEOUT: 'number',
 };
 
 let env: Record<string, any> = {

--- a/api/src/operations/exec/index.test.ts
+++ b/api/src/operations/exec/index.test.ts
@@ -1,142 +1,261 @@
-import { VMError } from 'vm2';
-import { test, expect } from 'vitest';
-
+import { describe, expect, it } from 'vitest';
 import config from './index.js';
 
-test('Rejects when modules are used without modules being allowed', async () => {
-	const testCode = `
-		const test = require('test');
-	`;
+const DEFAULT_LIMITS = {
+	FLOWS_RUN_SCRIPT_MAX_MEMORY: 8,
+	FLOWS_RUN_SCRIPT_TIMEOUT: 10000,
+};
 
-	await expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).rejects.toEqual(new VMError("Cannot find module 'test'"));
-});
+function callHandler(
+	code: string,
+	options: {
+		data?: Record<string, unknown>;
+		env?: Record<string, unknown>;
+		logger?: unknown;
+	} = {}
+) {
+	return config.handler(
+		{ code },
+		{
+			data: options.data ?? {},
+			env: options.env ?? DEFAULT_LIMITS,
+			logger: options.logger,
+		} as any
+	);
+}
 
-test('Rejects when code contains syntax errors', async () => {
-	const testCode = `
-		~~
-	`;
+function makeLogger() {
+	const calls: Array<{ method: string; arg: unknown }> = [];
 
-	await expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).rejects.toEqual(new SyntaxError('Unexpected end of input'));
-});
+	const record = (method: string) => (...args: unknown[]) => {
+		calls.push({ method, arg: args.length === 1 ? args[0] : args });
+	};
 
-test('Rejects when returned function does something illegal', async () => {
-	const testCode = `
-		module.exports = function() {
-			return a + b;
-		};
-	`;
+	const logger = {
+		log: record('log'),
+		info: record('info'),
+		warn: record('warn'),
+		error: record('error'),
+		trace: record('trace'),
+		debug: record('debug'),
+	};
 
-	await expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).rejects.toEqual(new ReferenceError('a is not defined'));
-});
+	return { logger, calls };
+}
 
-test("Rejects when code doesn't return valid function", async () => {
-	const testCode = `
-		module.exports = false;
-	`;
+describe('exec — sandbox enforcement', () => {
+	it('aborts when the isolate exceeds its memory limit', async () => {
+		const code = `
+			const buckets = [];
+			const chunkSize = 1 << 21; // 2 MiB
+			while (true) {
+				const chunk = new Uint8Array(chunkSize);
+				for (let i = 0; i < chunkSize; i += 4096) chunk[i] = 0xff;
+				buckets.push(chunk);
+			}
+		`;
 
-	await expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).rejects.toEqual(new TypeError('fn is not a function'));
-});
+		await expect(callHandler(code)).rejects.toThrow(/allocation failed/i);
+	});
 
-test('Rejects returned function throws errors', async () => {
-	const testCode = `
-		module.exports = function () {
-			throw new Error('test');
-		};
-	`;
+	it('aborts a synchronous script that runs past the configured timeout', async () => {
+		const code = 'for (;;) {}';
 
-	await expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).rejects.toEqual(new Error('test'));
-});
+		await expect(
+			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })
+		).rejects.toThrow(/timed out/i);
+	});
 
-test('Executes function when valid', () => {
-	const testCode = `
-		module.exports = function (data) {
-			return { result: data.input + ' test' };
-		};
-	`;
-
-	expect(
-		config.handler({ code: testCode }, {
-			data: {
-				input: 'start',
-			},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: '',
-			},
-		} as any)
-	).resolves.toEqual({ result: 'start test' });
-});
-
-test('Allows built-in modules that are whitelisted', () => {
-	const testCode = `
-		const crypto = require('crypto');
-
-		module.exports = async function (data) {
-			return {
-				result: crypto.createHash('sha256').update('example').digest('hex'),
+	it('aborts an exported handler that loops forever', async () => {
+		const code = `
+			module.exports = async function () {
+				let n = 0;
+				while (true) {
+					n += 1;
+				}
 			};
-		};
-	`;
+		`;
 
-	expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: 'crypto',
-			},
-		} as any)
-	).resolves.toEqual({ result: '50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c' });
+		await expect(
+			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })
+		).rejects.toThrow(/timed out/i);
+	});
+
+	it('rejects calls to the CommonJS require', async () => {
+		await expect(callHandler(`require('node:fs');`)).rejects.toThrow(/require is not defined/);
+	});
+
+	it('rejects ESM import statements', async () => {
+		await expect(callHandler(`import 'node:fs';`)).rejects.toThrow(/import statement outside a module/);
+	});
 });
 
-test('Allows external modules that are whitelisted', () => {
-	const testCode = `
-		const bytes = require('bytes');
+describe('exec — error propagation', () => {
+	it('surfaces syntax errors from the user script', async () => {
+		await expect(callHandler(`module.exports = function() { return ;;`)).rejects.toThrow(SyntaxError);
+	});
 
-		module.exports = function (data) {
-			return { result: bytes(1000) };
+	it('surfaces reference errors when the script touches an undefined identifier', async () => {
+		const code = `module.exports = function () { return undefinedThing; };`;
+
+		await expect(callHandler(code)).rejects.toThrow(/undefinedThing is not defined/);
+	});
+
+	it('rejects when module.exports is not a function', async () => {
+		await expect(callHandler(`module.exports = 42;`)).rejects.toThrow(/not a function/);
+	});
+
+	it('preserves the message of a user-thrown error', async () => {
+		const code = `
+			module.exports = function () {
+				throw new Error('intentional failure for the test');
+			};
+		`;
+
+		await expect(callHandler(code)).rejects.toThrow('intentional failure for the test');
+	});
+});
+
+describe('exec — successful execution', () => {
+	it('returns the value from a synchronous handler', async () => {
+		const code = `module.exports = function (data) { return { doubled: data.input * 2 }; };`;
+
+		await expect(callHandler(code, { data: { input: 21 } })).resolves.toEqual({ doubled: 42 });
+	});
+
+	it('returns the value from an asynchronous handler', async () => {
+		const code = `
+			module.exports = async function (data) {
+				return { upper: data.text.toUpperCase() };
+			};
+		`;
+
+		await expect(callHandler(code, { data: { text: 'cairn' } })).resolves.toEqual({ upper: 'CAIRN' });
+	});
+
+	it('passes deeply nested data through unchanged', async () => {
+		const code = `module.exports = (data) => data;`;
+		const payload = { a: 1, b: { c: [2, 3, { d: true, e: null }] } };
+
+		await expect(callHandler(code, { data: payload })).resolves.toEqual(payload);
+	});
+});
+
+describe('exec — data and environment', () => {
+	it('exposes data.$env to the user script via process.env', async () => {
+		const code = `module.exports = () => ({ token: process.env.TOKEN, lang: process.env.LANG });`;
+
+		await expect(
+			callHandler(code, { data: { $env: { TOKEN: 'secret-value', LANG: 'en' } } })
+		).resolves.toEqual({ token: 'secret-value', lang: 'en' });
+	});
+
+	it('strips functions from the data payload before crossing the isolate boundary', async () => {
+		const code = `
+			module.exports = function (data) {
+				return {
+					valueType: typeof data.value,
+					value: data.value,
+					callbackType: typeof data.callback,
+					nestedFnType: typeof data.nested.callback,
+				};
+			};
+		`;
+
+		const dataWithFunctions = {
+			value: 'kept',
+			callback: () => 1,
+			nested: { callback: () => 2 },
 		};
-	`;
 
-	expect(
-		config.handler({ code: testCode }, {
-			data: {},
-			env: {
-				FLOWS_EXEC_ALLOWED_MODULES: 'bytes',
-			},
-		} as any)
-	).resolves.toEqual({ result: '1000B' });
+		await expect(callHandler(code, { data: dataWithFunctions as any })).resolves.toEqual({
+			valueType: 'string',
+			value: 'kept',
+			callbackType: 'undefined',
+			nestedFnType: 'undefined',
+		});
+	});
+
+	it('handles a circular data payload without crashing the helper or the boundary', async () => {
+		const code = `
+			module.exports = function (data) {
+				return { name: data.name, cyclePreserved: data.self === data };
+			};
+		`;
+
+		type Cyclic = { name: string; self?: Cyclic };
+		const cyclic: Cyclic = { name: 'root' };
+		cyclic.self = cyclic;
+
+		await expect(callHandler(code, { data: cyclic as any })).resolves.toEqual({
+			name: 'root',
+			cyclePreserved: true,
+		});
+	});
+});
+
+describe('exec — console bridge', () => {
+	it('routes console.log to logger.info and other methods to their matching channels', async () => {
+		const { logger, calls } = makeLogger();
+
+		const code = `
+			module.exports = function () {
+				console.log('routed-log');
+				console.info('routed-info');
+				console.warn('routed-warn');
+				console.error('routed-error');
+				console.trace('routed-trace');
+				console.debug('routed-debug');
+				return null;
+			};
+		`;
+
+		await callHandler(code, { logger });
+
+		expect(calls).toEqual([
+			{ method: 'info', arg: 'routed-log' },
+			{ method: 'info', arg: 'routed-info' },
+			{ method: 'warn', arg: 'routed-warn' },
+			{ method: 'error', arg: 'routed-error' },
+			{ method: 'trace', arg: 'routed-trace' },
+			{ method: 'debug', arg: 'routed-debug' },
+		]);
+	});
+
+	it('unpacks a single argument but packs multiple arguments into an array', async () => {
+		const { logger, calls } = makeLogger();
+
+		const code = `
+			module.exports = function () {
+				console.log('only');
+				console.log('first', 'second', 'third');
+				return null;
+			};
+		`;
+
+		await callHandler(code, { logger });
+
+		expect(calls).toEqual([
+			{ method: 'info', arg: 'only' },
+			{ method: 'info', arg: ['first', 'second', 'third'] },
+		]);
+	});
+});
+
+describe('exec — configuration validation', () => {
+	it('rejects when FLOWS_RUN_SCRIPT_MAX_MEMORY is not a number', async () => {
+		const code = `module.exports = () => null;`;
+
+		await expect(
+			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_MAX_MEMORY: 'oops' } })
+		).rejects.toThrow(/memoryLimit.*must be a number/);
+	});
+
+	it('rejects when FLOWS_RUN_SCRIPT_TIMEOUT is not a number', async () => {
+		const code = `module.exports = () => null;`;
+
+		await expect(
+			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 'oops' } })
+		).rejects.toThrow(/timeout.*must be a 32-bit number/);
+	});
 });

--- a/api/src/operations/exec/index.test.ts
+++ b/api/src/operations/exec/index.test.ts
@@ -14,22 +14,21 @@ function callHandler(
 		logger?: unknown;
 	} = {}
 ) {
-	return config.handler(
-		{ code },
-		{
-			data: options.data ?? {},
-			env: options.env ?? DEFAULT_LIMITS,
-			logger: options.logger,
-		} as any
-	);
+	return config.handler({ code }, {
+		data: options.data ?? {},
+		env: options.env ?? DEFAULT_LIMITS,
+		logger: options.logger,
+	} as any);
 }
 
 function makeLogger() {
 	const calls: Array<{ method: string; arg: unknown }> = [];
 
-	const record = (method: string) => (...args: unknown[]) => {
-		calls.push({ method, arg: args.length === 1 ? args[0] : args });
-	};
+	const record =
+		(method: string) =>
+		(...args: unknown[]) => {
+			calls.push({ method, arg: args.length === 1 ? args[0] : args });
+		};
 
 	const logger = {
 		log: record('log'),
@@ -61,9 +60,9 @@ describe('exec — sandbox enforcement', () => {
 	it('aborts a synchronous script that runs past the configured timeout', async () => {
 		const code = 'for (;;) {}';
 
-		await expect(
-			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })
-		).rejects.toThrow(/timed out/i);
+		await expect(callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })).rejects.toThrow(
+			/timed out/i
+		);
 	});
 
 	it('aborts an exported handler that loops forever', async () => {
@@ -76,9 +75,9 @@ describe('exec — sandbox enforcement', () => {
 			};
 		`;
 
-		await expect(
-			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })
-		).rejects.toThrow(/timed out/i);
+		await expect(callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 250 } })).rejects.toThrow(
+			/timed out/i
+		);
 	});
 
 	it('rejects calls to the CommonJS require', async () => {
@@ -145,9 +144,10 @@ describe('exec — data and environment', () => {
 	it('exposes data.$env to the user script via process.env', async () => {
 		const code = `module.exports = () => ({ token: process.env.TOKEN, lang: process.env.LANG });`;
 
-		await expect(
-			callHandler(code, { data: { $env: { TOKEN: 'secret-value', LANG: 'en' } } })
-		).resolves.toEqual({ token: 'secret-value', lang: 'en' });
+		await expect(callHandler(code, { data: { $env: { TOKEN: 'secret-value', LANG: 'en' } } })).resolves.toEqual({
+			token: 'secret-value',
+			lang: 'en',
+		});
 	});
 
 	it('strips functions from the data payload before crossing the isolate boundary', async () => {
@@ -254,8 +254,8 @@ describe('exec — configuration validation', () => {
 	it('rejects when FLOWS_RUN_SCRIPT_TIMEOUT is not a number', async () => {
 		const code = `module.exports = () => null;`;
 
-		await expect(
-			callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 'oops' } })
-		).rejects.toThrow(/timeout.*must be a 32-bit number/);
+		await expect(callHandler(code, { env: { ...DEFAULT_LIMITS, FLOWS_RUN_SCRIPT_TIMEOUT: 'oops' } })).rejects.toThrow(
+			/timeout.*must be a 32-bit number/
+		);
 	});
 });

--- a/api/src/operations/exec/index.ts
+++ b/api/src/operations/exec/index.ts
@@ -1,49 +1,94 @@
-import { defineOperationApi, toArray } from '@cairncms/utils';
-import { isBuiltin } from 'node:module';
-import type { NodeVMOptions } from 'vm2';
-import { NodeVM, VMScript } from 'vm2';
+import { defineOperationApi, stripFunctions } from '@cairncms/utils';
+import { createRequire } from 'node:module';
+
+const ivm = createRequire(import.meta.url)('isolated-vm');
 
 type Options = {
 	code: string;
 };
 
+type LoggerLike = {
+	info: (...args: unknown[]) => void;
+	warn: (...args: unknown[]) => void;
+	error: (...args: unknown[]) => void;
+	trace: (...args: unknown[]) => void;
+	debug: (...args: unknown[]) => void;
+};
+
+const CONSOLE_METHODS = ['log', 'info', 'warn', 'error', 'trace', 'debug'] as const;
+
+function buildConsoleShim(logger: LoggerLike) {
+	const shim: Record<string, unknown> = {};
+
+	for (const method of CONSOLE_METHODS) {
+		const target = method === 'log' ? 'info' : method;
+
+		shim[method] = new ivm.Callback(
+			(...rest: unknown[]) => logger[target](rest.length === 1 ? rest[0] : rest),
+			{ sync: true }
+		);
+	}
+
+	return shim;
+}
+
+function prepareSandbox(context: any, scriptEnv: Record<string, unknown>, logger: LoggerLike): void {
+	const jail = context.global;
+
+	jail.setSync('global', jail.derefInto());
+	jail.setSync('module', { exports: null }, { copy: true });
+	jail.setSync('process', { env: scriptEnv }, { copy: true });
+	jail.setSync('console', buildConsoleShim(logger), { copy: true });
+}
+
+const wrapScript = (userCode: string) => `
+${userCode};
+if (typeof module.exports !== 'function') {
+	throw new TypeError('module.exports is not a function');
+}
+return module.exports($0.data);
+`;
+
 export default defineOperationApi<Options>({
 	id: 'exec',
-	handler: async ({ code }, { data, env }) => {
-		const allowedModules = env['FLOWS_EXEC_ALLOWED_MODULES'] ? toArray(env['FLOWS_EXEC_ALLOWED_MODULES']) : [];
-		const allowedModulesBuiltIn: string[] = [];
-		const allowedModulesExternal: string[] = [];
-		const allowedEnv = data['$env'] ?? {};
+	handler: async ({ code }, { data, env, logger }) => {
+		const memoryLimitMb = env['FLOWS_RUN_SCRIPT_MAX_MEMORY'];
+		const timeoutMs = env['FLOWS_RUN_SCRIPT_TIMEOUT'];
+		const scriptEnv = (data['$env'] ?? {}) as Record<string, unknown>;
 
-		const opts: NodeVMOptions = {
-			eval: false,
-			wasm: false,
-			env: allowedEnv,
-		};
+		const isolate = new ivm.Isolate({ memoryLimit: memoryLimitMb });
 
-		for (const module of allowedModules) {
-			if (isBuiltin(module)) {
-				allowedModulesBuiltIn.push(module);
-			} else {
-				allowedModulesExternal.push(module);
+		try {
+			const context = await isolate.createContext();
+
+			try {
+				prepareSandbox(context, scriptEnv, logger as LoggerLike);
+
+				const inputCopy = new ivm.ExternalCopy({ data: stripFunctions(data) });
+
+				try {
+					const resultRef = await context.evalClosure(
+						wrapScript(code),
+						[inputCopy.copyInto()],
+						{
+							result: { reference: true, promise: true },
+							timeout: timeoutMs,
+						}
+					);
+
+					try {
+						return await resultRef.copy();
+					} finally {
+						resultRef.release();
+					}
+				} finally {
+					inputCopy.release();
+				}
+			} finally {
+				context.release();
 			}
+		} finally {
+			isolate.dispose();
 		}
-
-		if (allowedModules.length > 0) {
-			opts.require = {
-				builtin: allowedModulesBuiltIn,
-				external: {
-					modules: allowedModulesExternal,
-					transitive: false,
-				},
-			};
-		}
-
-		const vm = new NodeVM(opts);
-
-		const script = new VMScript(code).compile();
-		const fn = await vm.run(script);
-
-		return await fn(data);
 	},
 });

--- a/api/src/operations/exec/index.ts
+++ b/api/src/operations/exec/index.ts
@@ -23,10 +23,9 @@ function buildConsoleShim(logger: LoggerLike) {
 	for (const method of CONSOLE_METHODS) {
 		const target = method === 'log' ? 'info' : method;
 
-		shim[method] = new ivm.Callback(
-			(...rest: unknown[]) => logger[target](rest.length === 1 ? rest[0] : rest),
-			{ sync: true }
-		);
+		shim[method] = new ivm.Callback((...rest: unknown[]) => logger[target](rest.length === 1 ? rest[0] : rest), {
+			sync: true,
+		});
 	}
 
 	return shim;
@@ -67,14 +66,10 @@ export default defineOperationApi<Options>({
 				const inputCopy = new ivm.ExternalCopy({ data: stripFunctions(data) });
 
 				try {
-					const resultRef = await context.evalClosure(
-						wrapScript(code),
-						[inputCopy.copyInto()],
-						{
-							result: { reference: true, promise: true },
-							timeout: timeoutMs,
-						}
-					);
+					const resultRef = await context.evalClosure(wrapScript(code), [inputCopy.copyInto()], {
+						result: { reference: true, promise: true },
+						timeout: timeoutMs,
+					});
 
 					try {
 						return await resultRef.copy();

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1894,16 +1894,6 @@ export class GraphQLService {
 							}),
 					  }
 					: GraphQLBoolean,
-				flows: {
-					type: new GraphQLObjectType({
-						name: 'server_info_flows',
-						fields: {
-							execAllowedModules: {
-								type: new GraphQLList(GraphQLString),
-							},
-						},
-					}),
-				},
 			});
 		}
 

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -70,9 +70,6 @@ export class ServerService {
 				info['rateLimitGlobal'] = false;
 			}
 
-			info['flows'] = {
-				execAllowedModules: env['FLOWS_EXEC_ALLOWED_MODULES'] ? toArray(env['FLOWS_EXEC_ALLOWED_MODULES']) : [],
-			};
 		}
 
 		if (this.accountability?.admin === true) {

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -69,7 +69,6 @@ export class ServerService {
 			} else {
 				info['rateLimitGlobal'] = false;
 			}
-
 		}
 
 		if (this.accountability?.admin === true) {

--- a/app/src/operations/exec/index.test.ts
+++ b/app/src/operations/exec/index.test.ts
@@ -1,22 +1,6 @@
-import { createTestingPinia } from '@pinia/testing';
-import { setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { cryptoStub } from '@/__utils__/crypto';
-
-vi.stubGlobal('crypto', cryptoStub);
-
-import { useServerStore } from '@/stores/server';
+import { describe, expect, it } from 'vitest';
 
 import config from './index';
-
-beforeEach(() => {
-	setActivePinia(
-		createTestingPinia({
-			createSpy: vi.fn,
-		})
-	);
-});
 
 describe('Overview', () => {
 	it('Renders empty array', () => {
@@ -25,17 +9,7 @@ describe('Overview', () => {
 });
 
 describe('Options', () => {
-	it("Doesn't show notice when no modules are allowed", () => {
+	it('Returns the code field as the only option', () => {
 		expect(config.options()).toHaveLength(1);
-	});
-
-	it('Shows notice when modules are allowed', () => {
-		const serverStore = useServerStore();
-
-		serverStore.info.flows = {
-			execAllowedModules: ['nanoid'],
-		};
-
-		expect(config.options()).toHaveLength(2);
 	});
 });

--- a/app/src/operations/exec/index.ts
+++ b/app/src/operations/exec/index.ts
@@ -1,7 +1,5 @@
-import { useServerStore } from '@/stores/server';
 import { DeepPartial, Field } from '@cairncms/types';
 import { defineOperationApp } from '@cairncms/utils';
-import { i18n } from '@/lang';
 
 export default defineOperationApp({
 	id: 'exec',
@@ -10,10 +8,6 @@ export default defineOperationApp({
 	description: '$t:operations.exec.description',
 	overview: () => [],
 	options: () => {
-		const { t } = i18n.global;
-
-		const serverStore = useServerStore();
-
 		const standard: DeepPartial<Field>[] = [
 			{
 				field: 'code',
@@ -28,32 +22,12 @@ export default defineOperationApp({
 				},
 				schema: {
 					default_value: `module.exports = async function(data) {
-	// Do something...
+	// Transform data here. The script runs in an isolated sandbox without require().
 	return {};
 }`,
 				},
 			},
 		];
-
-		if (serverStore.info?.flows?.execAllowedModules && serverStore.info.flows.execAllowedModules.length > 0) {
-			return [
-				...standard,
-				{
-					field: 'notice',
-					name: '$t:interfaces.presentation-notice.notice',
-					type: 'alias',
-					meta: {
-						width: 'full',
-						interface: 'presentation-notice',
-						options: {
-							text:
-								t('operations.exec.modules') +
-								`<br>${serverStore.info.flows.execAllowedModules.map((mod) => `\`${mod}\``).join(', ')}`,
-						},
-					},
-				},
-			];
-		}
 
 		return standard;
 	},

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -45,9 +45,6 @@ export type Info = {
 				points: number;
 				duration: number;
 		  };
-	flows?: {
-		execAllowedModules: string[];
-	};
 };
 
 export type Auth = {
@@ -62,7 +59,6 @@ export const useServerStore = defineStore('serverStore', () => {
 		node: undefined,
 		os: undefined,
 		rateLimit: undefined,
-		flows: undefined,
 	});
 
 	const auth = reactive<Auth>({

--- a/docs/api/system-collections/platform-and-utilities.md
+++ b/docs/api/system-collections/platform-and-utilities.md
@@ -58,7 +58,7 @@ The `/server` subtree exposes platform state and machine-readable specifications
 Returns a `data` envelope whose contents depend on the caller's accountability:
 
 - **Unauthenticated callers** receive only the public branding subset: `project.project_name`, `project_descriptor`, `project_logo`, `project_color`, `default_language`, `public_foreground`, `public_background`, `public_note`, and `custom_css`. This is what the admin app reads on the login screen before the user has authenticated.
-- **Authenticated users** additionally receive `rateLimit` and `rateLimitGlobal` blocks describing the configured rate-limiter policy, plus a `flows.execAllowedModules` array.
+- **Authenticated users** additionally receive `rateLimit` and `rateLimitGlobal` blocks describing the configured rate-limiter policy.
 - **Admins** additionally receive `cairncms.version`, a `node` block (Node version and uptime), and an `os` block.
 
 The platform version is admin-only on this endpoint. Clients that need to detect the running version without admin credentials should look at the package's published version channel rather than reading it from `/server/info`.

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -10,7 +10,7 @@ This page is for contributors who want to run CairnCMS from the source tree, mod
 ## Prerequisites
 
 - **Node.js 22 LTS** or newer. The platform targets Node 22 and runs CI against it.
-- **pnpm 9+**. The repo pins `pnpm@9.4.0` as its `packageManager`. Use corepack (`corepack enable`) to pick up the pinned version automatically.
+- **pnpm 10+**. The repo pins `pnpm@10.13.1` as its `packageManager`. Use corepack (`corepack enable`) to pick up the pinned version automatically.
 - **Docker and Docker Compose**, for the database and supporting services. The root `docker-compose.yml` provides every supported database vendor on local ports.
 - **Git**, with a configured user and email. Commits must be signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).
 

--- a/docs/guides/automate/operations.md
+++ b/docs/guides/automate/operations.md
@@ -23,13 +23,15 @@ When used at the end of a flow on a Filter (blocking) Event hook trigger, a fail
 
 ## Run Script
 
-Runs custom JavaScript inside an isolated vm2 sandbox.
+Runs custom JavaScript inside an isolated V8 sandbox.
 
-The sandbox has no file system access and no network access by default. The script receives the data chain as its argument and returns a JSON-serializable value, which is appended under the operation key.
+The sandbox is fully isolated from the host: no file system access, network access, or `require()` of built-in or external modules. The script receives the data chain as its argument and returns a JSON-serializable value, which is appended under the operation key. A `console` shim is available and routes to the platform logger.
+
+The script's `process.env` is populated from the operator-allow-listed environment variables (governed separately by `FLOWS_ENV_ALLOW_LIST`).
 
 Throwing inside a script ends the flow. On a Filter (blocking) Event hook trigger, throwing also cancels the original event transaction.
 
-Module access is disabled by default. Operators can opt in modules through the `FLOWS_EXEC_ALLOWED_MODULES` environment variable.
+The isolate has a configurable memory and time budget, set via `FLOWS_RUN_SCRIPT_MAX_MEMORY` (default 32, MB) and `FLOWS_RUN_SCRIPT_TIMEOUT` (default 10000, ms). Scripts that exceed either limit are aborted.
 
 ## Create Data
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -204,6 +204,14 @@ Asset transformation settings:
 - **`EXTENSIONS_AUTO_RELOAD`** — when `true`, the API watches extension files and reloads on change. Default `false`. Disabled in development; see the [Creating extensions](/docs/develop/extensions/creating-extensions/) page for the full caveat.
 - **`PACKAGE_FILE_LOCATION`** — directory containing the project `package.json` (used to discover npm-installed extensions). Default `.`.
 
+## Flows
+
+The Run Script flow operation runs user-supplied JavaScript inside an isolated V8 sandbox without `require()` or host APIs. Two env vars govern the isolate's resource budget; one governs which environment variables the script can read.
+
+- **`FLOWS_RUN_SCRIPT_MAX_MEMORY`** — memory limit for a single Run Script invocation, in MB. Default `32`. Scripts that exceed the limit are aborted.
+- **`FLOWS_RUN_SCRIPT_TIMEOUT`** — wall-clock timeout for a single Run Script invocation, in milliseconds. Default `10000`. Scripts that exceed the limit are aborted.
+- **`FLOWS_ENV_ALLOW_LIST`** — comma-separated list of environment variable names the Run Script operation is allowed to read via `process.env`. Default unset (no environment variables exposed to scripts).
+
 ## Resetting an admin password
 
 If you lose access to an admin account, the CLI can set a new password directly:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"format": "prettier --write \"**/*.{md,y?(a)ml,json}\"",
 		"lint": "eslint .",
 		"test": "pnpm --recursive --filter '!tests-blackbox' test",
-		"test:blackbox": "pnpm --filter cairncms deploy --prod --force dist && pnpm --filter tests-blackbox test"
+		"test:blackbox": "rm -rf dist && pnpm --filter cairncms deploy --legacy --prod dist && pnpm --filter tests-blackbox test"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "5.59.0",
@@ -18,10 +18,10 @@
 		"eslint-plugin-vue": "9.11.0",
 		"prettier": "2.8.7"
 	},
-	"packageManager": "pnpm@9.4.0",
+	"packageManager": "pnpm@10.13.1",
 	"engines": {
 		"node": ">=22.0.0",
-		"pnpm": "9"
+		"pnpm": "10"
 	},
 	"pnpm": {
 		"overrides": {

--- a/packages/utils/shared/index.ts
+++ b/packages/utils/shared/index.ts
@@ -28,5 +28,6 @@ export * from './parse-filter-function-path.js';
 export * from './parse-filter.js';
 export * from './parse-json.js';
 export * from './pluralize.js';
+export * from './strip-functions.js';
 export * from './to-array.js';
 export * from './validate-payload.js';

--- a/packages/utils/shared/strip-functions.test.ts
+++ b/packages/utils/shared/strip-functions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { stripFunctions } from './strip-functions.js';
+
+describe('stripFunctions', () => {
+	it('replaces a top-level function with undefined', () => {
+		expect(stripFunctions(() => 1)).toBe(undefined);
+	});
+
+	it('strips functions nested in an object', () => {
+		const result = stripFunctions({ a: 1, b: () => 2, c: 'x' });
+		expect(result).toEqual({ a: 1, b: undefined, c: 'x' });
+	});
+
+	it('strips functions nested in an array', () => {
+		const result = stripFunctions([1, () => 2, 3]);
+		expect(result).toEqual([1, undefined, 3]);
+	});
+
+	it('strips functions deep inside nested structures', () => {
+		const result = stripFunctions({ outer: { inner: [{ fn: () => 1 }] } });
+		expect(result).toEqual({ outer: { inner: [{ fn: undefined }] } });
+	});
+
+	it('passes primitives through unchanged', () => {
+		expect(stripFunctions(null)).toBe(null);
+		expect(stripFunctions(undefined)).toBe(undefined);
+		expect(stripFunctions(0)).toBe(0);
+		expect(stripFunctions('')).toBe('');
+		expect(stripFunctions(false)).toBe(false);
+		expect(Number.isNaN(stripFunctions(NaN))).toBe(true);
+	});
+
+	it('passes Date, RegExp, Map, Set, Error, ArrayBuffer, TypedArray through unchanged (same reference)', () => {
+		const date = new Date();
+		const regex = /x/g;
+		const map = new Map([['a', 1]]);
+		const set = new Set([1, 2]);
+		const err = new Error('boom');
+		const buf = new ArrayBuffer(4);
+		const arr = new Uint8Array([1, 2]);
+		expect(stripFunctions(date)).toBe(date);
+		expect(stripFunctions(regex)).toBe(regex);
+		expect(stripFunctions(map)).toBe(map);
+		expect(stripFunctions(set)).toBe(set);
+		expect(stripFunctions(err)).toBe(err);
+		expect(stripFunctions(buf)).toBe(buf);
+		expect(stripFunctions(arr)).toBe(arr);
+	});
+
+	it('deep-clones plain objects (output is not the same reference)', () => {
+		const input = { a: 1, b: { c: 2 } };
+		const output = stripFunctions(input);
+		expect(output).not.toBe(input);
+		expect(output.b).not.toBe(input.b);
+		expect(output).toEqual(input);
+	});
+
+	it('deep-clones plain arrays (output is not the same reference)', () => {
+		const input = [1, [2, 3]];
+		const output = stripFunctions(input);
+		expect(output).not.toBe(input);
+		expect(output[1]).not.toBe(input[1]);
+		expect(output).toEqual(input);
+	});
+
+	it('preserves circular references in the output', () => {
+		type Cyclic = { name: string; self?: Cyclic };
+		const input: Cyclic = { name: 'root' };
+		input.self = input;
+		const output = stripFunctions(input);
+		expect(output.name).toBe('root');
+		expect(output.self).toBe(output);
+	});
+
+	it('does not mutate the input', () => {
+		const fn = () => 1;
+		const input = { a: 1, b: fn, c: { d: fn } };
+		stripFunctions(input);
+		expect(input.b).toBe(fn);
+		expect(input.c.d).toBe(fn);
+	});
+});

--- a/packages/utils/shared/strip-functions.ts
+++ b/packages/utils/shared/strip-functions.ts
@@ -1,0 +1,45 @@
+/**
+ * Replace functions with `undefined` so the value can cross an isolated-vm boundary.
+ */
+export function stripFunctions<T>(value: T): T {
+	return strip(value, new WeakMap()) as T;
+}
+
+function strip(value: unknown, seen: WeakMap<object, unknown>): unknown {
+	if (typeof value === 'function') return undefined;
+	if (value === null || typeof value !== 'object') return value;
+
+	if (
+		value instanceof Date ||
+		value instanceof RegExp ||
+		value instanceof Map ||
+		value instanceof Set ||
+		value instanceof Error ||
+		value instanceof ArrayBuffer ||
+		ArrayBuffer.isView(value)
+	) {
+		return value;
+	}
+
+	if (seen.has(value)) return seen.get(value);
+
+	if (Array.isArray(value)) {
+		const out: unknown[] = [];
+		seen.set(value, out);
+
+		for (const item of value) {
+			out.push(strip(item, seen));
+		}
+
+		return out;
+	}
+
+	const out: Record<string, unknown> = {};
+	seen.set(value, out);
+
+	for (const key of Object.keys(value as Record<string, unknown>)) {
+		out[key] = strip((value as Record<string, unknown>)[key], seen);
+	}
+
+	return out;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.0
-        version: 5.59.0(@typescript-eslint/parser@5.59.0)(eslint@8.38.0)(typescript@5.4.5)
+        version: 5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: 5.59.0
         version: 5.59.0(eslint@8.38.0)(typescript@5.4.5)
@@ -43,10 +43,10 @@ importers:
         version: 8.8.0(eslint@8.38.0)
       eslint-plugin-jest:
         specifier: 27.2.1
-        version: 27.2.1(@typescript-eslint/eslint-plugin@5.59.0)(eslint@8.38.0)(typescript@5.4.5)
+        version: 27.2.1(@typescript-eslint/eslint-plugin@5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5)
       eslint-plugin-prettier:
         specifier: 4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.38.0)(prettier@2.8.7)
+        version: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.38.0))(eslint@8.38.0)(prettier@2.8.7)
       eslint-plugin-vue:
         specifier: 9.11.0
         version: 9.11.0(eslint@8.38.0)
@@ -118,7 +118,7 @@ importers:
         version: 3.0.1(rollup@4.60.1)
       argon2:
         specifier: 0.30.3
-        version: 0.30.3
+        version: 0.30.3(encoding@0.1.13)
       async:
         specifier: 3.2.4
         version: 3.2.4
@@ -209,6 +209,9 @@ importers:
       ioredis:
         specifier: 5.3.2
         version: 5.3.2
+      isolated-vm:
+        specifier: 5.0.3
+        version: 5.0.3
       joi:
         specifier: 17.9.1
         version: 17.9.1
@@ -229,7 +232,7 @@ importers:
         version: 4.5.2
       knex:
         specifier: 2.4.2
-        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
       ldapjs:
         specifier: 2.3.3
         version: 2.3.3
@@ -326,9 +329,6 @@ importers:
       uuid-validate:
         specifier: 0.0.3
         version: 0.0.3
-      vm2:
-        specifier: 3.10.2
-        version: 3.10.2
       wellknown:
         specifier: 0.5.0
         version: 0.5.0
@@ -347,7 +347,7 @@ importers:
         version: 3.10.0
       nodemailer-mailgun-transport:
         specifier: 2.1.5
-        version: 2.1.5
+        version: 2.1.5(lodash@4.18.1)(underscore@1.13.8)
       nodemailer-sendgrid:
         specifier: 1.0.3
         version: 1.0.3
@@ -356,7 +356,7 @@ importers:
         version: 8.10.0
       sqlite3:
         specifier: 5.1.6
-        version: 5.1.6
+        version: 5.1.6(encoding@0.1.13)
       tedious:
         specifier: 16.0.0
         version: 16.0.0(@azure/core-client@1.10.1)
@@ -477,7 +477,7 @@ importers:
         version: 0.5.4
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -486,7 +486,7 @@ importers:
         version: 4.0.4
       knex-mock-client:
         specifier: 2.0.0
-        version: 2.0.0(knex@2.4.2)
+        version: 2.0.0(knex@2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1)))
       supertest:
         specifier: 6.3.3
         version: 6.3.3
@@ -495,7 +495,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   app:
     dependencies:
@@ -556,7 +556,7 @@ importers:
         version: 5.0.1(mapbox-gl@1.13.3)
       '@pinia/testing':
         specifier: 0.0.16
-        version: 0.0.16(pinia@2.0.35)(vue@3.2.47)
+        version: 0.0.16(pinia@2.0.35(typescript@5.0.4)(vue@3.2.47))(vue@3.2.47)
       '@popperjs/core':
         specifier: 2.11.7
         version: 2.11.7
@@ -622,7 +622,7 @@ importers:
         version: 0.5.4
       '@vitejs/plugin-vue':
         specifier: 4.1.0
-        version: 4.1.0(vite@5.4.21)(vue@3.2.47)
+        version: 4.1.0(vite@5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1))(vue@3.2.47)
       '@vue/compiler-sfc':
         specifier: 3.2.47
         version: 3.2.47
@@ -748,10 +748,10 @@ importers:
         version: 5.0.4
       vite:
         specifier: 5.4.21
-        version: 5.4.21(sass@1.62.0)
+        version: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
       vue:
         specifier: 3.2.47
         version: 3.2.47
@@ -800,7 +800,7 @@ importers:
         version: 4.17.7
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       '@vue/test-utils':
         specifier: 2.3.2
         version: 2.3.2(vue@3.2.47)
@@ -812,7 +812,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/constants:
     dependencies:
@@ -846,7 +846,7 @@ importers:
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       joi:
         specifier: 17.9.1
         version: 17.9.1
@@ -855,7 +855,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/extensions-sdk:
     dependencies:
@@ -934,31 +934,31 @@ importers:
         version: 9.0.3
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/format-title:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/schema:
     dependencies:
       knex:
         specifier: 2.4.2
-        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
     devDependencies:
       typescript:
         specifier: 5.0.4
@@ -987,19 +987,19 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-azure:
     dependencies:
       '@azure/storage-blob':
         specifier: 12.14.0
-        version: 12.14.0
+        version: 12.14.0(encoding@0.1.13)
       '@cairncms/storage':
         specifier: workspace:*
         version: link:../storage
@@ -1012,13 +1012,13 @@ importers:
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-cloudinary:
     dependencies:
@@ -1040,13 +1040,13 @@ importers:
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-gcs:
     dependencies:
@@ -1058,20 +1058,20 @@ importers:
         version: link:../utils
       '@google-cloud/storage':
         specifier: 6.9.5
-        version: 6.9.5
+        version: 6.9.5(encoding@0.1.13)
     devDependencies:
       '@ngneat/falso':
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-local:
     dependencies:
@@ -1087,13 +1087,13 @@ importers:
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-s3:
     dependencies:
@@ -1118,13 +1118,13 @@ importers:
         version: 6.4.0
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/types:
     devDependencies:
@@ -1148,7 +1148,7 @@ importers:
         version: 0.5.0
       knex:
         specifier: 2.4.2
-        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
       pino:
         specifier: 8.11.0
         version: 8.11.0
@@ -1182,13 +1182,13 @@ importers:
         version: 7.3.13
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/utils:
     dependencies:
@@ -1240,7 +1240,7 @@ importers:
         version: 0.2.3
       '@vitest/coverage-v8':
         specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1)
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       concurrently:
         specifier: 8.0.1
         version: 8.0.1
@@ -1249,7 +1249,7 @@ importers:
         version: 5.0.4
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   sdk:
     devDependencies:
@@ -1261,19 +1261,19 @@ importers:
         version: 1.4.0
       knex:
         specifier: 2.4.2
-        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
       sqlite3:
         specifier: 5.1.6
-        version: 5.1.6
+        version: 5.1.6(encoding@0.1.13)
       tsup:
         specifier: 8.2.2
-        version: 8.2.2(typescript@5.4.5)
+        version: 8.2.2(postcss@8.5.9)(typescript@5.4.5)(yaml@2.8.3)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
       vitest:
         specifier: 1.6.1
-        version: 1.6.1(happy-dom@14.12.3)(sass@1.62.0)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   tests/blackbox:
     devDependencies:
@@ -1309,7 +1309,7 @@ importers:
         version: 11.1.0
       jest:
         specifier: 29.5.0
-        version: 29.5.0
+        version: 29.5.0(@types/node@22.19.17)
       jest-environment-node:
         specifier: 29.5.0
         version: 29.5.0
@@ -1321,7 +1321,7 @@ importers:
         version: 2.2.5
       knex:
         specifier: 2.4.2
-        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+        version: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
       listr2:
         specifier: 6.3.1
         version: 6.3.1
@@ -1336,7 +1336,7 @@ importers:
         version: 6.3.3
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.29.0)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.5.0(@types/node@22.19.17))(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -4146,6 +4146,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
 
@@ -4329,6 +4332,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4539,7 +4545,7 @@ packages:
       just: ^0.1.8
       liquid-node: ^3.0.1
       liquor: ^0.0.5
-      lodash: ^4.17.20
+      lodash: 4.18.1
       marko: ^3.14.4
       mote: ^0.2.0
       mustache: ^3.0.0
@@ -4563,7 +4569,7 @@ packages:
       toffee: ^0.3.6
       twig: ^1.15.2
       twing: ^5.0.2
-      underscore: ^1.11.0
+      underscore: 1.13.8
       vash: ^0.13.0
       velocityjs: ^2.0.1
       walrus: ^0.10.1
@@ -4881,6 +4887,10 @@ packages:
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -5295,6 +5305,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5473,6 +5487,9 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -5596,6 +5613,9 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
@@ -6110,6 +6130,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isolated-vm@5.0.3:
+    resolution: {integrity: sha512-GNqX0j7dkwdaNQfFogLLb/tSuPZbXtKlk5ldaJ084ngjaW9/bn34x9FQFL856p20KSZoubIIummmiJf+2hzhCw==}
+    engines: {node: '>=18.0.0'}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -6814,6 +6838,9 @@ packages:
   mitt@3.0.0:
     resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -6863,6 +6890,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   native-duplexpair@1.0.0:
     resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
 
@@ -6887,6 +6917,10 @@ packages:
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -7378,7 +7412,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: 2.8.3
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -7570,6 +7604,12 @@ packages:
   preact@10.12.1:
     resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   precond@0.2.3:
     resolution: {integrity: sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==}
     engines: {node: '>= 0.6'}
@@ -7724,6 +7764,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.0.0:
     resolution: {integrity: sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==}
@@ -8067,6 +8111,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-lru-cache@0.0.2:
     resolution: {integrity: sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw==}
 
@@ -8188,9 +8238,6 @@ packages:
 
   sqlite3@5.1.6:
     resolution: {integrity: sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==}
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -8326,6 +8373,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -8443,6 +8494,13 @@ packages:
 
   tabbable@4.0.0:
     resolution: {integrity: sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
@@ -8896,11 +8954,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vm2@3.10.2:
-    resolution: {integrity: sha512-qTnbvpada8qlEEyIPFwhTcF5Ns+k83fVlOSE8XvAtHkhcQ+okMnbvryVQBfP/ExRT1CRsQpYusdATR+FBJfrnQ==}
-    engines: {node: '>=6.0'}
-    hasBin: true
 
   vt-pbf@3.1.3:
     resolution: {integrity: sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==}
@@ -9951,6 +10004,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/abort-controller@1.1.0':
     dependencies:
@@ -9979,14 +10033,16 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-client': 1.10.1
       '@azure/core-rest-pipeline': 1.23.0
+    optional: true
 
-  '@azure/core-http@3.0.5':
+  '@azure/core-http@3.0.5(encoding@0.1.13)':
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.10.1
@@ -9996,7 +10052,7 @@ snapshots:
       '@types/node-fetch': 2.6.11
       '@types/tunnel': 0.0.3
       form-data: 4.0.4
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       process: 0.11.10
       tslib: 2.8.1
       tunnel: 0.0.6
@@ -10030,6 +10086,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/core-tracing@1.0.0-preview.13':
     dependencies:
@@ -10039,6 +10096,7 @@ snapshots:
   '@azure/core-tracing@1.3.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@azure/core-util@1.13.1':
     dependencies:
@@ -10068,6 +10126,7 @@ snapshots:
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/keyvault-common@2.1.0':
     dependencies:
@@ -10081,6 +10140,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
     dependencies:
@@ -10099,6 +10159,7 @@ snapshots:
     transitivePeerDependencies:
       - '@azure/core-client'
       - supports-color
+    optional: true
 
   '@azure/logger@1.3.0':
     dependencies:
@@ -10110,23 +10171,28 @@ snapshots:
   '@azure/msal-browser@2.39.0':
     dependencies:
       '@azure/msal-common': 13.3.3
+    optional: true
 
-  '@azure/msal-common@13.3.1': {}
+  '@azure/msal-common@13.3.1':
+    optional: true
 
-  '@azure/msal-common@13.3.3': {}
+  '@azure/msal-common@13.3.3':
+    optional: true
 
-  '@azure/msal-common@7.6.0': {}
+  '@azure/msal-common@7.6.0':
+    optional: true
 
   '@azure/msal-node@1.18.4':
     dependencies:
       '@azure/msal-common': 13.3.1
       jsonwebtoken: 9.0.0
       uuid: 8.3.2
+    optional: true
 
-  '@azure/storage-blob@12.14.0':
+  '@azure/storage-blob@12.14.0(encoding@0.1.13)':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-http': 3.0.5
+      '@azure/core-http': 3.0.5(encoding@0.1.13)
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
       '@azure/core-tracing': 1.0.0-preview.13
@@ -10706,7 +10772,7 @@ snapshots:
 
   '@google-cloud/promisify@3.0.1': {}
 
-  '@google-cloud/storage@6.9.5':
+  '@google-cloud/storage@6.9.5(encoding@0.1.13)':
     dependencies:
       '@google-cloud/paginator': 3.0.7
       '@google-cloud/projectify': 3.0.0
@@ -10717,13 +10783,13 @@ snapshots:
       duplexify: 4.1.3
       ent: 2.2.2
       extend: 3.0.2
-      gaxios: 5.1.3
-      google-auth-library: 8.9.0
+      gaxios: 5.1.3(encoding@0.1.13)
+      google-auth-library: 8.9.0(encoding@0.1.13)
       mime: 3.0.0
       mime-types: 2.1.35
       p-limit: 3.1.0
       retry-request: 5.0.2
-      teeny-request: 8.0.3
+      teeny-request: 8.0.3(encoding@0.1.13)
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
@@ -11049,7 +11115,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-joda/core@5.7.0': {}
+  '@js-joda/core@5.7.0':
+    optional: true
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -11132,16 +11199,16 @@ snapshots:
       is-plain-obj: 1.1.0
       xtend: 4.0.2
 
-  '@mapbox/node-pre-gyp@1.0.11':
+  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
     dependencies:
       detect-libc: 2.1.2
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.2
+      semver: 7.5.2
       tar: 7.5.11
     transitivePeerDependencies:
       - encoding
@@ -11228,7 +11295,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.2
+      semver: 7.5.2
     optional: true
 
   '@npmcli/move-file@1.1.2':
@@ -11268,7 +11335,7 @@ snapshots:
 
   '@phc/format@1.0.0': {}
 
-  '@pinia/testing@0.0.16(pinia@2.0.35)(vue@3.2.47)':
+  '@pinia/testing@0.0.16(pinia@2.0.35(typescript@5.0.4)(vue@3.2.47))(vue@3.2.47)':
     dependencies:
       pinia: 2.0.35(typescript@5.0.4)(vue@3.2.47)
       vue-demi: 0.14.10(vue@3.2.47)
@@ -11280,8 +11347,9 @@ snapshots:
 
   '@rollup/plugin-alias@5.0.0(rollup@4.60.1)':
     dependencies:
-      rollup: 4.60.1
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 4.60.1
 
   '@rollup/plugin-commonjs@24.1.0(rollup@4.60.1)':
     dependencies:
@@ -11291,11 +11359,13 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/plugin-json@6.0.0(rollup@4.60.1)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/plugin-node-resolve@15.0.2(rollup@4.60.1)':
@@ -11306,23 +11376,26 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.12
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/plugin-replace@5.0.2(rollup@4.60.1)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       magic-string: 0.27.0
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/plugin-terser@0.4.1(rollup@4.60.1)':
     dependencies:
-      rollup: 4.60.1
       serialize-javascript: 7.0.5
       smob: 0.0.6
       terser: 5.46.1
+    optionalDependencies:
+      rollup: 4.60.1
 
   '@rollup/plugin-virtual@3.0.1(rollup@4.60.1)':
-    dependencies:
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/plugin-yaml@4.0.1':
@@ -11341,6 +11414,7 @@ snapshots:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
+    optionalDependencies:
       rollup: 4.60.1
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -11817,7 +11891,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.59.0(@typescript-eslint/parser@5.59.0)(eslint@8.38.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 5.59.0(eslint@8.38.0)(typescript@5.4.5)
@@ -11829,8 +11903,9 @@ snapshots:
       grapheme-splitter: 1.0.4
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.6.2
+      semver: 7.5.2
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -11842,6 +11917,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.4.5)
       debug: 4.4.3
       eslint: 8.38.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -11863,6 +11939,7 @@ snapshots:
       debug: 4.4.3
       eslint: 8.38.0
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -11878,8 +11955,9 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.5.2
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -11891,8 +11969,9 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.5.2
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -11907,7 +11986,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.4.5)
       eslint: 8.38.0
       eslint-scope: 5.1.1
-      semver: 7.6.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11922,7 +12001,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       eslint: 8.38.0
       eslint-scope: 5.1.1
-      semver: 7.6.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11945,12 +12024,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@4.1.0(vite@5.4.21)(vue@3.2.47)':
+  '@vitejs/plugin-vue@4.1.0(vite@5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1))(vue@3.2.47)':
     dependencies:
-      vite: 5.4.21(sass@1.62.0)
+      vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
       vue: 3.2.47
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1)':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -11965,7 +12044,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@22.19.17)
+      vitest: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12149,7 +12228,7 @@ snapshots:
     optional: true
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.18.0
 
   ajv@6.14.0:
@@ -12221,9 +12300,9 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  argon2@0.30.3:
+  argon2@0.30.3(encoding@0.1.13):
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
       '@phc/format': 1.0.0
       node-addon-api: 5.1.0
     transitivePeerDependencies:
@@ -12310,7 +12389,7 @@ snapshots:
       progress: 2.0.3
       reinterval: 1.1.0
       retimer: 3.0.0
-      semver: 7.6.2
+      semver: 7.5.2
       subarg: 1.0.0
       timestring: 6.0.0
 
@@ -12412,6 +12491,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   bl@5.1.0:
     dependencies:
       buffer: 6.0.3
@@ -12475,7 +12560,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  buffer-writer@2.0.0: {}
+  buffer-writer@2.0.0:
+    optional: true
 
   buffer@5.6.0:
     dependencies:
@@ -12664,6 +12750,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chownr@1.1.4: {}
+
   chownr@2.0.0:
     optional: true
 
@@ -12823,9 +12911,12 @@ snapshots:
 
   console-control-strings@1.1.0: {}
 
-  consolidate@0.15.1:
+  consolidate@0.15.1(lodash@4.18.1)(underscore@1.13.8):
     dependencies:
       bluebird: 3.7.2
+    optionalDependencies:
+      lodash: 4.18.1
+      underscore: 1.13.8
     optional: true
 
   content-disposition@0.5.4:
@@ -12876,7 +12967,7 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
-  create-jest@29.7.0:
+  create-jest@29.7.0(@types/node@22.19.17):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
@@ -13012,6 +13103,7 @@ snapshots:
   debug@3.2.7(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
       supports-color: 5.5.0
 
   debug@4.3.4:
@@ -13043,6 +13135,8 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -13059,7 +13153,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  define-lazy-prop@2.0.0: {}
+  define-lazy-prop@2.0.0:
+    optional: true
 
   define-properties@1.2.1:
     dependencies:
@@ -13311,6 +13406,7 @@ snapshots:
       globalthis: 1.0.4
       has-property-descriptors: 1.0.2
       set-function-name: 2.0.2
+    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -13458,21 +13554,23 @@ snapshots:
     dependencies:
       eslint: 8.38.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.59.0)(eslint@8.38.0)(typescript@5.4.5):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.0(@typescript-eslint/parser@5.59.0)(eslint@8.38.0)(typescript@5.4.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.38.0)(typescript@5.4.5)
       eslint: 8.38.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 5.59.0(@typescript-eslint/parser@5.59.0(eslint@8.38.0)(typescript@5.4.5))(eslint@8.38.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.38.0)(prettier@2.8.7):
+  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.38.0))(eslint@8.38.0)(prettier@2.8.7):
     dependencies:
       eslint: 8.38.0
-      eslint-config-prettier: 8.8.0(eslint@8.38.0)
       prettier: 2.8.7
       prettier-linter-helpers: 1.0.1
+    optionalDependencies:
+      eslint-config-prettier: 8.8.0(eslint@8.38.0)
 
   eslint-plugin-vue@9.11.0(eslint@8.38.0):
     dependencies:
@@ -13481,7 +13579,7 @@ snapshots:
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
-      semver: 7.6.2
+      semver: 7.5.2
       vue-eslint-parser: 9.4.3(eslint@8.38.0)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
@@ -13630,6 +13728,8 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expand-template@2.0.3: {}
+
   expect@29.7.0:
     dependencies:
       '@jest/expect-utils': 29.7.0
@@ -13726,7 +13826,7 @@ snapshots:
       bser: 2.1.1
 
   fdir@6.5.0(picomatch@4.0.4):
-    dependencies:
+    optionalDependencies:
       picomatch: 4.0.4
 
   figures@5.0.0:
@@ -13856,6 +13956,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -13925,19 +14027,19 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
-  gaxios@5.1.3:
+  gaxios@5.1.3(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 5.0.1
       is-stream: 2.0.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gcp-metadata@5.3.0:
+  gcp-metadata@5.3.0(encoding@0.1.13):
     dependencies:
-      gaxios: 5.1.3
+      gaxios: 5.1.3(encoding@0.1.13)
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -13946,6 +14048,7 @@ snapshots:
   generate-function@2.3.1:
     dependencies:
       is-property: 1.0.2
+    optional: true
 
   generator-function@2.0.1: {}
 
@@ -14006,6 +14109,8 @@ snapshots:
       assert-plus: 1.0.0
     optional: true
 
+  github-from-package@0.0.0: {}
+
   gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
@@ -14051,15 +14156,15 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@8.9.0:
+  google-auth-library@8.9.0(encoding@0.1.13):
     dependencies:
       arrify: 2.0.1
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
       fast-text-encoding: 1.0.6
-      gaxios: 5.1.3
-      gcp-metadata: 5.3.0
-      gtoken: 6.1.2
+      gaxios: 5.1.3(encoding@0.1.13)
+      gcp-metadata: 5.3.0(encoding@0.1.13)
+      gtoken: 6.1.2(encoding@0.1.13)
       jws: 4.0.1
       lru-cache: 6.0.0
     transitivePeerDependencies:
@@ -14107,9 +14212,9 @@ snapshots:
 
   grid-index@1.1.0: {}
 
-  gtoken@6.1.2:
+  gtoken@6.1.2(encoding@0.1.13):
     dependencies:
-      gaxios: 5.1.3
+      gaxios: 5.1.3(encoding@0.1.13)
       google-p12-pem: 4.0.1
       jws: 4.0.1
     transitivePeerDependencies:
@@ -14294,6 +14399,7 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+    optional: true
 
   icss-utils@5.1.0(postcss@8.5.9):
     dependencies:
@@ -14482,7 +14588,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-property@1.0.2: {}
+  is-property@1.0.2:
+    optional: true
 
   is-reference@1.2.1:
     dependencies:
@@ -14549,6 +14656,10 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isolated-vm@5.0.3:
+    dependencies:
+      prebuild-install: 7.1.3
 
   isstream@0.1.2:
     optional: true
@@ -14639,13 +14750,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
+  jest-cli@29.7.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@22.19.17)
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.17)
@@ -14663,7 +14774,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.17
       babel-jest: 29.7.0(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -14683,6 +14793,8 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14773,7 +14885,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -14911,12 +15023,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.5.0:
+  jest@29.5.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0
+      jest-cli: 29.7.0(@types/node@22.19.17)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14942,7 +15054,8 @@ snapshots:
       glob: 8.1.0
       nopt: 6.0.0
 
-  js-md4@0.3.2: {}
+  js-md4@0.3.2:
+    optional: true
 
   js-sdsl@4.4.2: {}
 
@@ -14963,7 +15076,8 @@ snapshots:
     dependencies:
       xmlcreate: 2.0.4
 
-  jsbi@4.3.2: {}
+  jsbi@4.3.2:
+    optional: true
 
   jsbn@0.1.1:
     optional: true
@@ -15043,7 +15157,7 @@ snapshots:
       jws: 3.2.3
       lodash: 4.18.1
       ms: 2.1.3
-      semver: 7.6.2
+      semver: 7.5.2
 
   jsprim@1.4.2:
     dependencies:
@@ -15095,12 +15209,12 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knex-mock-client@2.0.0(knex@2.4.2):
+  knex-mock-client@2.0.0(knex@2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))):
     dependencies:
-      knex: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0)
+      knex: 2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1))
       lodash.clonedeep: 4.5.0
 
-  knex@2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6)(tedious@16.0.0):
+  knex@2.4.2(mysql2@3.10.0)(pg@8.10.0)(sqlite3@5.1.6(encoding@0.1.13))(tedious@16.0.0(@azure/core-client@1.10.1)):
     dependencies:
       colorette: 2.0.19
       commander: 9.5.0
@@ -15111,15 +15225,16 @@ snapshots:
       getopts: 2.3.0
       interpret: 2.2.0
       lodash: 4.18.1
-      mysql2: 3.10.0
-      pg: 8.10.0
       pg-connection-string: 2.5.0
       rechoir: 0.8.0
       resolve-from: 5.0.0
-      sqlite3: 5.1.6
       tarn: 3.0.2
-      tedious: 16.0.0(@azure/core-client@1.10.1)
       tildify: 2.0.0
+    optionalDependencies:
+      mysql2: 3.10.0
+      pg: 8.10.0
+      sqlite3: 5.1.6(encoding@0.1.13)
+      tedious: 16.0.0(@azure/core-client@1.10.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15222,7 +15337,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 8.1.0
 
-  long@5.3.2: {}
+  long@5.3.2:
+    optional: true
 
   loose-envify@1.4.0:
     dependencies:
@@ -15247,9 +15363,11 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lru-cache@8.0.5: {}
+  lru-cache@8.0.5:
+    optional: true
 
-  lru.min@1.1.4: {}
+  lru.min@1.1.4:
+    optional: true
 
   magic-string@0.25.9:
     dependencies:
@@ -15509,6 +15627,8 @@ snapshots:
 
   mitt@3.0.0: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   mlly@1.8.2:
@@ -15540,6 +15660,7 @@ snapshots:
       named-placeholders: 1.1.6
       seq-queue: 0.0.5
       sqlstring: 2.3.3
+    optional: true
 
   mz@2.7.0:
     dependencies:
@@ -15550,12 +15671,16 @@ snapshots:
   named-placeholders@1.1.6:
     dependencies:
       lru.min: 1.1.4
+    optional: true
 
   nanoid@3.3.11: {}
 
   nanoid@5.0.9: {}
 
-  native-duplexpair@1.0.0: {}
+  napi-build-utils@2.0.0: {}
+
+  native-duplexpair@1.0.0:
+    optional: true
 
   native-promise-only@0.8.1: {}
 
@@ -15576,7 +15701,12 @@ snapshots:
   negotiator@0.6.4:
     optional: true
 
-  node-abort-controller@3.1.1: {}
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.5.2
+
+  node-abort-controller@3.1.1:
+    optional: true
 
   node-addon-api@4.3.0: {}
 
@@ -15586,9 +15716,11 @@ snapshots:
     dependencies:
       uuid: 8.3.2
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-forge@1.4.0: {}
 
@@ -15601,7 +15733,7 @@ snapshots:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.6.2
+      semver: 7.5.2
       tar: 7.5.11
       which: 2.0.2
     transitivePeerDependencies:
@@ -15619,9 +15751,9 @@ snapshots:
 
   node-xmllint@1.0.0: {}
 
-  nodemailer-mailgun-transport@2.1.5:
+  nodemailer-mailgun-transport@2.1.5(lodash@4.18.1)(underscore@1.13.8):
     dependencies:
-      consolidate: 0.15.1
+      consolidate: 0.15.1(lodash@4.18.1)(underscore@1.13.8)
       form-data: 4.0.4
       mailgun.js: 8.2.2
     transitivePeerDependencies:
@@ -15725,7 +15857,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.6.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -15820,6 +15952,7 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    optional: true
 
   openapi-types@12.1.0: {}
 
@@ -15916,7 +16049,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  packet-reader@1.0.0: {}
+  packet-reader@1.0.0:
+    optional: true
 
   pako@1.0.11: {}
 
@@ -15979,17 +16113,21 @@ snapshots:
   performance-now@2.1.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
+  pg-connection-string@2.12.0:
+    optional: true
 
   pg-connection-string@2.5.0: {}
 
-  pg-int8@1.0.1: {}
+  pg-int8@1.0.1:
+    optional: true
 
   pg-pool@3.13.0(pg@8.10.0):
     dependencies:
       pg: 8.10.0
+    optional: true
 
-  pg-protocol@1.13.0: {}
+  pg-protocol@1.13.0:
+    optional: true
 
   pg-types@2.2.0:
     dependencies:
@@ -15998,6 +16136,7 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+    optional: true
 
   pg@8.10.0:
     dependencies:
@@ -16008,10 +16147,12 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
       pgpass: 1.0.5
+    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -16022,9 +16163,10 @@ snapshots:
   pinia@2.0.35(typescript@5.0.4)(vue@3.2.47):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      typescript: 5.0.4
       vue: 3.2.47
       vue-demi: 0.14.10(vue@3.2.47)
+    optionalDependencies:
+      typescript: 5.0.4
 
   pino-abstract-transport@0.4.0:
     dependencies:
@@ -16164,9 +16306,12 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.9)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.9
+      yaml: 2.8.3
 
   postcss-merge-longhand@5.1.7(postcss@8.5.9):
     dependencies:
@@ -16319,19 +16464,38 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres-array@2.0.0: {}
+  postgres-array@2.0.0:
+    optional: true
 
-  postgres-bytea@1.0.1: {}
+  postgres-bytea@1.0.1:
+    optional: true
 
-  postgres-date@1.0.7: {}
+  postgres-date@1.0.7:
+    optional: true
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+    optional: true
 
   potpack@1.0.2: {}
 
   preact@10.12.1: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
 
   precond@0.2.3: {}
 
@@ -16461,6 +16625,13 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.0.0(react@18.0.0):
     dependencies:
@@ -16845,7 +17016,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seq-queue@0.0.5: {}
+  seq-queue@0.0.5:
+    optional: true
 
   serialize-javascript@7.0.5: {}
 
@@ -16953,6 +17125,14 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-lru-cache@0.0.2:
     optional: true
@@ -17098,11 +17278,12 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sprintf-js@1.1.3: {}
+  sprintf-js@1.1.3:
+    optional: true
 
-  sqlite3@5.1.6:
+  sqlite3@5.1.6(encoding@0.1.13):
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
       node-addon-api: 4.3.0
       tar: 7.5.11
     optionalDependencies:
@@ -17112,7 +17293,8 @@ snapshots:
       - encoding
       - supports-color
 
-  sqlstring@2.3.3: {}
+  sqlstring@2.3.3:
+    optional: true
 
   sshpk@1.18.0:
     dependencies:
@@ -17255,6 +17437,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@2.1.1:
@@ -17304,7 +17488,7 @@ snapshots:
       mime: 2.6.0
       qs: 6.12.3
       readable-stream: 3.6.2
-      semver: 7.6.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17319,7 +17503,7 @@ snapshots:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.12.3
-      semver: 7.6.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17415,6 +17599,21 @@ snapshots:
 
   tabbable@4.0.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -17442,12 +17641,13 @@ snapshots:
     transitivePeerDependencies:
       - '@azure/core-client'
       - supports-color
+    optional: true
 
-  teeny-request@8.0.3:
+  teeny-request@8.0.3(encoding@0.1.13):
     dependencies:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.0
     transitivePeerDependencies:
@@ -17563,25 +17763,28 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.0(@babel/core@7.29.0)(jest@29.5.0)(typescript@5.0.4):
+  ts-jest@29.1.0(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.5.0(@types/node@22.19.17))(typescript@5.0.4):
     dependencies:
-      '@babel/core': 7.29.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0
+      jest: 29.5.0(@types/node@22.19.17)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.5.2
       typescript: 5.0.4
       yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
 
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
-  tsup@8.2.2(typescript@5.4.5):
+  tsup@8.2.2(postcss@8.5.9)(typescript@5.4.5)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -17593,12 +17796,14 @@ snapshots:
       globby: 11.1.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.9)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.8.0-beta.0
       sucrase: 3.35.1
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.9
       typescript: 5.4.5
     transitivePeerDependencies:
       - jiti
@@ -17622,7 +17827,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   tunnel@0.0.6: {}
 
@@ -17809,13 +18013,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@1.6.1(@types/node@22.19.17):
+  vite-node@1.6.1(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@22.19.17)
+      vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -17827,98 +18031,42 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(sass@1.62.0):
+  vite@5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.21(sass@1.62.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.21(@types/node@22.19.17):
-    dependencies:
-      '@types/node': 22.19.17
       esbuild: 0.21.5
       postcss: 8.5.9
       rollup: 4.60.1
     optionalDependencies:
+      '@types/node': 22.19.17
       fsevents: 2.3.3
-
-  vite@5.4.21(sass@1.62.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.9
-      rollup: 4.60.1
       sass: 1.62.0
+      terser: 5.46.1
+
+  vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
+      vite-node: 1.6.1(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
+      why-is-node-running: 2.3.0
     optionalDependencies:
-      fsevents: 2.3.3
-
-  vitest@1.6.1(@types/node@22.19.17):
-    dependencies:
       '@types/node': 22.19.17
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.5
-      chai: 4.5.0
-      debug: 4.4.3
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@22.19.17)
-      vite-node: 1.6.1(@types/node@22.19.17)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(happy-dom@14.12.3)(sass@1.62.0):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.5
-      chai: 4.5.0
-      debug: 4.4.3
-      execa: 8.0.1
       happy-dom: 14.12.3
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(sass@1.62.0)
-      vite-node: 1.6.1(sass@1.62.0)
-      why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -17928,11 +18076,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vm2@3.10.2:
-    dependencies:
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
 
   vt-pbf@3.1.3:
     dependencies:
@@ -17953,7 +18096,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.7.0
       lodash: 4.18.1
-      semver: 7.6.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(rollup@4.60.1)
       argon2:
-        specifier: 0.30.3
-        version: 0.30.3(encoding@0.1.13)
+        specifier: 0.40.3
+        version: 0.40.3
       async:
         specifier: 3.2.4
         version: 3.2.4
@@ -332,34 +332,6 @@ importers:
       wellknown:
         specifier: 0.5.0
         version: 0.5.0
-    optionalDependencies:
-      '@keyv/redis':
-        specifier: 2.5.7
-        version: 2.5.7
-      keyv-memcache:
-        specifier: 1.3.3
-        version: 1.3.3
-      memcached:
-        specifier: 2.2.2
-        version: 2.2.2
-      mysql2:
-        specifier: 3.10.0
-        version: 3.10.0
-      nodemailer-mailgun-transport:
-        specifier: 2.1.5
-        version: 2.1.5(lodash@4.18.1)(underscore@1.13.8)
-      nodemailer-sendgrid:
-        specifier: 1.0.3
-        version: 1.0.3
-      pg:
-        specifier: 8.10.0
-        version: 8.10.0
-      sqlite3:
-        specifier: 5.1.6
-        version: 5.1.6(encoding@0.1.13)
-      tedious:
-        specifier: 16.0.0
-        version: 16.0.0(@azure/core-client@1.10.1)
     devDependencies:
       '@cairncms/types':
         specifier: workspace:*
@@ -496,6 +468,34 @@ importers:
       vitest:
         specifier: 1.6.1
         version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+    optionalDependencies:
+      '@keyv/redis':
+        specifier: 2.5.7
+        version: 2.5.7
+      keyv-memcache:
+        specifier: 1.3.3
+        version: 1.3.3
+      memcached:
+        specifier: 2.2.2
+        version: 2.2.2
+      mysql2:
+        specifier: 3.10.0
+        version: 3.10.0
+      nodemailer-mailgun-transport:
+        specifier: 2.1.5
+        version: 2.1.5(lodash@4.18.1)(underscore@1.13.8)
+      nodemailer-sendgrid:
+        specifier: 1.0.3
+        version: 1.0.3
+      pg:
+        specifier: 8.10.0
+        version: 8.10.0
+      sqlite3:
+        specifier: 5.1.6
+        version: 5.1.6(encoding@0.1.13)
+      tedious:
+        specifier: 16.0.0
+        version: 16.0.0(@azure/core-client@1.10.1)
 
   app:
     dependencies:
@@ -4002,9 +4002,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
-  argon2@0.30.3:
-    resolution: {integrity: sha512-DoH/kv8c9127ueJSBxAVJXinW9+EuPA3EMUxoV2sAY1qDE5H9BjTyVF/aD2XyHqbqUWabgBkIfcP3ZZuGhbJdg==}
-    engines: {node: '>=14.0.0'}
+  argon2@0.40.3:
+    resolution: {integrity: sha512-FrSmz4VeM91jwFvvjsQv9GYp6o/kARWoYKjbjDB2U5io1H3e5X67PYGclFDeQff6UXIhUd4aHR3mxCdBbMMuQw==}
+    engines: {node: '>=16.17.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -6928,8 +6928,9 @@ packages:
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
-  node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-cron@3.0.2:
     resolution: {integrity: sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==}
@@ -6947,6 +6948,10 @@ packages:
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -12300,14 +12305,11 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  argon2@0.30.3(encoding@0.1.13):
+  argon2@0.40.3:
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
       '@phc/format': 1.0.0
-      node-addon-api: 5.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
 
   argparse@1.0.10:
     dependencies:
@@ -15710,7 +15712,7 @@ snapshots:
 
   node-addon-api@4.3.0: {}
 
-  node-addon-api@5.1.0: {}
+  node-addon-api@8.7.0: {}
 
   node-cron@3.0.2:
     dependencies:
@@ -15723,6 +15725,8 @@ snapshots:
       encoding: 0.1.13
 
   node-forge@1.4.0: {}
+
+  node-gyp-build@4.8.4: {}
 
   node-gyp@8.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,18 @@ packages:
   - sdk
   - packages/*
   - tests/*
+
+onlyBuiltDependencies:
+  - '@fortawesome/fontawesome-common-types'
+  - '@fortawesome/fontawesome-svg-core'
+  - '@fortawesome/free-brands-svg-icons'
+  - '@fortawesome/free-regular-svg-icons'
+  - '@fortawesome/free-solid-svg-icons'
+  - '@parcel/watcher'
+  - argon2
+  - esbuild
+  - isolated-vm
+  - sharp
+  - snappy
+  - sqlite3
+  - vue-demi

--- a/tests/blackbox/README.md
+++ b/tests/blackbox/README.md
@@ -62,7 +62,7 @@ The blackbox suite runs the deployed `dist/` code, but inside an environment tha
 1. `tests/blackbox/common/config.ts:66` spreads `...process.env` into each vendor's env block.
 2. `tests/blackbox/setup/setup.ts:42` (bootstrap) and `tests/blackbox/setup/setup.ts:58` (server start) both pass that merged env to the spawned `node` process.
 
-When blackbox is invoked via `pnpm test:blackbox`, pnpm sets `NODE_PATH=<repo>/node_modules/.pnpm/node_modules` for the script run, and that `NODE_PATH` flows through into the spawned bootstrap. The published Docker image runs `node /cairncms/cli.js bootstrap` directly with no `NODE_PATH`.
+When blackbox is invoked via `pnpm test:blackbox`, pnpm sets `NODE_PATH=<repo>/node_modules/.pnpm/node_modules` for the script run, and that `NODE_PATH` flows through into the spawned bootstrap. The published Docker image runs `node --no-node-snapshot /cairncms/cli.js bootstrap` directly with no `NODE_PATH`.
 
 Practical consequence: the suite can pass even when the published image has a real module-resolution bug. The workspace's flat virtual store provides a fallback resolution path that the container does not have. If you are debugging "this works in CI but breaks in production," reproduce against the Docker image directly (`docker build` and `docker run`) instead of relying on a green blackbox run as evidence that runtime module resolution is healthy.
 

--- a/tests/blackbox/logger/redact.test.ts
+++ b/tests/blackbox/logger/redact.test.ts
@@ -28,7 +28,7 @@ describe('Logger Redact Tests', () => {
 		for (const vendor of vendors) {
 			databases.set(vendor, knex(config.knexConfig[vendor]!));
 
-			const server = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env[vendor] });
+			const server = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env: env[vendor] });
 			directusInstances[vendor] = server;
 
 			promises.push(awaitDirectusConnection(Number(env[vendor].PORT)));

--- a/tests/blackbox/routes/collections/schema-cache.test.ts
+++ b/tests/blackbox/routes/collections/schema-cache.test.ts
@@ -58,10 +58,10 @@ describeFn('Schema Caching Tests', () => {
 			env3[vendor]!.PORT = String(newServerPort3);
 			env4[vendor]!.PORT = String(newServerPort4);
 
-			const server1 = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env1[vendor] });
-			const server2 = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env2[vendor] });
-			const server3 = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env3[vendor] });
-			const server4 = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env4[vendor] });
+			const server1 = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env: env1[vendor] });
+			const server2 = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env: env2[vendor] });
+			const server3 = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env: env3[vendor] });
+			const server4 = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env: env4[vendor] });
 
 			tzDirectus[vendor] = [server1, server2, server3, server4];
 			envs[vendor] = [env1, env2, env3, env4];

--- a/tests/blackbox/schema/timezone/timezone-changed-node-tz-america.test.ts
+++ b/tests/blackbox/schema/timezone/timezone-changed-node-tz-america.test.ts
@@ -78,7 +78,7 @@ describe('schema', () => {
 			env.PORT = String(newServerPort);
 			tzEnvs[vendor] = env;
 
-			const server = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env });
+			const server = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env });
 			tzDirectus[vendor] = server;
 
 			let serverOutput = '';

--- a/tests/blackbox/schema/timezone/timezone-changed-node-tz-asia.test.ts
+++ b/tests/blackbox/schema/timezone/timezone-changed-node-tz-asia.test.ts
@@ -75,7 +75,7 @@ describe('schema', () => {
 			env.PORT = String(newServerPort);
 			tzEnvs[vendor] = env;
 
-			const server = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env });
+			const server = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], { cwd: paths.cwd, env });
 			tzDirectus[vendor] = server;
 
 			let serverOutput = '';

--- a/tests/blackbox/setup/setup.ts
+++ b/tests/blackbox/setup/setup.ts
@@ -39,7 +39,7 @@ export default async (): Promise<void> => {
 									writeFileSync(path.join(paths.cwd, 'test.db'), '');
 								}
 
-								const bootstrap = spawnSync('node', [paths.cli, 'bootstrap'], {
+								const bootstrap = spawnSync('node', ['--no-node-snapshot', paths.cli, 'bootstrap'], {
 									cwd: paths.cwd,
 									env: config.envs[vendor],
 								});
@@ -55,7 +55,7 @@ export default async (): Promise<void> => {
 								await database.destroy();
 
 								if (!process.env.TEST_LOCAL) {
-									const server = spawn('node', [paths.cli, 'start'], {
+									const server = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], {
 										cwd: paths.cwd,
 										env: config.envs[vendor],
 									});
@@ -84,7 +84,12 @@ export default async (): Promise<void> => {
 									const noCacheEnv = clone(config.envs[vendor]!);
 									noCacheEnv.CACHE_SCHEMA = 'false';
 									noCacheEnv.PORT = String(parseInt(noCacheEnv.PORT!) + 50);
-									const serverNoCache = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: noCacheEnv });
+
+									const serverNoCache = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], {
+										cwd: paths.cwd,
+										env: noCacheEnv,
+									});
+
 									global.directusNoCache[vendor] = serverNoCache;
 									let serverNoCacheOutput = '';
 									serverNoCache.stdout.setEncoding('utf8');


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Closes the majority of open CVEs.

The Run Script flow operation runs untrusted JS inside vm2, which is abandoned with multiple unfixed sandbox-escape vulnerabilities. This PR replaces vm2 with isolated-vm and narrows the operation's capability.

We considered the following alternatives:

- **SES + `worker_threads`:** would have required substantive redesign
- **quickjs-emscripten:** too immature for this project

isolated-vm itself is in maintenance mode but we feel that this is acceptable for v1 with the understanding that SES + `worker_threads` is the next path when needed.

NOTE: Replacing vm2 cleanly required some dep whack-a-mole. Under pnpm 9, adding isolated-vm to our workspace triggered a peer-context cascase in `pnpm deploy --prod` that selectively dropped sqlite3 from the deployed artifact, which would have shipped a Docker image that failed to bootstrap on its default config. The final stack required to run this migration is:

- **pnpm 8.3.1 -> 10.13.1** with `pnpm-deploy --legacy --prod`. Per pnpm 10's deploy reference, `--legacy` is the opt-out for the new deploy walker.
- **`onlyBuiltDependencies` allowList** in `pnpm-workspace.yml`. Per pnpm 10's release notes, install scripts no longer run by default; native deps (sqlite3, isolated-vm, etc.) need explicit opt-in or their `.node` bidings never get materialized.
- **argon2 0.30 -> 0.40.3**. Per argon2's changelog, 0.40 migrated from `@mapbox/node-pre-gyp` to `node-gyp-build`. This eliminates one transitive contributor to the cascade.
- **`--no-node-snapshot` Node flag** wired through every node-spawn site. Per isolated-vm docs, this flag is required on Node 20+.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
