### PR TITLE
Remove version from unauthenticated admin bundle (GHSA-5mhg-wv8w-p59j)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Canonicalized IPv4-mapped IPv6 addresses before deny-list check in file imports (GHSA-wv3h-5fx7-966h / CVE-2026-35409).
 - Memoized GraphQL server_health resolver per request (GHSA-6q22-g298-grjh / CVE-2026-35441).
 - Masked concealed fields in aggregate query results (GHSA-38hg-ww64-rrwc / CVE-2026-35442).
+- Removed CairnCMS version string from unauthenticated admin bundle (GHSA-5mhg-wv8w-p59j / CVE-2024-27296).
 
 ### Acknowledgements
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -16,8 +16,6 @@ import { loadExtensions, registerExtensions } from './extensions';
 init();
 
 async function init() {
-	const version = __CAIRNCMS_VERSION__;
-
 	console.log(CAIRNCMS_LOGO);
 
 	console.info(`%c🪨 CairnCMS | https://cairncms.dev`, 'color:Green');
@@ -50,11 +48,6 @@ async function init() {
 	console.timeEnd('🕓 Application Loaded');
 
 	console.group(`%c✨ Project Information`, 'color:DodgerBlue'); // groupCollapsed
-
-	if (import.meta.env.DEV) {
-		console.info(`%cVersion: v${version}`, 'color:DodgerBlue');
-	}
-
 	console.info(`%cEnvironment: ${import.meta.env.MODE}`, 'color:DodgerBlue');
 	console.groupEnd();
 

--- a/app/src/modules/settings/components/navigation.test.ts
+++ b/app/src/modules/settings/components/navigation.test.ts
@@ -1,0 +1,63 @@
+import { i18n } from '@/lang';
+import { useServerStore } from '@/stores/server';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Navigation from './navigation.vue';
+
+const stubs = {
+	'v-list': { template: '<div><slot /></div>' },
+	'v-list-item': {
+		props: ['href', 'to'],
+		template: '<a :href="href" :data-to="to" class="v-list-item-stub"><slot /></a>',
+	},
+	'v-list-item-icon': { template: '<span><slot /></span>' },
+	'v-list-item-content': { template: '<span><slot /></span>' },
+	'v-icon': { props: ['name'], template: '<i :data-name="name"></i>' },
+	'v-text-overflow': { props: ['text'], template: '<span class="text">{{ text }}</span>' },
+	'v-divider': { template: '<hr />' },
+};
+
+function mountNavigation() {
+	return mount(Navigation, {
+		global: {
+			plugins: [i18n],
+			stubs,
+		},
+	});
+}
+
+describe('Settings Navigation — version display', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: true,
+			})
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('renders the version row with the value from the server store when present', () => {
+		const serverStore = useServerStore();
+		serverStore.info.cairncms = { version: '9.9.9-test' };
+
+		const wrapper = mountNavigation();
+
+		expect(wrapper.html()).toContain('CairnCMS 9.9.9-test');
+	});
+
+	it('hides the version row when the server store has no version', () => {
+		const serverStore = useServerStore();
+		serverStore.info.cairncms = undefined;
+
+		const wrapper = mountNavigation();
+
+		expect(wrapper.html()).not.toContain('CairnCMS ');
+		expect(wrapper.html()).not.toContain('github.com/CairnCMS/cairncms/releases');
+	});
+});

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -16,7 +16,7 @@
 			</v-list-item-content>
 		</v-list-item>
 
-		<v-list-item href="https://github.com/CairnCMS/cairncms/releases" class="version">
+		<v-list-item v-if="version" href="https://github.com/CairnCMS/cairncms/releases" class="version">
 			<v-list-item-icon><v-icon small name="cairncms" /></v-list-item-icon>
 			<v-list-item-content>
 				<v-text-overflow class="version" :text="`CairnCMS ${version}`" />
@@ -26,12 +26,14 @@
 </template>
 
 <script lang="ts">
+import { useServerStore } from '@/stores/server';
 import { computed, defineComponent } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
 	setup() {
-		const version = __CAIRNCMS_VERSION__;
+		const serverStore = useServerStore();
+		const version = computed(() => serverStore.info.cairncms?.version);
 
 		const { t } = useI18n();
 

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-declare const __CAIRNCMS_VERSION__: string;

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -17,15 +17,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { searchForWorkspaceRoot } from 'vite';
 import { defineConfig } from 'vitest/config';
-import { version } from '../cairncms/package.json';
 
 const API_PATH = path.join('..', 'api');
 const EXTENSIONS_PATH = path.join(API_PATH, 'extensions');
 
 export default defineConfig({
-	define: {
-		__CAIRNCMS_VERSION__: JSON.stringify(version),
-	},
 	plugins: [
 		cairncmsExtensions(),
 		vue(),


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-5mhg-wv8w-p59j / CVE-2024-27296.

The admin app bundle was embedding the CairnCMS version string at build time. Because the admin static assets are publicly fetchable before authentication, an unauthenticated actor could retrieve the compiled JavaScript and identify the deployed release version.

This PR removes the build-time version injection from the public admin bundle. The settings navigation now reads the version from the existing `/server/info` runtime response instead, which is already gated to admin accountability on the API side.

That keeps the version visible to authenticated admins in the settings sidebar without shipping it in unauthenticated static assets.

### Testing / verification

- Added `navigation.test.ts`
- Covered both UI branches:
  - renders `CairnCMS <version>` when the server store has an admin-visible version
  - hides the version row when the server store has no version

Also verified against a live production-mode instance.

Confirmed:
- a fresh admin app build no longer contains the literal CairnCMS version string
- unauthenticated `/admin` HTML does not contain the version string
- unauthenticated fetched admin JS chunks do not contain the version string
- unauthenticated `/server/info` does not expose `cairncms.version`
- admin-authenticated `/server/info` still exposes `cairncms.version`
- the settings sidebar still shows the version for an authenticated admin

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
