### PR TITLE
Canonicalize SSO callback redirects to local paths (GHSA-3573-4c68-g8…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Removed CairnCMS version string from unauthenticated admin bundle (GHSA-5mhg-wv8w-p59j / CVE-2024-27296).
 - Validated post-SSO redirect target in OAuth2 and OpenID login flows (GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
 - Validated post-SSO redirect target in SAML login flow (GHSA-3573-4c68-g8cc / CVE-2026-22032).
+- Canonicalized post-SSO redirect targets to local paths across SSO login flows (GHSA-3573-4c68-g8cc / CVE-2026-22032, GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
 
 ### Acknowledgements
 

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -28,7 +28,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
-import { isSafeRedirect } from '../../utils/validate-redirect.js';
+import { getSafeRedirect, getSafeRedirectWithReason } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 export class OAuth2AuthDriver extends LocalAuthDriver {
@@ -364,8 +364,10 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 						logger.warn(error, `[OAuth2] Unexpected error during OAuth2 login`);
 					}
 
-					if (isSafeRedirect(redirect)) {
-						return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					const safeErrorRedirect = getSafeRedirectWithReason(redirect, reason);
+
+					if (safeErrorRedirect) {
+						return res.redirect(safeErrorRedirect);
 					}
 
 					logger.warn({ redirect }, '[OAuth2] Rejecting unsafe redirect on error path');
@@ -378,7 +380,9 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 
 			const { accessToken, refreshToken, expires } = authResponse;
 
-			if (redirect && isSafeRedirect(redirect)) {
+			const safeRedirect = redirect ? getSafeRedirect(redirect) : null;
+
+			if (safeRedirect) {
 				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
 					httpOnly: true,
 					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
@@ -387,7 +391,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 					sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 				});
 
-				return res.redirect(redirect);
+				return res.redirect(safeRedirect);
 			}
 
 			if (redirect) {

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -28,7 +28,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
-import { isSafeRedirect } from '../../utils/validate-redirect.js';
+import { getSafeRedirect, getSafeRedirectWithReason } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 export class OpenIDAuthDriver extends LocalAuthDriver {
@@ -396,8 +396,10 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 						logger.warn(error, `[OpenID] Unexpected error during OpenID login`);
 					}
 
-					if (isSafeRedirect(redirect)) {
-						return res.redirect(`${redirect.split('?')[0]}?reason=${reason}`);
+					const safeErrorRedirect = getSafeRedirectWithReason(redirect, reason);
+
+					if (safeErrorRedirect) {
+						return res.redirect(safeErrorRedirect);
 					}
 
 					logger.warn({ redirect }, '[OpenID] Rejecting unsafe redirect on error path');
@@ -410,7 +412,9 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 
 			const { accessToken, refreshToken, expires } = authResponse;
 
-			if (redirect && isSafeRedirect(redirect)) {
+			const safeRedirect = redirect ? getSafeRedirect(redirect) : null;
+
+			if (safeRedirect) {
 				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
 					httpOnly: true,
 					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
@@ -419,7 +423,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 					sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 				});
 
-				return res.redirect(redirect);
+				return res.redirect(safeRedirect);
 			}
 
 			if (redirect) {

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -16,7 +16,7 @@ import { UsersService } from '../../services/users.js';
 import type { AuthDriverOptions, User } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
-import { isSafeRedirect } from '../../utils/validate-redirect.js';
+import { getSafeRedirect, getSafeRedirectWithReason } from '../../utils/validate-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
 // Register the samlify schema validator
@@ -170,9 +170,11 @@ export function createSAMLAuthRouter(providerName: string) {
 					},
 				};
 
-				if (relayState && isSafeRedirect(relayState)) {
+				const safeRelay = relayState ? getSafeRedirect(relayState) : null;
+
+				if (safeRelay) {
 					res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
-					return res.redirect(relayState);
+					return res.redirect(safeRelay);
 				}
 
 				if (relayState) {
@@ -190,8 +192,10 @@ export function createSAMLAuthRouter(providerName: string) {
 						logger.warn(error, `[SAML] Unexpected error during SAML login`);
 					}
 
-					if (isSafeRedirect(relayState)) {
-						return res.redirect(`${relayState.split('?')[0]}?reason=${reason}`);
+					const safeErrorRedirect = getSafeRedirectWithReason(relayState, reason);
+
+					if (safeErrorRedirect) {
+						return res.redirect(safeErrorRedirect);
 					}
 
 					logger.warn({ relayState }, '[SAML] Rejecting unsafe RelayState on error path');

--- a/api/src/utils/validate-redirect.test.ts
+++ b/api/src/utils/validate-redirect.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { isSafeRedirect } from './validate-redirect.js';
+import { getSafeRedirect, getSafeRedirectWithReason, isSafeRedirect } from './validate-redirect.js';
 
 const factoryEnv: { [k: string]: any } = {};
 
@@ -85,5 +85,91 @@ describe('isSafeRedirect — malformed and boundary inputs', () => {
 
 	test('rejects non-string object', () => {
 		expect(isSafeRedirect({ url: 'https://cairncms.example' })).toBe(false);
+	});
+});
+
+describe('getSafeRedirect — canonicalizes safe inputs to path-local form', () => {
+	test('safe absolute URL returns path-only, dropping origin', () => {
+		expect(getSafeRedirect('https://cairncms.example/admin/content')).toBe('/admin/content');
+	});
+
+	test('safe absolute URL with query and hash preserves them', () => {
+		expect(getSafeRedirect('https://cairncms.example/admin?foo=1#section')).toBe('/admin?foo=1#section');
+	});
+
+	test('safe relative path passes through as-is', () => {
+		expect(getSafeRedirect('/admin/content')).toBe('/admin/content');
+	});
+
+	test('safe bare-relative path resolves to root-relative form', () => {
+		expect(getSafeRedirect('admin/content')).toBe('/admin/content');
+	});
+
+	test('safe parent-traversal path resolves under origin', () => {
+		expect(getSafeRedirect('../admin')).toBe('/admin');
+	});
+
+	test('cross-origin absolute URL returns null', () => {
+		expect(getSafeRedirect('https://evil.example/path')).toBeNull();
+	});
+
+	test('protocol-relative URL returns null', () => {
+		expect(getSafeRedirect('//evil.example/path')).toBeNull();
+	});
+
+	test('javascript: URL returns null', () => {
+		expect(getSafeRedirect('javascript:alert(1)')).toBeNull();
+	});
+
+	test('empty string returns null', () => {
+		expect(getSafeRedirect('')).toBeNull();
+	});
+
+	test('undefined returns null', () => {
+		expect(getSafeRedirect(undefined)).toBeNull();
+	});
+});
+
+describe('getSafeRedirectWithReason — drops query/hash and sets reason', () => {
+	test('safe absolute URL with no query returns path with reason', () => {
+		expect(getSafeRedirectWithReason('https://cairncms.example/admin', 'TOKEN_EXPIRED')).toBe(
+			'/admin?reason=TOKEN_EXPIRED'
+		);
+	});
+
+	test('safe absolute URL with existing query has the query dropped', () => {
+		expect(getSafeRedirectWithReason('https://cairncms.example/admin?foo=1&bar=2', 'TOKEN_EXPIRED')).toBe(
+			'/admin?reason=TOKEN_EXPIRED'
+		);
+	});
+
+	test('safe absolute URL with hash has the hash dropped', () => {
+		expect(getSafeRedirectWithReason('https://cairncms.example/admin#section', 'TOKEN_EXPIRED')).toBe(
+			'/admin?reason=TOKEN_EXPIRED'
+		);
+	});
+
+	test('safe relative path returns path with reason', () => {
+		expect(getSafeRedirectWithReason('/admin', 'TOKEN_EXPIRED')).toBe('/admin?reason=TOKEN_EXPIRED');
+	});
+
+	test('reason value with special characters is URL-encoded', () => {
+		expect(getSafeRedirectWithReason('/admin', 'A B&C')).toBe('/admin?reason=A+B%26C');
+	});
+
+	test('cross-origin absolute URL returns null', () => {
+		expect(getSafeRedirectWithReason('https://evil.example/path', 'TOKEN_EXPIRED')).toBeNull();
+	});
+
+	test('protocol-relative URL returns null', () => {
+		expect(getSafeRedirectWithReason('//evil.example', 'TOKEN_EXPIRED')).toBeNull();
+	});
+
+	test('empty string returns null', () => {
+		expect(getSafeRedirectWithReason('', 'TOKEN_EXPIRED')).toBeNull();
+	});
+
+	test('undefined returns null', () => {
+		expect(getSafeRedirectWithReason(undefined, 'TOKEN_EXPIRED')).toBeNull();
 	});
 });

--- a/api/src/utils/validate-redirect.ts
+++ b/api/src/utils/validate-redirect.ts
@@ -13,3 +13,25 @@ export function isSafeRedirect(redirect: unknown): boolean {
 		return false;
 	}
 }
+
+export function getSafeRedirect(redirect: unknown): string | null {
+	if (!isSafeRedirect(redirect)) return null;
+
+	const base = new URL(env['PUBLIC_URL'] as string);
+	const target = new URL(String(redirect), base);
+
+	return `${target.pathname}${target.search}${target.hash}`;
+}
+
+export function getSafeRedirectWithReason(redirect: unknown, reason: string): string | null {
+	if (!isSafeRedirect(redirect)) return null;
+
+	const base = new URL(env['PUBLIC_URL'] as string);
+	const target = new URL(String(redirect), base);
+
+	target.hash = '';
+	target.search = '';
+	target.searchParams.set('reason', reason);
+
+	return `${target.pathname}${target.search}`;
+}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

This is a hardening pass on top of the already-merged SSO redirect validation fixes (#25, #26). It keeps the existing redirect policy, but strengthens the redirect sink contract across all three SSO callback drivers.

The earlier fixes validated `redirect` / `RelayState` before using them after successful SSO login. That closed the cross-origin open redirect, but the callback handlers still passed user-derived URL strings into `res.redirect(...)` after validation.

This PR adds a second layer:
- safe redirects are canonicalized to local path-only targets before redirecting
- error redirects are canonicalized to local path-only targets with a controlled `reason` query
- unsafe redirects still fall back to the existing safe local behavior

After this change, the OAuth2, OpenID, and SAML callback flows only redirect to:
- a local path produced by the redirect helper, or
- the hardcoded local fallback `./?reason=...`

No user-derived absolute URL is passed directly to `res.redirect(...)` in these SSO callback paths.

### Testing / verification

- Extended `api/src/utils/validate-redirect.test.ts` with 19 new test cases for:
  - safe absolute URL -> local path canonicalization
  - safe relative URL -> local path canonicalization
  - query/hash preservation on success redirects
  - query/hash removal plus controlled `reason` on error redirects
  - unsafe and malformed inputs -> `null`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
