### PR TITLE
Memoize GraphQL server_health resolver per request (GHSA-6q22-g298-grjh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Added Cross-Origin-Opener-Policy header to /auth routes (GHSA-8m32-p958-jg99 / CVE-2026-35408).
 - Stripped server-controlled fields from file metadata writes (GHSA-393c-p46r-7c95 / CVE-2026-39942).
 - Canonicalized IPv4-mapped IPv6 addresses before deny-list check in file imports (GHSA-wv3h-5fx7-966h / CVE-2026-35409).
+- Memoized GraphQL server_health resolver per request (GHSA-6q22-g298-grjh / CVE-2026-35441).
 
 ### Acknowledgements
 

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -114,11 +114,26 @@ export class GraphQLService {
 	schema: SchemaOverview;
 	scope: 'items' | 'system';
 
+	private serverHealthPromise: Promise<Record<string, any>> | null = null;
+
 	constructor(options: AbstractServiceOptions & { scope: 'items' | 'system' }) {
 		this.accountability = options?.accountability || null;
 		this.knex = options?.knex || getDatabase();
 		this.schema = options.schema;
 		this.scope = options.scope;
+	}
+
+	private resolveServerHealth(): Promise<Record<string, any>> {
+		if (!this.serverHealthPromise) {
+			const service = new ServerService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+
+			this.serverHealthPromise = service.health();
+		}
+
+		return this.serverHealthPromise;
 	}
 
 	/**
@@ -2012,14 +2027,7 @@ export class GraphQLService {
 			},
 			server_health: {
 				type: GraphQLJSON,
-				resolve: async () => {
-					const service = new ServerService({
-						accountability: this.accountability,
-						schema: this.schema,
-					});
-
-					return await service.health();
-				},
+				resolve: () => this.resolveServerHealth(),
 			},
 		});
 

--- a/api/src/services/graphql/server-health-memoize.test.ts
+++ b/api/src/services/graphql/server-health-memoize.test.ts
@@ -1,0 +1,56 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ServerService } from '../server.js';
+import { GraphQLService } from './index.js';
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabase: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const accountability: Accountability = {
+	user: null,
+	role: null,
+	admin: false,
+	app: false,
+	ip: '127.0.0.1',
+};
+
+const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+describe('GraphQLService — server_health memoization', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('runs ServerService.health() exactly once across concurrent parallel invocations', async () => {
+		const healthSpy = vi.spyOn(ServerService.prototype, 'health').mockResolvedValue({ status: 'ok' });
+		const service = new GraphQLService({ accountability, schema, scope: 'system' });
+
+		const results = await Promise.all([
+			(service as any).resolveServerHealth(),
+			(service as any).resolveServerHealth(),
+			(service as any).resolveServerHealth(),
+			(service as any).resolveServerHealth(),
+			(service as any).resolveServerHealth(),
+		]);
+
+		expect(healthSpy).toHaveBeenCalledOnce();
+		expect(results).toHaveLength(5);
+
+		for (const result of results) {
+			expect(result).toEqual({ status: 'ok' });
+		}
+	});
+
+	it('runs ServerService.health() exactly once on a single invocation (regression)', async () => {
+		const healthSpy = vi.spyOn(ServerService.prototype, 'health').mockResolvedValue({ status: 'ok' });
+		const service = new GraphQLService({ accountability, schema, scope: 'system' });
+
+		const result = await (service as any).resolveServerHealth();
+
+		expect(healthSpy).toHaveBeenCalledOnce();
+		expect(result).toEqual({ status: 'ok' });
+	});
+});


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-6q22-g298-grjh.

The system GraphQL schema exposes `server_health`, which runs a full backend health check including database, cache, storage, rate limiter, and email probes. Before this change, GraphQL aliases caused each `server_health` field to resolve independently. A single unauthenticated `/graphql/system` request could therefore multiply backend work by repeating the same field under many aliases.

This PR adds per-request memoization for `server_health`. Within a single `GraphQLService` instance, the first resolver call creates the `ServerService.health()` promise and subsequent alias invocations return that same promise instead of triggering duplicate work.

The fix closes the unauthenticated amplification path without changing broader GraphQL resolver behavior.

### Testing / verification

- Added `server-health-memoize.test.ts`
- Covered the concurrent contract directly at the method seam:
  - five parallel `resolveServerHealth()` calls invoke `ServerService.health()` exactly once
  - a single invocation still calls `ServerService.health()` exactly once and returns the expected result

Also verified against a live production-mode instance through `/graphql/system`.

- Unauthenticated aliased query `{ a:server_health b:server_health c:server_health d:server_health e:server_health }` returned HTTP 200
- All alias fields were present
- All alias values were identical
- Single-query baseline `{ server_health }` also returned HTTP 200 with the expected `{"status":"ok"}` payload

This manual probe was used as a wiring check only.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
