### PR TITLE
Validate post-SSO redirect target in OAuth2/OpenID drivers (GHSA-fr3w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Memoized GraphQL server_health resolver per request (GHSA-6q22-g298-grjh / CVE-2026-35441).
 - Masked concealed fields in aggregate query results (GHSA-38hg-ww64-rrwc / CVE-2026-35442).
 - Removed CairnCMS version string from unauthenticated admin bundle (GHSA-5mhg-wv8w-p59j / CVE-2024-27296).
+- Validated post-SSO redirect target in OAuth2 and OpenID login flows (GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
 
 ### Acknowledgements
 

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -28,6 +28,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
+import { isSafeRedirect } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
@@ -363,7 +364,12 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 						logger.warn(error, `[OAuth2] Unexpected error during OAuth2 login`);
 					}
 
-					return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					if (isSafeRedirect(redirect)) {
+						return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					}
+
+					logger.warn({ redirect }, '[OAuth2] Rejecting unsafe redirect on error path');
+					return res.redirect(`./?reason=${reason}`);
 				}
 
 				logger.warn(error, `[OAuth2] Unexpected error during OAuth2 login`);
@@ -372,7 +378,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 
 			const { accessToken, refreshToken, expires } = authResponse;
 
-			if (redirect) {
+			if (redirect && isSafeRedirect(redirect)) {
 				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
 					httpOnly: true,
 					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
@@ -382,6 +388,10 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 				});
 
 				return res.redirect(redirect);
+			}
+
+			if (redirect) {
+				logger.warn({ redirect }, '[OAuth2] Rejecting unsafe redirect after successful login');
 			}
 
 			res.locals['payload'] = {

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -28,6 +28,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
+import { isSafeRedirect } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
@@ -395,7 +396,12 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 						logger.warn(error, `[OpenID] Unexpected error during OpenID login`);
 					}
 
-					return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					if (isSafeRedirect(redirect)) {
+						return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					}
+
+					logger.warn({ redirect }, '[OpenID] Rejecting unsafe redirect on error path');
+					return res.redirect(`./?reason=${reason}`);
 				}
 
 				logger.warn(error, `[OpenID] Unexpected error during OpenID login`);
@@ -404,7 +410,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 
 			const { accessToken, refreshToken, expires } = authResponse;
 
-			if (redirect) {
+			if (redirect && isSafeRedirect(redirect)) {
 				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
 					httpOnly: true,
 					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
@@ -414,6 +420,10 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 				});
 
 				return res.redirect(redirect);
+			}
+
+			if (redirect) {
+				logger.warn({ redirect }, '[OpenID] Rejecting unsafe redirect after successful login');
 			}
 
 			res.locals['payload'] = {

--- a/api/src/utils/validate-redirect.test.ts
+++ b/api/src/utils/validate-redirect.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { isSafeRedirect } from './validate-redirect.js';
+
+const factoryEnv: { [k: string]: any } = {};
+
+vi.mock('../env.js', () => ({
+	default: new Proxy(
+		{},
+		{
+			get(_target, prop) {
+				return factoryEnv[prop as string];
+			},
+		}
+	),
+}));
+
+beforeEach(() => {
+	factoryEnv['PUBLIC_URL'] = 'https://cairncms.example';
+});
+
+describe('isSafeRedirect — same-origin absolute URLs', () => {
+	test.each([
+		['plain path', 'https://cairncms.example/admin/content'],
+		['with query and fragment', 'https://cairncms.example/path?with=query#frag'],
+		['uppercase host (URL parser normalizes)', 'https://CAIRNCMS.example/path'],
+	])('allows %s', (_label, redirect) => {
+		expect(isSafeRedirect(redirect)).toBe(true);
+	});
+});
+
+describe('isSafeRedirect — same-origin relative references', () => {
+	test.each([
+		['root-relative path', '/admin/content'],
+		['root', '/'],
+		['bare relative path', 'admin/content'],
+		['parent-traversal relative path', '../admin/content'],
+	])('allows %s', (_label, redirect) => {
+		expect(isSafeRedirect(redirect)).toBe(true);
+	});
+});
+
+describe('isSafeRedirect — cross-origin URLs', () => {
+	test.each([
+		['different host', 'https://evil.example/path'],
+		['scheme mismatch (http vs https)', 'http://cairncms.example/path'],
+		['host-suffix attack', 'https://cairncms.example.evil.com/path'],
+		['port mismatch', 'https://cairncms.example:8080/path'],
+	])('rejects %s', (_label, redirect) => {
+		expect(isSafeRedirect(redirect)).toBe(false);
+	});
+});
+
+describe('isSafeRedirect — protocol-relative URLs', () => {
+	test('rejects //evil.example/path', () => {
+		expect(isSafeRedirect('//evil.example/path')).toBe(false);
+	});
+});
+
+describe('isSafeRedirect — non-http(s) schemes', () => {
+	test.each([
+		['javascript', 'javascript:alert(1)'],
+		['data', 'data:text/html,<script>alert(1)</script>'],
+		['file', 'file:///etc/passwd'],
+	])('rejects %s URL', (_label, redirect) => {
+		expect(isSafeRedirect(redirect)).toBe(false);
+	});
+});
+
+describe('isSafeRedirect — malformed and boundary inputs', () => {
+	test('rejects empty string', () => {
+		expect(isSafeRedirect('')).toBe(false);
+	});
+
+	test('rejects undefined', () => {
+		expect(isSafeRedirect(undefined)).toBe(false);
+	});
+
+	test('rejects null', () => {
+		expect(isSafeRedirect(null)).toBe(false);
+	});
+
+	test('rejects non-string numeric', () => {
+		expect(isSafeRedirect(42)).toBe(false);
+	});
+
+	test('rejects non-string object', () => {
+		expect(isSafeRedirect({ url: 'https://cairncms.example' })).toBe(false);
+	});
+});

--- a/api/src/utils/validate-redirect.ts
+++ b/api/src/utils/validate-redirect.ts
@@ -1,0 +1,15 @@
+import env from '../env.js';
+
+export function isSafeRedirect(redirect: unknown): boolean {
+	if (typeof redirect !== 'string' || redirect.length === 0) {
+		return false;
+	}
+
+	try {
+		const base = new URL(env['PUBLIC_URL'] as string);
+		const target = new URL(redirect, base);
+		return target.origin === base.origin;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-fr3w-2p22-6w7p / CVE-2024-28239.

The OAuth2 and OpenID login flows accepted a user-controlled `redirect` parameter and later redirected to it without validating the target origin. That allowed a successful SSO login to bounce a user from a legitimate CairnCMS instance to an attacker-controlled site.

This PR adds shared redirect validation for those drivers. Post-login redirects are now allowed only when they resolve to the same origin as `PUBLIC_URL`, including same-origin relative paths. Unsafe redirects are rejected.

The fix preserves existing user-facing flow semantics:
- on the success path, an unsafe redirect falls back to the normal JSON token response
- on the error path, an unsafe redirect falls back to the local login page with the existing `reason=...` pattern

### Testing / verification

- Added `validate-redirect.test.ts`
- Covered 20 helper test cases across:
  - same-origin absolute URLs
  - same-origin relative references
  - cross-origin URLs
  - protocol-relative URLs
  - non-http(s) schemes
  - malformed and non-string inputs

Also verified against the built API helper directly and confirmed:
- same-origin absolute URLs are allowed
- same-origin relative paths are allowed
- cross-origin, protocol-relative, `javascript:`, host-suffix, and port-mismatch redirects are rejected

This PR is intentionally limited to OAuth2 and OpenID. The SAML `RelayState` redirect path is being kept for the separate SAML advisory so the fixes remain advisory-scoped and traceable.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
