### PR TITLE
Unify local-login error to close SSO user enumeration (GHSA-jgf4-vwc3…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Replaced vm2 with isolated-vm in the Run Script flow operation.
 - Redacted tokens in flow logs (GHSA-f24x-rm6g-3w5v / CVE-2025-53886).
 - Send password reset email to the stored address rather than the supplied input (GHSA-qw9g-7549-7wg5 / CVE-2024-27295).
+- Unified local-login error responses to prevent SSO user enumeration (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
 
 ### Acknowledgements
 

--- a/api/src/services/authentication.test.ts
+++ b/api/src/services/authentication.test.ts
@@ -1,0 +1,148 @@
+import type { SchemaOverview } from '@cairncms/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient, Tracker } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InvalidCredentialsException } from '../exceptions/index.js';
+import { AuthenticationService } from './authentication.js';
+import { SettingsService } from './settings.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../env', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+		LOGIN_STALL_TIME: 0,
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
+vi.mock('../emitter.js', () => ({
+	default: {
+		emitFilter: vi.fn(async (_event, payload) => payload),
+		emitAction: vi.fn(),
+	},
+}));
+
+const mockLocalDriver = {
+	getUserID: vi.fn(),
+	login: vi.fn(),
+};
+
+vi.mock('../auth.js', () => ({
+	getAuthProvider: vi.fn(() => mockLocalDriver),
+	DEFAULT_AUTH_PROVIDER: 'default',
+}));
+
+const testSchema = {
+	collections: {},
+	relations: [],
+} as SchemaOverview;
+
+describe('Integration Tests', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(async () => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	beforeEach(() => {
+		mockLocalDriver.getUserID.mockReset();
+		mockLocalDriver.login.mockReset();
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	describe('Services / Authentication', () => {
+		describe('login — local-login failure paths surface a uniform error', () => {
+			it('throws InvalidCredentialsException when the email does not exist', async () => {
+				mockLocalDriver.getUserID.mockRejectedValueOnce(new InvalidCredentialsException());
+
+				const service = new AuthenticationService({
+					knex: db,
+					schema: testSchema,
+				});
+
+				await expect(
+					service.login('default', { email: 'nobody@example.com', password: 'whatever' })
+				).rejects.toBeInstanceOf(InvalidCredentialsException);
+			});
+
+			it('throws InvalidCredentialsException when the email belongs to a different provider', async () => {
+				mockLocalDriver.getUserID.mockResolvedValueOnce('sso-user-id');
+
+				tracker.on.select(/select.*from "directus_users"/).response({
+					id: 'sso-user-id',
+					first_name: 'Sso',
+					last_name: 'User',
+					email: 'sso@example.com',
+					password: 'hashed',
+					status: 'active',
+					role: 'role-id',
+					admin_access: false,
+					app_access: true,
+					tfa_secret: null,
+					provider: 'openid',
+					external_identifier: 'sso-external-id',
+					auth_data: null,
+				});
+
+				const service = new AuthenticationService({
+					knex: db,
+					schema: testSchema,
+				});
+
+				await expect(
+					service.login('default', { email: 'sso@example.com', password: 'whatever' })
+				).rejects.toBeInstanceOf(InvalidCredentialsException);
+			});
+
+			it('throws InvalidCredentialsException when the password is wrong for a local user', async () => {
+				mockLocalDriver.getUserID.mockResolvedValueOnce('local-user-id');
+				mockLocalDriver.login.mockRejectedValueOnce(new InvalidCredentialsException());
+
+				tracker.on.select(/select.*from "directus_users"/).response({
+					id: 'local-user-id',
+					first_name: 'Local',
+					last_name: 'User',
+					email: 'local@example.com',
+					password: 'hashed',
+					status: 'active',
+					role: 'role-id',
+					admin_access: false,
+					app_access: true,
+					tfa_secret: null,
+					provider: 'default',
+					external_identifier: null,
+					auth_data: null,
+				});
+
+				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({ auth_login_attempts: null });
+
+				const service = new AuthenticationService({
+					knex: db,
+					schema: testSchema,
+				});
+
+				await expect(
+					service.login('default', { email: 'local@example.com', password: 'wrong' })
+				).rejects.toBeInstanceOf(InvalidCredentialsException);
+			});
+		});
+	});
+});

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -9,12 +9,7 @@ import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import getDatabase from '../database/index.js';
 import emitter from '../emitter.js';
 import env from '../env.js';
-import {
-	InvalidCredentialsException,
-	InvalidOTPException,
-	InvalidProviderException,
-	UserSuspendedException,
-} from '../exceptions/index.js';
+import { InvalidCredentialsException, InvalidOTPException, UserSuspendedException } from '../exceptions/index.js';
 import { createRateLimiter } from '../rate-limiter.js';
 import type { AbstractServiceOptions, CairnTokenPayload, LoginResult, Session, User } from '../types/index.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
@@ -130,7 +125,7 @@ export class AuthenticationService {
 			}
 		} else if (user.provider !== providerName) {
 			await stall(STALL_TIME, timeStart);
-			throw new InvalidProviderException();
+			throw new InvalidCredentialsException();
 		}
 
 		const settingsService = new SettingsService({


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-jgf4-vwc3-r46v / CVE-2024-39896.

When local authentication and SSO authentication coexist, local login attempts could return a different error for an email that belongs to another auth provider than for an email that does not exist. This allows unauthenticated attackers to enumerate whether a given email was registered as an SSO user.

This PR unifies those local-login failure paths by returning `InvalidCredentialsException` for provider mismatch as well. After this change, these cases surface the same client-facing error:

- email does not exist
- email belongs to a different auth provider
- email exists for the local provider, but the password is wrong

This closes the documented SSO-provider enumeration vector. It does not change the separate suspended-user path.

### Testing / verification

- Added 3 authentication tests covering the three local-login failure paths above

Also verified against a live production-mode instance.

Probed all three failure cases through the login API:
- non-existent email
- existing SSO-user email
- existing local-user email with wrong password

All three returned byte-identical failure responses, with no distinguishable provider-specific signal.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
