### PR TITLE
Validate post-SSO redirect target in SAML driver (GHSA-3573-4c68-g8cc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Masked concealed fields in aggregate query results (GHSA-38hg-ww64-rrwc / CVE-2026-35442).
 - Removed CairnCMS version string from unauthenticated admin bundle (GHSA-5mhg-wv8w-p59j / CVE-2024-27296).
 - Validated post-SSO redirect target in OAuth2 and OpenID login flows (GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
+- Validated post-SSO redirect target in SAML login flow (GHSA-3573-4c68-g8cc / CVE-2026-22032).
 
 ### Acknowledgements
 

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -16,6 +16,7 @@ import { UsersService } from '../../services/users.js';
 import type { AuthDriverOptions, User } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
+import { isSafeRedirect } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 // Register the samlify schema validator
@@ -169,9 +170,13 @@ export function createSAMLAuthRouter(providerName: string) {
 					},
 				};
 
-				if (relayState) {
+				if (relayState && isSafeRedirect(relayState)) {
 					res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
 					return res.redirect(relayState);
+				}
+
+				if (relayState) {
+					logger.warn({ relayState }, '[SAML] Rejecting unsafe RelayState after successful login');
 				}
 
 				return next();
@@ -185,7 +190,12 @@ export function createSAMLAuthRouter(providerName: string) {
 						logger.warn(error, `[SAML] Unexpected error during SAML login`);
 					}
 
-					return res.redirect(`${relayState.split('?')[0]}?reason=${reason}`);
+					if (isSafeRedirect(relayState)) {
+						return res.redirect(`${relayState.split('?')[0]}?reason=${reason}`);
+					}
+
+					logger.warn({ relayState }, '[SAML] Rejecting unsafe RelayState on error path');
+					return res.redirect(`./?reason=${reason}`);
 				}
 
 				logger.warn(error, `[SAML] Unexpected error during SAML login`);

--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -302,6 +302,7 @@ const isWindows = ['win32', 'win64'].includes(process.platform);
 
 for (const vendor of allVendors) {
 	config.envs[vendor]!.TZ = isWindows ? '0' : 'UTC';
+	config.envs[vendor]!.PUBLIC_URL = `http://127.0.0.1:${config.envs[vendor]!.PORT}`;
 }
 
 export function getUrl(vendor: (typeof allVendors)[number], overrideEnv?: Env) {

--- a/tests/blackbox/routes/auth/saml.test.ts
+++ b/tests/blackbox/routes/auth/saml.test.ts
@@ -119,7 +119,7 @@ describe('/auth/login/saml', () => {
 				it.each(vendors)('%s', async (vendor) => {
 					// Action
 					const samlLogin = await request(getUrl(vendor))
-						.get(`/auth/login/saml?redirect=${getUrl(vendor)}/admin/login?continue`)
+						.get(`/auth/login/saml?redirect=${encodeURIComponent('/admin/login?continue')}`)
 						.expect(302);
 
 					const samlRedirectUrl = String(samlLogin.headers.location).split('/simplesaml/');


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-3573-4c68-g8cc / CVE-2026-22032.

The SAML ACS callback accepted `RelayState` from the request body and used it directly in `res.redirect()` on both the success and error paths. That allowed an attacker to supply an external redirect target, send a victim through a legitimate SAML login flow, and have CairnCMS redirect the browser to an attacker-controlled site after authentication.

This PR validates `RelayState` at the SAML callback boundary before using it as a redirect target.

Allowed redirect targets are:
- same-origin absolute URLs under the configured `PUBLIC_URL`
- relative URLs that resolve to the same origin

When `RelayState` is unsafe:
- the success path falls back to the existing JSON token response instead of redirecting
- the error path falls back to a safe local `./?reason=...` redirect

This extends the redirect-validation policy introduced in PR #25 for OAuth2 and OpenID to the SAML ACS callback.

### Testing / verification

- Reused the existing `validate-redirect` helper coverage (20 test cases introduced in #25)

Verified the fix in two ways:
- Re-ran the `isSafeRedirect` helper probe against the same same-origin, cross-origin, protocol-relative, and non-HTTP(S) cases used for the OAuth2/OpenID redirect fix
- Reviewed the SAML ACS callback diff to confirm both redirect call sites now follow the same gating pattern as the OAuth2 and OpenID drivers


## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
