### PR TITLE
Exclude /auth routes from response cache (GHSA-cff8-x7jv-4fm8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Redacted tokens in flow logs (GHSA-f24x-rm6g-3w5v / CVE-2025-53886).
 - Send password reset email to the stored address rather than the supplied input (GHSA-qw9g-7549-7wg5 / CVE-2024-27295).
 - Unified local-login error responses to prevent SSO user enumeration (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
+- Excluded /auth responses from the response cache (GHSA-cff8-x7jv-4fm8 / CVE-2024-45596).
 
 ### Acknowledgements
 

--- a/api/src/middleware/respond.test.ts
+++ b/api/src/middleware/respond.test.ts
@@ -1,0 +1,86 @@
+import type { Request, Response } from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const setCacheValueMock = vi.fn();
+const fakeCache = {} as any;
+
+vi.mock('../cache.js', () => ({
+	getCache: () => ({ cache: fakeCache, systemCache: fakeCache, sharedSchemaCache: fakeCache }),
+	setCacheValue: (...args: unknown[]) => setCacheValueMock(...args),
+}));
+
+vi.mock('../env.js', () => {
+	const MOCK_ENV = {
+		CACHE_ENABLED: true,
+		CACHE_TTL: '5m',
+		CACHE_VALUE_MAX_SIZE: false,
+		CACHE_AUTO_PURGE: false,
+		CACHE_CONTROL_S_MAXAGE: '0',
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
+vi.mock('../utils/get-cache-key.js', () => ({
+	getCacheKey: (req: Request) => `key:${req.originalUrl}`,
+}));
+
+import { respond } from './respond.js';
+
+function makeReqRes(originalUrl: string, method = 'GET') {
+	const headers: Record<string, string> = {};
+
+	const req = {
+		method,
+		originalUrl,
+		sanitizedQuery: {},
+		accountability: null,
+	} as unknown as Request;
+
+	const res = {
+		locals: { payload: { data: { ok: true } } } as Record<string, unknown>,
+		setHeader: (name: string, value: string) => {
+			headers[name.toLowerCase()] = value;
+		},
+		json: vi.fn().mockReturnThis(),
+		status: vi.fn().mockReturnThis(),
+		end: vi.fn().mockReturnThis(),
+	} as unknown as Response;
+
+	return { req, res, headers };
+}
+
+describe('respond middleware — auth path cache exclusion', () => {
+	afterEach(() => {
+		setCacheValueMock.mockReset();
+	});
+
+	it('does not cache GET /auth/* responses and emits Cache-Control: no-cache', async () => {
+		const { req, res, headers } = makeReqRes('/auth/login/openid/callback');
+		await (respond as any)(req, res, vi.fn());
+
+		expect(setCacheValueMock).not.toHaveBeenCalled();
+		expect(headers['cache-control']).toBe('no-cache');
+	});
+
+	it('does not cache the bare GET /auth response either', async () => {
+		const { req, res, headers } = makeReqRes('/auth');
+		await (respond as any)(req, res, vi.fn());
+
+		expect(setCacheValueMock).not.toHaveBeenCalled();
+		expect(headers['cache-control']).toBe('no-cache');
+	});
+
+	it('caches a non-/auth GET response and emits a TTL-based Cache-Control', async () => {
+		const { req, res, headers } = makeReqRes('/server/info');
+		await (respond as any)(req, res, vi.fn());
+
+		expect(setCacheValueMock).toHaveBeenCalled();
+		expect(headers['cache-control']).not.toBe('no-cache');
+	});
+});

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -22,8 +22,13 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		exceedsMaxSize = valueSize > maxSize;
 	}
 
+	const isAuthRoute = req.originalUrl?.startsWith('/auth') ?? false;
+
+	const isCacheableRequest =
+		(req.method.toLowerCase() === 'get' || req.originalUrl?.startsWith('/graphql')) && !isAuthRoute;
+
 	if (
-		(req.method.toLowerCase() === 'get' || req.originalUrl?.startsWith('/graphql')) &&
+		isCacheableRequest &&
 		env['CACHE_ENABLED'] === true &&
 		cache &&
 		!req.sanitizedQuery.export &&


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-cff8-x7jv-4fm8 / CVE-2024-45596.

When response caching is enabled, successful OpenID and OAuth2 callback responses can return credential JSON on a `GET` request when no `redirect` parameter is used. Before this change, those responses were eligible for the shared response cache, which could allow a later unauthenticated request to receive the previous user's credentials.

This PR fixes that at the middleware level by excluding `/auth` responses from the shared response cache. Auth responses are inherently user-specific and should not be cached by URL.

### Testing

- Added 3 `respond` middleware tests covering:
  - `GET /auth/login/openid/callback` is not cached
  - `GET /auth` is not cached
  - a non-`/auth` `GET` response is still cached normally

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
