### PR TITLE
Bump axios to 1.15.2

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,7 @@
 		"@rollup/plugin-virtual": "3.0.1",
 		"argon2": "0.40.3",
 		"async": "3.2.4",
-		"axios": "1.15.0",
+		"axios": "1.15.2",
 		"busboy": "1.6.0",
 		"bytes": "3.1.2",
 		"camelcase": "7.0.1",

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -286,10 +286,12 @@ export class FilesService extends ItemsService {
 		const parsedURL = url.parse(fileResponse.request.res.responseUrl);
 		const filename = decodeURI(path.basename(parsedURL.pathname as string));
 
+		const contentType = fileResponse.headers['content-type'];
+
 		const payload = {
 			filename_download: filename,
 			storage: toArray(env['STORAGE_LOCATIONS'])[0],
-			type: fileResponse.headers['content-type'],
+			type: typeof contentType === 'string' ? contentType : null,
 			title: formatTitle(filename),
 			...(body || {}),
 		};

--- a/app/package.json
+++ b/app/package.json
@@ -68,7 +68,7 @@
 		"@vue/compiler-sfc": "3.2.47",
 		"@vue/test-utils": "2.3.2",
 		"apexcharts": "3.39.0",
-		"axios": "1.15.0",
+		"axios": "1.15.2",
 		"base-64": "1.0.0",
 		"c8": "7.13.0",
 		"caret-pos": "2.0.0",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -32,7 +32,7 @@
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-v8": "1.6.1",
 		"@vue/test-utils": "2.3.2",
-		"axios": "1.15.0",
+		"axios": "1.15.2",
 		"typescript": "5.0.4",
 		"vitest": "1.6.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: 3.2.4
         version: 3.2.4
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -633,8 +633,8 @@ importers:
         specifier: 3.39.0
         version: 3.39.0
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       base-64:
         specifier: 1.0.0
         version: 1.0.0
@@ -805,8 +805,8 @@ importers:
         specifier: 2.3.2
         version: 2.3.2(vue@3.2.47)
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1302,8 +1302,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       globby:
         specifier: 11.1.0
         version: 11.1.0
@@ -4083,8 +4083,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -12405,7 +12405,7 @@ snapshots:
   aws4@1.13.2:
     optional: true
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -15391,7 +15391,7 @@ snapshots:
 
   mailgun.js@8.2.2:
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:

--- a/tests/blackbox/package.json
+++ b/tests/blackbox/package.json
@@ -13,7 +13,7 @@
 		"@types/supertest": "2.0.12",
 		"@types/uuid": "9.0.1",
 		"autocannon": "7.10.0",
-		"axios": "1.15.0",
+		"axios": "1.15.2",
 		"globby": "11.1.0",
 		"jest": "29.5.0",
 		"jest-environment-node": "29.5.0",


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves a number of dependency alerts. axios is a direct dep in four packages (previously pinned to 1.15.0). Bumped all to 1.15.2.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
