### PR TITLE
Add COOP header to /auth routes (GHSA-8m32-p958-jg99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Unified local-login error responses to prevent SSO user enumeration (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
 - Excluded /auth responses from the response cache (GHSA-cff8-x7jv-4fm8 / CVE-2024-45596).
 - Sanitized condition operation validation errors in flow responses (GHSA-fm3h-p9wm-h74h / CVE-2025-30353).
+- Added Cross-Origin-Opener-Policy header to /auth routes (GHSA-8m32-p958-jg99 / CVE-2026-35408).
 
 ### Acknowledgements
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -240,7 +240,7 @@ export default async function createApp(): Promise<express.Application> {
 
 	await emitter.emitInit('routes.before', { app });
 
-	app.use('/auth', authRouter);
+	app.use('/auth', helmet.crossOriginOpenerPolicy(), authRouter);
 
 	app.use('/graphql', graphqlRouter);
 

--- a/api/src/middleware/coop.test.ts
+++ b/api/src/middleware/coop.test.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import helmet from 'helmet';
+import request from 'supertest';
+import { describe, expect, test } from 'vitest';
+
+function buildHarness(applyCoop: boolean) {
+	const app = express();
+
+	const authRouter = express.Router();
+	authRouter.get('/test', (_req, res) => res.json({ ok: true }));
+
+	if (applyCoop) {
+		app.use('/auth', helmet.crossOriginOpenerPolicy(), authRouter);
+	} else {
+		app.use('/auth', authRouter);
+	}
+
+	app.get('/server/info', (_req, res) => res.json({ ok: true }));
+
+	return app;
+}
+
+describe('Cross-Origin-Opener-Policy on /auth routes', () => {
+	test('GET /auth/* response includes Cross-Origin-Opener-Policy: same-origin when the middleware is mounted', async () => {
+		const app = buildHarness(true);
+		const res = await request(app).get('/auth/test');
+		expect(res.headers['cross-origin-opener-policy']).toBe('same-origin');
+	});
+
+	test('GET /server/info does not get the COOP header (regression guard: not set globally)', async () => {
+		const app = buildHarness(true);
+		const res = await request(app).get('/server/info');
+		expect(res.headers['cross-origin-opener-policy']).toBeUndefined();
+	});
+
+	test('without the middleware mounted, GET /auth/* does not get the COOP header (baseline negative)', async () => {
+		const app = buildHarness(false);
+		const res = await request(app).get('/auth/test');
+		expect(res.headers['cross-origin-opener-policy']).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-8m32-p958-jg99 / CVE-2026-35408.

SSO-related auth endpoints were missing the `Cross-Origin-Opener-Policy` header. Without COOP, a malicious cross-origin page can retain an opener reference to an auth window and interfere with the browser-side login flow.

This PR adds `Cross-Origin-Opener-Policy: same-origin` to the `/auth` route group by mounting `helmet.crossOriginOpenerPolicy()` at the `/auth` boundary in `api/src/app.ts`. That covers the browser-facing auth surface used by local and SSO login routes without changing header behavior for the rest of the app.

### Testing / verification

- Added a `coop` middleware contract test covering:
  - `/auth/*` responses receive `Cross-Origin-Opener-Policy: same-origin`
  - non-`/auth` responses do not receive the header
  - baseline negative case without the middleware mounted

Also verified against a live instance:

- `GET /auth` returns `Cross-Origin-Opener-Policy: same-origin`
- `GET /server/info` does not return the header

The automated test is a middleware contract test rather than a full-app route regression. The live probe verifies that the same header behavior is wired into the real app.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
