### PR TITLE
Sanitize condition operation validation errors (GHSA-fm3h-p9wm-h74h)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Send password reset email to the stored address rather than the supplied input (GHSA-qw9g-7549-7wg5 / CVE-2024-27295).
 - Unified local-login error responses to prevent SSO user enumeration (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
 - Excluded /auth responses from the response cache (GHSA-cff8-x7jv-4fm8 / CVE-2024-45596).
+- Sanitized condition operation validation errors in flow responses (GHSA-fm3h-p9wm-h74h / CVE-2025-30353).
 
 ### Acknowledgements
 

--- a/api/src/flows.test.ts
+++ b/api/src/flows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { REDACT_TEXT } from './constants.js';
-import { buildRevisionData, type Step } from './flows.js';
+import { buildRevisionData, getFlowManager, type Step } from './flows.js';
+import conditionOp from './operations/condition/index.js';
 
 const TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.HEADER_PAYLOAD_LONG_ENOUGH_TO_BE_REAL_TOKEN';
 
@@ -100,5 +101,49 @@ describe('buildRevisionData', () => {
 		expect(step.operation).toBe('op-1');
 		expect(step.key).toBe('send-notification');
 		expect(step.status).toBe('resolve');
+	});
+});
+
+describe('executeFlow — webhook trigger with failing condition does not leak context into response', () => {
+	test('the value returned from executeFlow when a condition fails contains no $accountability or $trigger.headers markers', async () => {
+		const manager = getFlowManager();
+		manager.addOperation('condition', conditionOp.handler as any);
+
+		const flow = {
+			id: 'test-flow',
+			name: 'test-flow',
+			status: 'active',
+			trigger: 'webhook',
+			accountability: null,
+			options: { method: 'POST', return: '$last', async: false },
+			operation: {
+				id: 'op-1',
+				key: 'check',
+				type: 'condition',
+				options: { filter: { must_pass: { _eq: 'expected' } } },
+				resolve: null,
+				reject: null,
+			},
+		};
+
+		const data = {
+			path: '/flows/trigger/test',
+			method: 'POST',
+			headers: { authorization: 'Bearer TOKEN_MARKER_CCC_DO_NOT_LEAK' },
+			query: {},
+			body: { must_pass: 'actual' },
+		};
+
+		const context = {
+			accountability: { user: 'USER_MARKER_BBB_DO_NOT_LEAK', role: 'role-id', admin: true, app: true, ip: '127.0.0.1' },
+			database: {} as any,
+			schema: { collections: {}, relations: [] } as any,
+		};
+
+		const result = await (manager as any).executeFlow(flow, data, context);
+		const blob = JSON.stringify(result);
+
+		expect(blob).not.toContain('TOKEN_MARKER_CCC_DO_NOT_LEAK');
+		expect(blob).not.toContain('USER_MARKER_BBB_DO_NOT_LEAK');
 	});
 });

--- a/api/src/operations/condition/index.test.ts
+++ b/api/src/operations/condition/index.test.ts
@@ -28,13 +28,14 @@ describe('Operations / Condition', () => {
 			status: false,
 		};
 
-		expect.assertions(2); // ensure catch block is reached
+		expect.assertions(3);
 
 		try {
 			config.handler({ filter }, { data } as any);
 		} catch (err: any) {
 			expect(err).toHaveLength(1);
-			expect(err[0]!.message).toBe(`"status" must be [true]`);
+			expect(err[0]!.path).toEqual(['status']);
+			expect(err[0]!.type).toBe('any.only');
 		}
 	});
 
@@ -47,13 +48,87 @@ describe('Operations / Condition', () => {
 
 		const data = {};
 
-		expect.assertions(2); // ensure catch block is reached
+		expect.assertions(3);
 
 		try {
 			config.handler({ filter }, { data } as any);
 		} catch (err: any) {
 			expect(err).toHaveLength(1);
-			expect(err[0]!.message).toBe(`"status" is required`);
+			expect(err[0]!.path).toEqual(['status']);
+			expect(err[0]!.type).toBe('any.required');
+		}
+	});
+
+	test('thrown error does not contain marker values from $env, $accountability, or $trigger.headers', () => {
+		const filter = {
+			must_pass: {
+				_eq: 'expected',
+			},
+		};
+
+		const data = {
+			must_pass: 'actual',
+			$env: { LEAK_PROBE: 'SECRET_MARKER_AAA_DO_NOT_LEAK' },
+			$accountability: { user: 'USER_MARKER_BBB_DO_NOT_LEAK' },
+			$trigger: { headers: { authorization: 'Bearer TOKEN_MARKER_CCC_DO_NOT_LEAK' } },
+		};
+
+		expect.assertions(4);
+
+		try {
+			config.handler({ filter }, { data } as any);
+		} catch (err: any) {
+			const blob = JSON.stringify(err);
+			expect(err).toBeDefined();
+			expect(blob).not.toContain('SECRET_MARKER_AAA_DO_NOT_LEAK');
+			expect(blob).not.toContain('USER_MARKER_BBB_DO_NOT_LEAK');
+			expect(blob).not.toContain('TOKEN_MARKER_CCC_DO_NOT_LEAK');
+		}
+	});
+
+	test('thrown error does not contain the rejected candidate value when the filter operator is _starts_with', () => {
+		const filter = {
+			some_field: {
+				_starts_with: 'expected_prefix_',
+			},
+		};
+
+		const data = {
+			some_field: 'SECRET_CANDIDATE_VALUE_DDD_DO_NOT_LEAK',
+		};
+
+		expect.assertions(2);
+
+		try {
+			config.handler({ filter }, { data } as any);
+		} catch (err: any) {
+			const blob = JSON.stringify(err);
+			expect(err).toBeDefined();
+			expect(blob).not.toContain('SECRET_CANDIDATE_VALUE_DDD_DO_NOT_LEAK');
+		}
+	});
+
+	test('thrown error does not contain the rejected candidate value when the filter operator is _regex', () => {
+		const filter = {
+			some_field: {
+				_regex: '^expected_prefix_',
+			},
+		};
+
+		const data = {
+			some_field: 'SECRET_CANDIDATE_VALUE_EEE_DO_NOT_LEAK',
+		};
+
+		expect.assertions(4);
+
+		try {
+			config.handler({ filter }, { data } as any);
+		} catch (err: any) {
+			const blob = JSON.stringify(err);
+			expect(blob).not.toContain('SECRET_CANDIDATE_VALUE_EEE_DO_NOT_LEAK');
+			expect(err).toHaveLength(1);
+			expect(err[0]!.path).toEqual(['some_field']);
+			expect(err[0]!.type).toBe('string.pattern.base');
 		}
 	});
 });

--- a/api/src/operations/condition/index.ts
+++ b/api/src/operations/condition/index.ts
@@ -11,10 +11,13 @@ export default defineOperationApi<Options>({
 	handler: ({ filter }, { data }) => {
 		const errors = validatePayload(filter, data, { requireAll: true });
 
-		if (errors.length > 0) {
-			throw errors;
-		} else {
-			return null;
-		}
+		if (errors.length === 0) return null;
+
+		throw errors.flatMap((error) =>
+			error.details.map((detail) => ({
+				path: detail.path,
+				type: detail.type,
+			}))
+		);
 	},
 });


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-fm3h-p9wm-h74h / CVE-2025-30353.

Webhook-triggered flows can return the result of the last operation as the HTTP response body. Before this change, when a `condition` operation failed, it threw raw Joi validation errors, and those errors carried references to the validation input, which could include sensitive flow context such as `$trigger`, `$accountability`, `$env`, or prior operation output.

This PR sanitizes condition-operation validation failures before they re-enter the flow data path. Instead of returning raw Joi error objects, the condition operation now throws a plain array of `{ path, type }` entries. This preserves enough structure to identify the failed condition while preventing validation input data from being reflected back into webhook responses.

### Testing / verification

- Extended `condition` operation tests to cover:
  - the sanitized `{ path, type }` shape for validation failures
  - marker probes ensuring `$env`, `$accountability`, and `$trigger.headers` values do not appear in the thrown error
  - `_starts_with` and `_regex` regressions ensuring rejected candidate values are not echoed back through operator-specific validation output
- Added a flow-level regression in `flows.test.ts` covering a webhook-triggered flow with `return: '$last'` and a failing condition

The fix was manually verified at:

- unit-level: the condition operation no longer throws raw Joi validation objects
- flow-level: a failing webhook condition no longer returns `$trigger.headers` or `$accountability` markers through the flow response body

This closes the documented leak path without changing unrelated validation utilities or the broader `executeOperation()` error-handling contract.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
