### PR TITLE
Restrict _in/_nin filter operators with empty arrays (GHSA-hxgm-ghmv-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Validated post-SSO redirect target in SAML login flow (GHSA-3573-4c68-g8cc / CVE-2026-22032).
 - Canonicalized post-SSO redirect targets to local paths across SSO login flows (GHSA-3573-4c68-g8cc / CVE-2026-22032, GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
 - Moved outbound HTTP IP validation to connection time (GHSA-8p72-rcq4-h6pw / CVE-2024-39699).
+- Restricted _in/_nin filter operators with empty arrays (GHSA-hxgm-ghmv-xjjm).
 
 ### Acknowledgements
 

--- a/api/src/services/authorization.test.ts
+++ b/api/src/services/authorization.test.ts
@@ -1,0 +1,143 @@
+import { FailedValidationException } from '@cairncms/exceptions';
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthorizationService } from './authorization.js';
+
+vi.mock('../database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const testSchema = {
+	collections: {
+		directus_users: {
+			collection: 'directus_users',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: true,
+					generated: true,
+					type: 'uuid',
+					dbType: 'uuid',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+				role: {
+					field: 'role',
+					defaultValue: null,
+					nullable: true,
+					generated: false,
+					type: 'uuid',
+					dbType: 'uuid',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+			},
+		},
+	},
+	relations: [],
+} as SchemaOverview;
+
+describe('AuthorizationService.validatePayload — _in filter with empty array (GHSA-hxgm-ghmv-xjjm)', () => {
+	let db: MockedFunction<Knex>;
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		createTracker(db);
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('throws FailedValidationException when permission validation carries _in [] and the payload would otherwise pass', () => {
+		const accountability: Accountability = {
+			role: 'restricted-editor-role-uuid',
+			user: 'user-uuid',
+			admin: false,
+			app: true,
+			permissions: [
+				{
+					id: 1,
+					role: 'restricted-editor-role-uuid',
+					collection: 'directus_users',
+					action: 'update',
+					permissions: {},
+					validation: { role: { _in: [] } },
+					presets: {},
+					fields: ['*'],
+				},
+			],
+		};
+
+		const service = new AuthorizationService({
+			knex: db,
+			schema: testSchema,
+			accountability,
+		});
+
+		let thrown: unknown;
+
+		try {
+			service.validatePayload('update', 'directus_users', { role: 'admin-role-uuid' });
+		} catch (err) {
+			thrown = err;
+		}
+
+		expect(thrown).toBeDefined();
+		expect(Array.isArray(thrown)).toBe(true);
+		expect((thrown as unknown[]).length).toBeGreaterThan(0);
+		expect((thrown as unknown[])[0]).toBeInstanceOf(FailedValidationException);
+	});
+
+	it('returns the payload without throwing when permission validation carries _in with a matching value', () => {
+		const accountability: Accountability = {
+			role: 'restricted-editor-role-uuid',
+			user: 'user-uuid',
+			admin: false,
+			app: true,
+			permissions: [
+				{
+					id: 1,
+					role: 'restricted-editor-role-uuid',
+					collection: 'directus_users',
+					action: 'update',
+					permissions: {},
+					validation: { role: { _in: ['some-allowed-role-uuid'] } },
+					presets: {},
+					fields: ['*'],
+				},
+			],
+		};
+
+		const service = new AuthorizationService({
+			knex: db,
+			schema: testSchema,
+			accountability,
+		});
+
+		const result = service.validatePayload('update', 'directus_users', {
+			role: 'some-allowed-role-uuid',
+		});
+
+		expect(result).toStrictEqual({ role: 'some-allowed-role-uuid' });
+	});
+});

--- a/packages/utils/shared/generate-joi.test.ts
+++ b/packages/utils/shared/generate-joi.test.ts
@@ -806,4 +806,48 @@ describe(`generateJoi`, () => {
 
 		expect(generateJoi(mockFieldFilter).describe()).toStrictEqual(mockSchema);
 	});
+
+	describe(`_in / _nin with empty arrays (GHSA-hxgm-ghmv-xjjm)`, () => {
+		it(`_in [] rejects a string payload value`, () => {
+			const schema = generateJoi({ field: { _in: [] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: 'anything' }).error).toBeDefined();
+		});
+
+		it(`_in [] rejects a numeric payload value`, () => {
+			const schema = generateJoi({ field: { _in: [] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: 42 }).error).toBeDefined();
+		});
+
+		it(`_in [] rejects a null payload value`, () => {
+			const schema = generateJoi({ field: { _in: [] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: null }).error).toBeDefined();
+		});
+
+		it(`_in [] is vacuously satisfied when the keyed field is absent from the payload`, () => {
+			const schema = generateJoi({ field: { _in: [] } } as unknown as FieldFilter);
+			expect(schema.validate({}).error).toBeUndefined();
+		});
+
+		it(`_nin [] accepts a string payload value`, () => {
+			const schema = generateJoi({ field: { _nin: [] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: 'anything' }).error).toBeUndefined();
+		});
+
+		it(`_nin [] accepts a null payload value`, () => {
+			const schema = generateJoi({ field: { _nin: [] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: null }).error).toBeUndefined();
+		});
+
+		it(`_in ['allowed'] accepts 'allowed' and rejects 'other'`, () => {
+			const schema = generateJoi({ field: { _in: ['allowed'] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: 'allowed' }).error).toBeUndefined();
+			expect(schema.validate({ field: 'other' }).error).toBeDefined();
+		});
+
+		it(`_nin ['blocked'] accepts 'allowed' and rejects 'blocked'`, () => {
+			const schema = generateJoi({ field: { _nin: ['blocked'] } } as unknown as FieldFilter);
+			expect(schema.validate({ field: 'allowed' }).error).toBeUndefined();
+			expect(schema.validate({ field: 'blocked' }).error).toBeDefined();
+		});
+	});
 });

--- a/packages/utils/shared/generate-joi.ts
+++ b/packages/utils/shared/generate-joi.ts
@@ -67,6 +67,8 @@ const defaults: JoiOptions = {
 	requireAll: false,
 };
 
+const EMPTY_IN_SENTINEL = Symbol('cairncms-empty-in');
+
 /**
  * Generate a Joi schema from a filter object.
  *
@@ -198,11 +200,19 @@ export function generateJoi(filter: FieldFilter | null, options?: JoiOptions): A
 		}
 
 		if (operator === '_in') {
-			schema[key] = getAnySchema().equal(...(compareValue as (string | number)[]));
+			if (Array.isArray(compareValue) && compareValue.length === 0) {
+				schema[key] = Joi.any().valid(EMPTY_IN_SENTINEL);
+			} else {
+				schema[key] = getAnySchema().equal(...(compareValue as (string | number)[]));
+			}
 		}
 
 		if (operator === '_nin') {
-			schema[key] = getAnySchema().not(...(compareValue as (string | number)[]));
+			if (Array.isArray(compareValue) && compareValue.length === 0) {
+				schema[key] = Joi.any();
+			} else {
+				schema[key] = getAnySchema().not(...(compareValue as (string | number)[]));
+			}
 		}
 
 		if (operator === '_gt') {

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -219,4 +219,24 @@ describe('', () => {
 		const mockAccountability = { role: 'admin', user: 'user' };
 		expect(parseFilter(mockFilter, mockAccountability)).toStrictEqual(mockResult);
 	});
+
+	it('substitutes an empty $CURRENT_USER scalar-array path into _in []', () => {
+		const mockFilter = { role: { _in: '$CURRENT_USER.allowed_roles' } } as Filter;
+		const mockAccountability = { role: 'admin', user: 'user' };
+		const mockContext = { $CURRENT_USER: { allowed_roles: [] } } as any;
+
+		expect(parseFilter(mockFilter, mockAccountability, mockContext)).toStrictEqual({
+			role: { _in: [] },
+		});
+	});
+
+	it('substitutes an empty $CURRENT_USER relational path into _in []', () => {
+		const mockFilter = { role: { _in: '$CURRENT_USER.user_roles.role' } } as Filter;
+		const mockAccountability = { role: 'admin', user: 'user' };
+		const mockContext = { $CURRENT_USER: { user_roles: [] } } as any;
+
+		expect(parseFilter(mockFilter, mockAccountability, mockContext)).toStrictEqual({
+			role: { _in: [] },
+		});
+	});
 });


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-hxgm-ghmv-xjjm / CVE-2024-39701.

Dynamic permission and validation filters accepted empty-array `_in` and `_nin` operands and passed them straight into Joi's vararg equality checks. For `_in: []`, that produced an accidentally permissive schema where the intended semantic is restrictive. For `_nin: []`, the permissive result happened to match the correct semantic by accident.

This PR makes both empty-array cases explicit in `generateJoi()` such that `_in: []` now rejects present values, `_nin: []` now allows values explicitly, and non-empty `_in` / `_nin` behavior is unchanged.

The fix is applied at the Joi-generation layer so the empty-array case is handled consistently wherever the filter input came from, including dynamic substitution through `parse-filter`.

### Testing / verification

- Added `generate-joi` runtime-behavior tests covering:
  - `_in: []` rejection
  - `_in: []` absent-field behavior
  - `_nin: []` pass-through
  - non-empty `_in` / `_nin` regression behavior
- Added `parse-filter` tests covering both empty-array substitution paths:
  - scalar-array path
  - relational empty path
- Added `authorization.test.ts` covering the enforcement seam:
  - `AuthorizationService.validatePayload()` rejects validation containing `_in: []`
  - positive non-empty `_in` control still passes

Also verified the SQL layer directly and confirmed:
- `whereIn([])` compiles to an always-false sentinel
- `whereNotIn([])` compiles to an always-true sentinel
- behavior is consistent across the Knex clients tested locally (`sqlite3`, `pg`, `mysql2`)

This confirms the vulnerability was in Joi validation generation rather than the SQL query layer.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
