### PR TITLE
Mask concealed fields routed through query aliases (GHSA-p8v3-m643-4xqx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Canonicalized post-SSO redirect targets to local paths across SSO login flows (GHSA-3573-4c68-g8cc / CVE-2026-22032, GHSA-fr3w-2p22-6w7p / CVE-2024-28239).
 - Moved outbound HTTP IP validation to connection time (GHSA-8p72-rcq4-h6pw / CVE-2024-39699).
 - Restricted _in/_nin filter operators with empty arrays (GHSA-hxgm-ghmv-xjjm).
+- Masked concealed fields routed through query aliases (GHSA-p8v3-m643-4xqx / CVE-2024-34708).
 
 ### Acknowledgements
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -83,7 +83,7 @@ export default async function runAST(
 
 		// Run the items through the special transforms
 		const payloadService = new PayloadService(collection, { knex, schema });
-		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems, query.alias);
+		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems, query.alias ?? undefined);
 
 		if (!items || (Array.isArray(items) && items.length === 0)) return items;
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -83,7 +83,7 @@ export default async function runAST(
 
 		// Run the items through the special transforms
 		const payloadService = new PayloadService(collection, { knex, schema });
-		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems);
+		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems, query.alias);
 
 		if (!items || (Array.isArray(items) && items.length === 0)) return items;
 

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -382,6 +382,181 @@ describe('Integration Tests', () => {
 				expect(result[1].id).toBe(2);
 			});
 		});
+
+		describe('processValues — conceal masking on query aliases (GHSA-p8v3-m643-4xqx)', () => {
+			function makeService(collectionName: string, fieldConfigs: Array<[string, string[]?]>) {
+				const field = (name: string, special: string[] = []) =>
+					({
+						field: name,
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						type: 'string' as const,
+						dbType: 'varchar',
+						precision: null,
+						scale: null,
+						special,
+						note: null,
+						validation: null,
+						alias: false,
+					} as any);
+
+				const fields: Record<string, any> = {};
+
+				for (const [name, special] of fieldConfigs) {
+					fields[name] = field(name, special ?? []);
+				}
+
+				return new PayloadService(collectionName, {
+					knex: db,
+					schema: {
+						collections: {
+							[collectionName]: {
+								collection: collectionName,
+								primary: 'id',
+								singleton: false,
+								sortField: null,
+								note: null,
+								accountability: null,
+								fields,
+							},
+						},
+						relations: [],
+					},
+				});
+			}
+
+			function usersService() {
+				return makeService('directus_users', [
+					['id'],
+					['email'],
+					['password', ['conceal']],
+					['tfa_secret', ['conceal']],
+					['token', ['conceal']],
+				]);
+			}
+
+			function sharesService() {
+				return makeService('directus_shares', [['id'], ['password', ['conceal']]]);
+			}
+
+			it('masks an aliased concealed field', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ hash: 'raw-hash' }], { hash: 'password' })) as any[];
+
+				expect(result[0].hash).toBe('**********');
+			});
+
+			it('does not mask an aliased non-concealed field', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ display_email: 'a@b.com' }], {
+					display_email: 'email',
+				})) as any[];
+
+				expect(result[0].display_email).toBe('a@b.com');
+			});
+
+			it('masks multiple concealed aliases in a single payload', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ h: 'raw-hash', e: 'a@b.com' }], {
+					h: 'password',
+					e: 'email',
+				})) as any[];
+
+				expect(result[0].h).toBe('**********');
+				expect(result[0].e).toBe('a@b.com');
+			});
+
+			it('still masks canonical concealed reads when no alias map is provided', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ password: 'raw-hash' }])) as any[];
+
+				expect(result[0].password).toBe('**********');
+			});
+
+			it('still masks canonical concealed reads when alias map is empty', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ password: 'raw-hash' }], {})) as any[];
+
+				expect(result[0].password).toBe('**********');
+			});
+
+			it('does not mask when alias target is not in the collection schema', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ x: 'value' }], { x: 'no_such_field' })) as any[];
+
+				expect(result[0].x).toBe('value');
+			});
+
+			it('preserves null aliased concealed value as null', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ hash: null }], { hash: 'password' })) as any[];
+
+				expect(result[0].hash).toBeNull();
+			});
+
+			it('masks empty-string aliased concealed value', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ hash: '' }], { hash: 'password' })) as any[];
+
+				expect(result[0].hash).toBe('**********');
+			});
+
+			it('masks aliased concealed values across multiple rows', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ hash: 'raw-1' }, { hash: 'raw-2' }], {
+					hash: 'password',
+				})) as any[];
+
+				expect(result[0].hash).toBe('**********');
+				expect(result[1].hash).toBe('**********');
+			});
+
+			it('masks aliased concealed field on directus_shares (multi-collection coverage)', async () => {
+				const service = sharesService();
+
+				const result = (await service.processValues('read', [{ shared_pwd: 'raw-share-hash' }], {
+					shared_pwd: 'password',
+				})) as any[];
+
+				expect(result[0].shared_pwd).toBe('**********');
+			});
+
+			it('masks both canonical and aliased concealed values in the same payload', async () => {
+				const service = usersService();
+
+				const result = (await service.processValues('read', [{ password: 'raw1', hash: 'raw2' }], {
+					hash: 'password',
+				})) as any[];
+
+				expect(result[0].password).toBe('**********');
+				expect(result[0].hash).toBe('**********');
+			});
+
+			it('masks a nested level when its own collection-scoped alias map is passed in (per-level seam, not a propagation test)', async () => {
+				const parentService = usersService();
+				const childService = sharesService();
+
+				const parentResult = (await parentService.processValues('read', [{ id: 'u1', email: 'a@b.com' }])) as any[];
+				expect(parentResult[0].id).toBe('u1');
+				expect(parentResult[0].email).toBe('a@b.com');
+
+				const childResult = (await childService.processValues('read', [{ shared_pwd: 'raw-share-hash' }], {
+					shared_pwd: 'password',
+				})) as any[];
+
+				expect(childResult[0].shared_pwd).toBe('**********');
+			});
+		});
 	});
 });
 

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -146,11 +146,14 @@ export class PayloadService {
 		},
 	};
 
-	processValues(action: Action, payloads: Partial<Item>[]): Promise<Partial<Item>[]>;
-	processValues(action: Action, payload: Partial<Item>): Promise<Partial<Item>>;
+	processValues(action: Action, payloads: Partial<Item>[], aliasMap?: Record<string, string>): Promise<Partial<Item>[]>;
+
+	processValues(action: Action, payload: Partial<Item>, aliasMap?: Record<string, string>): Promise<Partial<Item>>;
+
 	async processValues(
 		action: Action,
-		payload: Partial<Item> | Partial<Item>[]
+		payload: Partial<Item> | Partial<Item>[],
+		aliasMap?: Record<string, string>
 	): Promise<Partial<Item> | Partial<Item>[]> {
 		const processedPayload = toArray(payload);
 
@@ -196,6 +199,7 @@ export class PayloadService {
 
 		if (action === 'read') {
 			this.maskConcealedAggregates(processedPayload);
+			this.maskAliasedConcealedFields(processedPayload, aliasMap);
 			this.processAggregates(processedPayload);
 		}
 
@@ -236,6 +240,27 @@ export class PayloadService {
 				if (!concealedFields.has(operandField)) continue;
 
 				item[key] = item[key] == null ? null : '**********';
+			}
+		}
+	}
+
+	private maskAliasedConcealedFields(payload: Partial<Item>[], aliasMap?: Record<string, string>): void {
+		if (!aliasMap || payload.length === 0) return;
+
+		const concealedFields = new Set(
+			Object.entries(this.schema.collections[this.collection]?.fields ?? {})
+				.filter(([_name, field]) => field.special?.includes('conceal'))
+				.map(([name]) => name)
+		);
+
+		if (concealedFields.size === 0) return;
+
+		for (const [aliasKey, sourceField] of Object.entries(aliasMap)) {
+			if (!concealedFields.has(sourceField)) continue;
+
+			for (const item of payload) {
+				if (!(aliasKey in item)) continue;
+				item[aliasKey] = item[aliasKey] == null ? null : '**********';
 			}
 		}
 	}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-p8v3-m643-4xqx / CVE-2024-34708.

Fields marked with `special: [conceal]` were masked on normal reads, but query aliases could bypass that masking. When a request renamed a concealed field through `query.alias`, the response payload no longer contained the canonical field name, so the existing conceal transform was filtered out and never ran.

This PR makes read-time conceal masking alias-aware in `PayloadService`. Aliased concealed fields are now masked the same way as canonical concealed fields, and non-concealed aliases are unchanged.

The fix is applied at the payload-masking layer so it covers both REST and GraphQL, which already converge on the same `query.alias` shape before `runAST()`.

### Testing / verification

- Added `payload.test.ts` coverage for:
  - aliased concealed field masking
  - aliased non-concealed pass-through
  - multiple aliases in one payload
  - no-alias and empty-alias regression behavior
  - null and empty-string boundary cases
  - multi-row behavior
  - multi-collection coverage (`directus_users` and `directus_shares`)
  - canonical and aliased concealed values in the same payload
  - per-collection nested masking seam

Also verified against a live SQLite instance and confirmed:
- REST alias reads of concealed fields now return `'**********'`
- canonical concealed reads still return `'**********'`
- aliased non-concealed fields still return their raw values
- GraphQL aliases route through the same fix and return masked values

This closes the alias-based conceal bypass without changing alias semantics for non-concealed fields.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
