### PR TITLE
Send password reset to stored email (GHSA-qw9g-7549-7wg5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Restored default `DB_CLIENT=sqlite3` bootstrap in the published image.
 - Replaced vm2 with isolated-vm in the Run Script flow operation.
 - Redacted tokens in flow logs (GHSA-f24x-rm6g-3w5v / CVE-2025-53886).
+- Send password reset email to the stored address rather than the supplied input (GHSA-qw9g-7549-7wg5 / CVE-2024-27295).
 
 ### Acknowledgements
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -6,6 +6,7 @@ import type { MockedFunction, MockInstance } from 'vitest';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RecordNotUniqueException } from '../exceptions/database/record-not-unique.js';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import jwt from 'jsonwebtoken';
 import { ItemsService, MailService, UsersService } from './index.js';
 
 vi.mock('../../src/database/index', () => ({
@@ -741,6 +742,35 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([1]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+		});
+
+		describe('requestPasswordReset', () => {
+			it('sends the reset email to the stored address even when supplied a confusable variant', async () => {
+				const storedEmail = 'julian@cure53.de';
+				const suppliedEmail = 'julian@cüre53.de';
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id',
+					role: 'user-role',
+					status: 'active',
+					password: 'hashed-password',
+					email: storedEmail,
+				});
+
+				const promise = service.requestPasswordReset(suppliedEmail, null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(mailService.send).toBeCalledTimes(1);
+				const sendArgs = (mailService.send as any).mock.calls[0][0];
+
+				expect(sendArgs.to).toBe(storedEmail);
+				expect(sendArgs.template.data.email).toBe(storedEmail);
+
+				const tokenMatch = sendArgs.template.data.url.match(/token=([^&]+)/);
+				expect(tokenMatch).not.toBeNull();
+				const decoded = jwt.decode(tokenMatch[1]) as { email: string };
+				expect(decoded.email).toBe(storedEmail);
 			});
 		});
 	});

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -14,6 +14,18 @@ vi.mock('../../src/database/index', () => ({
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
 }));
 
+vi.mock('../env', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
 vi.mock('./mail', () => {
 	const MailService = vi.fn();
 	MailService.prototype.send = vi.fn();

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -18,6 +18,14 @@ import { ItemsService } from './items.js';
 import { MailService } from './mail/index.js';
 import { SettingsService } from './settings.js';
 
+type EmailLookupResult = {
+	id: string;
+	role: string;
+	status: string;
+	password: string;
+	email: string;
+};
+
 export class UsersService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {
 		super('directus_users', options);
@@ -139,10 +147,10 @@ export class UsersService extends ItemsService {
 	/**
 	 * Get basic information of user identified by email
 	 */
-	private async getUserByEmail(email: string): Promise<{ id: string; role: string; status: string; password: string }> {
+	private async getUserByEmail(email: string): Promise<EmailLookupResult> {
 		return await this.knex
-			.select('id', 'role', 'status', 'password')
 			.from('directus_users')
+			.select(['id', 'role', 'status', 'password', 'email'])
 			.whereRaw(`LOWER(??) = ?`, ['email', email.toLowerCase()])
 			.first();
 	}
@@ -451,8 +459,13 @@ export class UsersService extends ItemsService {
 			accountability: this.accountability,
 		});
 
-		const payload = { email, scope: 'password-reset', hash: getSimpleHash('' + user.password) };
-		const token = jwt.sign(payload, env['SECRET'] as string, { expiresIn: '1d', issuer: 'cairncms' });
+		const { email: storedEmail, password: storedPassword } = user;
+
+		const token = jwt.sign(
+			{ scope: 'password-reset', hash: getSimpleHash(String(storedPassword)), email: storedEmail },
+			env['SECRET'] as string,
+			{ expiresIn: '1d', issuer: 'cairncms' }
+		);
 
 		const acceptURL = url
 			? new Url(url).setQuery('token', token).toString()
@@ -461,13 +474,13 @@ export class UsersService extends ItemsService {
 		const subjectLine = subject ? subject : 'Password Reset Request';
 
 		await mailService.send({
-			to: email,
+			to: storedEmail,
 			subject: subjectLine,
 			template: {
 				name: 'password-reset',
 				data: {
 					url: acceptURL,
-					email,
+					email: storedEmail,
 				},
 			},
 		});


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-qw9g-7549-7wg5 / CVE-2024-27295.

On MySQL and MariaDB, accent-insensitive email matching can cause password reset requests to resolve a stored user record from a confusable input address. Before this change, the password reset flow used the supplied email address for both the reset token payload and the outgoing email recipient, meaning a reset link could be delivered to an incorrect mailbox.

This PR updates the password reset flow to use the canonical stored email address after lookup. Once a matching user is found, the reset JWT, mail recipient, and template email field all use the stored `directus_users.email` value rather than the request input.

### Testing / verification

- Added a unit test in `users.test.ts` covering the advisory content
- Verified that when a confusable input email resolves to a stored user, the rest email target and JWT `email` claim both use the stored address

Also manually verified the password reset flow against a live instance to confirm the normal reset path still works with the stored-address behavior in place.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
