### PR TITLE
Strip server-controlled fields from FilesService writes (GHSA-393c-p4…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Excluded /auth responses from the response cache (GHSA-cff8-x7jv-4fm8 / CVE-2024-45596).
 - Sanitized condition operation validation errors in flow responses (GHSA-fm3h-p9wm-h74h / CVE-2025-30353).
 - Added Cross-Origin-Opener-Policy header to /auth routes (GHSA-8m32-p958-jg99 / CVE-2026-35408).
+- Stripped server-controlled fields from file metadata writes (GHSA-393c-p46r-7c95 / CVE-2026-39942).
 
 ### Acknowledgements
 

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -1,10 +1,42 @@
 import type { Knex } from 'knex';
 import knex from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
+import { Readable } from 'node:stream';
 import type { MockedFunction, SpyInstance } from 'vitest';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InvalidPayloadException } from '../exceptions/index.js';
 import { FilesService, ItemsService } from './index.js';
+
+const ATTACKER_FILENAME_DISK = '../victim-deadbeef.bin';
+const ATTACKER_UPLOADED_BY = '00000000-dead-dead-dead-000000000000';
+
+const storageWrite = vi.fn(async () => undefined);
+const storageStat = vi.fn(async () => ({ size: 42 }));
+
+const storageList = vi.fn(() => ({
+	async *[Symbol.asyncIterator]() {
+		// no entries
+	},
+}));
+
+const storageDelete = vi.fn(async () => undefined);
+
+vi.mock('../storage/index.js', () => ({
+	getStorage: vi.fn(async () => ({
+		location: () => ({
+			write: storageWrite,
+			stat: storageStat,
+			list: storageList,
+			delete: storageDelete,
+		}),
+	})),
+}));
+
+vi.mock('../emitter.js', () => ({
+	default: {
+		emitAction: vi.fn(),
+	},
+}));
 
 describe('Integration Tests', () => {
 	let db: MockedFunction<Knex>;
@@ -58,6 +90,256 @@ describe('Integration Tests', () => {
 				});
 
 				expect(superCreateOne).toHaveBeenCalled();
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by before reaching super', async () => {
+				await service.createOne({
+					title: 'Test File',
+					storage: 'local',
+					filename_download: 'test_file',
+					type: 'application/octet-stream',
+					filename_disk: ATTACKER_FILENAME_DISK,
+					uploaded_by: ATTACKER_UPLOADED_BY,
+				} as any);
+
+				expect(superCreateOne).toHaveBeenCalledOnce();
+				const [payload] = superCreateOne.mock.calls[0]!;
+				expect(payload).not.toHaveProperty('filename_disk');
+				expect(payload).not.toHaveProperty('uploaded_by');
+				expect(payload.title).toBe('Test File');
+				expect(payload.type).toBe('application/octet-stream');
+			});
+		});
+
+		describe('createMany', () => {
+			let service: FilesService;
+			let superCreateMany: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superCreateMany = vi.spyOn(ItemsService.prototype, 'createMany').mockReturnValue(Promise.resolve([1, 2]));
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by from every item before reaching super', async () => {
+				await service.createMany([
+					{
+						title: 'File A',
+						type: 'application/octet-stream',
+						filename_disk: ATTACKER_FILENAME_DISK,
+						uploaded_by: ATTACKER_UPLOADED_BY,
+					} as any,
+					{
+						title: 'File B',
+						type: 'application/octet-stream',
+						filename_disk: ATTACKER_FILENAME_DISK,
+						uploaded_by: ATTACKER_UPLOADED_BY,
+					} as any,
+				]);
+
+				expect(superCreateMany).toHaveBeenCalledOnce();
+				const [payloads] = superCreateMany.mock.calls[0]!;
+				expect(payloads).toHaveLength(2);
+
+				for (const payload of payloads) {
+					expect(payload).not.toHaveProperty('filename_disk');
+					expect(payload).not.toHaveProperty('uploaded_by');
+				}
+
+				expect(payloads[0].title).toBe('File A');
+				expect(payloads[1].title).toBe('File B');
+			});
+		});
+
+		describe('updateOne', () => {
+			let service: FilesService;
+			let superUpdateOne: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superUpdateOne = vi.spyOn(ItemsService.prototype, 'updateOne').mockReturnValue(Promise.resolve(1));
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by before reaching super', async () => {
+				await service.updateOne(1, {
+					title: 'Renamed',
+					filename_disk: ATTACKER_FILENAME_DISK,
+					uploaded_by: ATTACKER_UPLOADED_BY,
+				} as any);
+
+				expect(superUpdateOne).toHaveBeenCalledOnce();
+				const [key, payload] = superUpdateOne.mock.calls[0]!;
+				expect(key).toBe(1);
+				expect(payload).not.toHaveProperty('filename_disk');
+				expect(payload).not.toHaveProperty('uploaded_by');
+				expect(payload.title).toBe('Renamed');
+			});
+		});
+
+		describe('updateMany', () => {
+			let service: FilesService;
+			let superUpdateMany: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superUpdateMany = vi.spyOn(ItemsService.prototype, 'updateMany').mockReturnValue(Promise.resolve([1, 2]));
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by before reaching super', async () => {
+				await service.updateMany([1, 2], {
+					title: 'Renamed',
+					filename_disk: ATTACKER_FILENAME_DISK,
+					uploaded_by: ATTACKER_UPLOADED_BY,
+				} as any);
+
+				expect(superUpdateMany).toHaveBeenCalledOnce();
+				const [keys, payload] = superUpdateMany.mock.calls[0]!;
+				expect(keys).toEqual([1, 2]);
+				expect(payload).not.toHaveProperty('filename_disk');
+				expect(payload).not.toHaveProperty('uploaded_by');
+				expect(payload.title).toBe('Renamed');
+			});
+		});
+
+		describe('updateBatch', () => {
+			let service: FilesService;
+			let superUpdateBatch: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superUpdateBatch = vi.spyOn(ItemsService.prototype, 'updateBatch').mockReturnValue(Promise.resolve([1, 2]));
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by from every item before reaching super', async () => {
+				await service.updateBatch([
+					{
+						id: 1,
+						title: 'File A renamed',
+						filename_disk: ATTACKER_FILENAME_DISK,
+						uploaded_by: ATTACKER_UPLOADED_BY,
+					} as any,
+					{
+						id: 2,
+						title: 'File B renamed',
+						filename_disk: ATTACKER_FILENAME_DISK,
+						uploaded_by: ATTACKER_UPLOADED_BY,
+					} as any,
+				]);
+
+				expect(superUpdateBatch).toHaveBeenCalledOnce();
+				const [payloads] = superUpdateBatch.mock.calls[0]!;
+				expect(payloads).toHaveLength(2);
+
+				for (const payload of payloads) {
+					expect(payload).not.toHaveProperty('filename_disk');
+					expect(payload).not.toHaveProperty('uploaded_by');
+				}
+
+				expect(payloads[0].id).toBe(1);
+				expect(payloads[0].title).toBe('File A renamed');
+				expect(payloads[1].id).toBe(2);
+				expect(payloads[1].title).toBe('File B renamed');
+			});
+		});
+
+		describe('uploadOne — regression guard for strip overrides', () => {
+			let service: FilesService;
+			let superUpdateOne: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superUpdateOne = vi.spyOn(ItemsService.prototype, 'updateOne').mockReturnValue(Promise.resolve(1));
+
+				storageWrite.mockClear();
+				storageStat.mockClear();
+				storageList.mockClear();
+				storageDelete.mockClear();
+			});
+
+			it('writes uploaded bytes to the primary-key-derived path, ignoring attacker-supplied filename_disk', async () => {
+				const primaryKey = 'aaaaaaaa-1111-2222-3333-cccccccccccc';
+
+				tracker.on
+					.select(/select "folder", "filename_download" from "directus_files"/)
+					.response({ folder: null, filename_download: 'legit.bin' });
+
+				tracker.on
+					.select(/select "storage_default_folder" from "directus_settings"/)
+					.response({ storage_default_folder: null });
+
+				const stream = Readable.from(['payload-bytes']);
+
+				await service.uploadOne(
+					stream,
+					{
+						storage: 'local',
+						type: 'application/octet-stream',
+						filename_download: 'legit.bin',
+						filename_disk: ATTACKER_FILENAME_DISK,
+						uploaded_by: ATTACKER_UPLOADED_BY,
+					},
+					primaryKey,
+					{ emitEvents: false }
+				);
+
+				expect(storageWrite).toHaveBeenCalledOnce();
+				const diskPath = (storageWrite.mock.calls[0] as unknown[])[0];
+				expect(diskPath).toBe(`${primaryKey}.bin`);
+				expect(diskPath).not.toContain('victim-deadbeef');
+
+				const finalUpdateCall = superUpdateOne.mock.calls.at(-1)!;
+				const finalPayload = finalUpdateCall[1] as Record<string, unknown>;
+				expect(finalPayload['filename_disk']).toBe(`${primaryKey}.bin`);
+			});
+		});
+
+		describe('updateByQuery', () => {
+			let service: FilesService;
+			let superUpdateByQuery: SpyInstance;
+
+			beforeEach(() => {
+				service = new FilesService({
+					knex: db,
+					schema: { collections: {}, relations: [] },
+				});
+
+				superUpdateByQuery = vi.spyOn(ItemsService.prototype, 'updateByQuery').mockReturnValue(Promise.resolve([1]));
+			});
+
+			it('strips user-supplied filename_disk and uploaded_by before reaching super', async () => {
+				const query = { filter: { type: { _eq: 'image/png' } } };
+
+				await service.updateByQuery(query, {
+					title: 'Bulk renamed',
+					filename_disk: ATTACKER_FILENAME_DISK,
+					uploaded_by: ATTACKER_UPLOADED_BY,
+				} as any);
+
+				expect(superUpdateByQuery).toHaveBeenCalledOnce();
+				const [passedQuery, payload] = superUpdateByQuery.mock.calls[0]!;
+				expect(passedQuery).toEqual(query);
+				expect(payload).not.toHaveProperty('filename_disk');
+				expect(payload).not.toHaveProperty('uploaded_by');
+				expect(payload.title).toBe('Bulk renamed');
 			});
 		});
 	});

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -1,3 +1,4 @@
+import type { Query } from '@cairncms/types';
 import formatTitle from '@cairncms/format-title';
 import { toArray } from '@cairncms/utils';
 import encodeURL from 'encodeurl';
@@ -21,6 +22,19 @@ import { getStorage } from '../storage/index.js';
 import type { AbstractServiceOptions, File, Metadata, MutationOptions, PrimaryKey } from '../types/index.js';
 import { parseIptc, parseXmp } from '../utils/parse-image-metadata.js';
 import { ItemsService } from './items.js';
+
+const SERVER_CONTROLLED_FIELDS = ['filename_disk', 'uploaded_by'] as const;
+
+function sanitizeFilePayload<T extends Partial<File>>(payload: T): T {
+	if (!payload || typeof payload !== 'object') return payload;
+	const sanitized = { ...payload } as Record<string, unknown>;
+
+	for (const field of SERVER_CONTROLLED_FIELDS) {
+		delete sanitized[field];
+	}
+
+	return sanitized as T;
+}
 
 export class FilesService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {
@@ -304,12 +318,34 @@ export class FilesService extends ItemsService {
 	 * Useful for associating metadata with existing file in storage
 	 */
 	override async createOne(data: Partial<File>, opts?: MutationOptions): Promise<PrimaryKey> {
-		if (!data.type) {
+		const sanitized = sanitizeFilePayload(data);
+
+		if (!sanitized.type) {
 			throw new InvalidPayloadException(`"type" is required`);
 		}
 
-		const key = await super.createOne(data, opts);
+		const key = await super.createOne(sanitized, opts);
 		return key;
+	}
+
+	override async createMany(data: Partial<File>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		return super.createMany(data.map(sanitizeFilePayload), opts);
+	}
+
+	override async updateOne(key: PrimaryKey, data: Partial<File>, opts?: MutationOptions): Promise<PrimaryKey> {
+		return super.updateOne(key, sanitizeFilePayload(data), opts);
+	}
+
+	override async updateMany(keys: PrimaryKey[], data: Partial<File>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		return super.updateMany(keys, sanitizeFilePayload(data), opts);
+	}
+
+	override async updateBatch(data: Partial<File>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		return super.updateBatch(data.map(sanitizeFilePayload), opts);
+	}
+
+	override async updateByQuery(query: Query, data: Partial<File>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		return super.updateByQuery(query, sanitizeFilePayload(data), opts);
 	}
 
 	/**


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-393c-p46r-7c95 / CVE-2026-39942.

`filename_disk` and `uploaded_by` are server-controlled fields on `directus_files`. Before this change, those fields could still be supplied through the generic FilesService JSON write paths (`create*`, `update*`, `updateByQuery`) and would be forwarded to the underlying item mutation layer if the caller had permission to write files, which allowed file-record pointer redirection and attribution tampering through the API.

This PR enforces those two advisory-named fields at the FilesService boundary. User-supplied `filename_disk` and `uploaded_by` are stripped from incoming file payloads before delegating to the generic item write methods. The multipart upload path remains intact: `uploadOne()` still derives the on-disk filename from the file primary key and writes that corrected value back to the file record.

### Testing / verification

- Added strip-contract tests for all user-facing FilesService write entry points:
  - `createOne`
  - `createMany`
  - `updateOne`
  - `updateMany`
  - `updateBatch`
  - `updateByQuery`
- Added an `uploadOne()` regression guard proving that the strip overrides do not interfere with legitimate uploads and that the final persisted `filename_disk` still uses the primary-key-derived path

Also verified against a live production-mode SQLite instance.

Using an admin account, issued `PATCH /files/{id}` with attacker-supplied values for:
- `filename_disk`
- `uploaded_by`

Confirmed in both the API response and direct SQL inspection that:
- `filename_disk` remained the original server-derived value
- `uploaded_by` remained the original uploader

Also confirmed a normal metadata update (`title`, `description`) still succeeds, so the strip is narrow and does not interfere with legitimate file edits.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
