### PR TITLE
Mask concealed fields in aggregate query results (GHSA-38hg-ww64-rrwc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Stripped server-controlled fields from file metadata writes (GHSA-393c-p46r-7c95 / CVE-2026-39942).
 - Canonicalized IPv4-mapped IPv6 addresses before deny-list check in file imports (GHSA-wv3h-5fx7-966h / CVE-2026-35409).
 - Memoized GraphQL server_health resolver per request (GHSA-6q22-g298-grjh / CVE-2026-35441).
+- Masked concealed fields in aggregate query results (GHSA-38hg-ww64-rrwc / CVE-2026-35442).
 
 ### Acknowledgements
 

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -254,6 +254,134 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+
+		describe('processValues — conceal masking on aggregate keys', () => {
+			function makeService() {
+				const field = (name: string, special: string[] = []) =>
+					({
+						field: name,
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						type: 'string' as const,
+						dbType: 'varchar',
+						precision: null,
+						scale: null,
+						special,
+						note: null,
+						validation: null,
+						alias: false,
+					} as any);
+
+				return new PayloadService('test', {
+					knex: db,
+					schema: {
+						collections: {
+							test: {
+								collection: 'test',
+								primary: 'id',
+								singleton: false,
+								sortField: null,
+								note: null,
+								accountability: null,
+								fields: {
+									id: field('id'),
+									status: field('status'),
+									tfa_secret: field('tfa_secret', ['conceal']),
+									token: field('token', ['conceal']),
+									password: field('password', ['conceal']),
+								},
+							},
+						},
+						relations: [],
+					},
+				});
+			}
+
+			it.each([
+				['min', 'tfa_secret', 'raw-secret'],
+				['max', 'tfa_secret', 'raw-secret'],
+				['min', 'token', 'raw-token'],
+				['max', 'password', 'raw-password'],
+				['sum', 'tfa_secret', 'raw-secret'],
+				['sumDistinct', 'tfa_secret', 'raw-secret'],
+				['avg', 'tfa_secret', 'raw-secret'],
+				['avgDistinct', 'tfa_secret', 'raw-secret'],
+			])('masks value-deriving aggregate %s on %s', async (op, fieldName, raw) => {
+				const service = makeService();
+				const flatKey = `${op}->${fieldName}`;
+
+				const result = (await service.processValues('read', [{ [flatKey]: raw }])) as any[];
+
+				expect(result[0][op][fieldName]).toBe('**********');
+			});
+
+			it.each([
+				['count', 'tfa_secret', 5],
+				['countDistinct', 'tfa_secret', 3],
+				['countAll', 'tfa_secret', 7],
+			])('does not mask count-style aggregate %s on %s', async (op, fieldName, count) => {
+				const service = makeService();
+				const flatKey = `${op}->${fieldName}`;
+
+				const result = (await service.processValues('read', [{ [flatKey]: count }])) as any[];
+
+				expect(result[0][op][fieldName]).toBe(count);
+			});
+
+			it.each([
+				['min', 'status', 'active'],
+				['max', 'id', 42],
+			])('does not mask aggregate %s on non-concealed field %s', async (op, fieldName, value) => {
+				const service = makeService();
+				const flatKey = `${op}->${fieldName}`;
+
+				const result = (await service.processValues('read', [{ [flatKey]: value }])) as any[];
+
+				expect(result[0][op][fieldName]).toBe(value);
+			});
+
+			it('masks a numeric zero result on a concealed aggregate without corrupting it to null', async () => {
+				const service = makeService();
+
+				const result = (await service.processValues('read', [{ 'sum->tfa_secret': 0 }])) as any[];
+
+				expect(result[0].sum.tfa_secret).toBe('**********');
+			});
+
+			it('passes null aggregate values through unchanged', async () => {
+				const service = makeService();
+
+				const result = (await service.processValues('read', [{ 'min->tfa_secret': null }])) as any[];
+
+				expect(result[0].min.tfa_secret).toBeNull();
+			});
+
+			it('still masks plain non-aggregate reads of concealed fields (regression)', async () => {
+				const service = makeService();
+
+				const result = (await service.processValues('read', [{ tfa_secret: 'raw-secret' }])) as any[];
+
+				expect(result[0].tfa_secret).toBe('**********');
+			});
+
+			it('masks concealed aggregates in every row of a grouped result', async () => {
+				const service = makeService();
+
+				const result = (await service.processValues('read', [
+					{ 'min->tfa_secret': 'secret-A', 'max->tfa_secret': 'secret-Z', id: 1 },
+					{ 'min->tfa_secret': 'secret-B', 'max->tfa_secret': 'secret-Y', id: 2 },
+				])) as any[];
+
+				for (const row of result) {
+					expect(row.min.tfa_secret).toBe('**********');
+					expect(row.max.tfa_secret).toBe('**********');
+				}
+
+				expect(result[0].id).toBe(1);
+				expect(result[1].id).toBe(2);
+			});
+		});
 	});
 });
 

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -195,6 +195,7 @@ export class PayloadService {
 		}
 
 		if (action === 'read') {
+			this.maskConcealedAggregates(processedPayload);
 			this.processAggregates(processedPayload);
 		}
 
@@ -203,6 +204,40 @@ export class PayloadService {
 		}
 
 		return processedPayload[0]!;
+	}
+
+	private static readonly VALUE_DERIVING_AGGREGATES = new Set([
+		'min',
+		'max',
+		'sum',
+		'sumDistinct',
+		'avg',
+		'avgDistinct',
+	]);
+
+	private maskConcealedAggregates(payload: Partial<Item>[]): void {
+		if (payload.length === 0) return;
+
+		const concealedFields = new Set(
+			Object.entries(this.schema.collections[this.collection]?.fields ?? {})
+				.filter(([_name, field]) => field.special?.includes('conceal'))
+				.map(([name]) => name)
+		);
+
+		if (concealedFields.size === 0) return;
+
+		for (const item of payload) {
+			for (const key of Object.keys(item)) {
+				if (!key.includes('->')) continue;
+
+				const [operation, operandField] = key.split('->');
+				if (!operation || !operandField) continue;
+				if (!PayloadService.VALUE_DERIVING_AGGREGATES.has(operation)) continue;
+				if (!concealedFields.has(operandField)) continue;
+
+				item[key] = item[key] == null ? null : '**********';
+			}
+		}
 	}
 
 	processAggregates(payload: Partial<Item>[]) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-38hg-ww64-rrwc / CVE-2026-35442.

Fields marked with `special: [conceal]` are masked on normal reads, but aggregate query results were not going through the same protection when the database returned aggregate aliases such as `min->tfa_secret` or `max->token`. This allowed raw concealed values to be exposed through aggregate responses.

This PR closes that leak in `PayloadService` by masking concealed aggregate operands before aggregate keys are expanded into the nested response shape. The fix is field-agnostic and applies to any collection field marked with `special: [conceal]`.

The masking scope is intentionally slightly broader than the most obvious `min` / `max` leak examples. It covers all value-deriving aggregate operations (`min`, `max`, `sum`, `sumDistinct`, `avg`, `avgDistinct`) while leaving count-style operations unchanged. That keeps the protection in line with the bug shape where concealed aggregate operands should not return raw values, regardless of which value-deriving aggregate operator produced them.

### Testing / verification

- Added 17 test cases in `payload.test.ts`, covering:
  - concealed-field aggregates across all value-deriving operations
  - count-style aggregate pass-through
  - non-concealed aggregate pass-through
  - boundary cases for `0` and `null`
  - plain non-aggregate conceal regression
  - grouped aggregate masking across multiple rows

Also verified against a live production-mode instance and confirmed:
- plain `/users/me` reads still mask concealed fields
- REST aggregate queries on concealed fields return masked values
- REST aggregate queries on non-concealed fields still return raw values
- REST and GraphQL count-style aggregates still return integer counts

Also confirmed that GraphQL does not expose `min` / `max` for the string concealed fields in `directus_users` on this branch, so the practical exfiltration path for the named secret fields is primarily REST. The payload-layer fix still protects both endpoints transparently.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
