### PR TITLE
Deduplicate GraphQL aggregate field selections (GHSA-7hmh-pfrp-vcx4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Moved outbound HTTP IP validation to connection time (GHSA-8p72-rcq4-h6pw / CVE-2024-39699).
 - Restricted _in/_nin filter operators with empty arrays (GHSA-hxgm-ghmv-xjjm).
 - Masked concealed fields routed through query aliases (GHSA-p8v3-m643-4xqx / CVE-2024-34708).
+- Deduplicated GraphQL aggregate field selections (GHSA-7hmh-pfrp-vcx4 / CVE-2024-39895).
 
 ### Acknowledgements
 

--- a/api/src/services/graphql/aggregate-field-dedup.test.ts
+++ b/api/src/services/graphql/aggregate-field-dedup.test.ts
@@ -1,0 +1,177 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GraphQLService } from './index.js';
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabase: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const accountability: Accountability = {
+	user: null,
+	role: null,
+	admin: false,
+	app: false,
+	ip: '127.0.0.1',
+};
+
+const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+function field(name: string, innerSelections?: any[]): any {
+	return {
+		kind: 'Field',
+		name: { kind: 'Name', value: name },
+		selectionSet: innerSelections ? { kind: 'SelectionSet', selections: innerSelections } : undefined,
+	};
+}
+
+function makeService() {
+	return new GraphQLService({ accountability, schema, scope: 'system' });
+}
+
+describe('GraphQLService.getAggregateQuery — field deduplication (GHSA-7hmh-pfrp-vcx4)', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('inner duplication (advisory PoC shape)', () => {
+		it('deduplicates repeated identical field selections within a single aggregate block', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [field('id'), field('id'), field('id')])]);
+
+			expect(result.aggregate).toEqual({ max: ['id'] });
+		});
+
+		it('deduplicates while preserving non-duplicate fields in declared order', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id'), field('id'), field('status')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id', 'status'] });
+		});
+	});
+
+	describe('outer duplication (merge contract)', () => {
+		it('collapses repeated identical outer blocks (advisory PoC at small scale)', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [field('id')]), field('max', [field('id')])]);
+
+			expect(result.aggregate).toEqual({ max: ['id'] });
+		});
+
+		it('merges field names from repeated outer blocks with distinct inner fields', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id')]),
+				field('max', [field('email')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id', 'email'] });
+		});
+
+		it('merges partially-overlapping inner field lists across repeated outer blocks', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id'), field('email')]),
+				field('max', [field('email'), field('status')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id', 'email', 'status'] });
+		});
+
+		it('collapses combined outer-and-inner duplication (mini PoC)', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id'), field('id'), field('id')]),
+				field('max', [field('id'), field('id'), field('id')]),
+				field('max', [field('id'), field('id'), field('id')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id'] });
+		});
+	});
+
+	describe('regression guards', () => {
+		it('passes a single-occurrence aggregate block through unchanged', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [field('id')])]);
+
+			expect(result.aggregate).toEqual({ max: ['id'] });
+		});
+
+		it('preserves multiple distinct fields in a single block in declared order', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id'), field('status'), field('email')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id', 'status', 'email'] });
+		});
+
+		it('processes distinct aggregate operations independently', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('max', [field('id')]),
+				field('min', [field('status')]),
+			]);
+
+			expect(result.aggregate).toEqual({ max: ['id'], min: ['status'] });
+		});
+
+		it('skips __typename pointers in inner selections', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [field('id'), field('__typename')])]);
+
+			expect(result.aggregate).toEqual({ max: ['id'] });
+		});
+
+		it('produces an empty array when the inner selection set is empty', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [])]);
+
+			expect(result.aggregate).toEqual({ max: [] });
+		});
+	});
+
+	describe('boundary cases', () => {
+		it('keeps same-name fields under distinct aggregate operations separate', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('max', [field('id')]), field('sum', [field('id')])]);
+
+			expect(result.aggregate).toEqual({ max: ['id'], sum: ['id'] });
+		});
+
+		it('deduplicates the wildcard field within a count block', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [field('count', [field('*'), field('*'), field('*')])]);
+
+			expect(result.aggregate).toEqual({ count: ['*'] });
+		});
+
+		it('deduplicates across repeated outer count blocks with the wildcard field', () => {
+			const service = makeService();
+
+			const result = (service as any).getAggregateQuery({}, [
+				field('count', [field('*')]),
+				field('count', [field('*')]),
+			]);
+
+			expect(result.aggregate).toEqual({ count: ['*'] });
+		});
+	});
+});

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -1684,6 +1684,8 @@ export class GraphQLService {
 
 		query.aggregate = {};
 
+		const aggregateFieldSets: Record<string, Set<string>> = {};
+
 		for (let aggregationGroup of selections) {
 			if ((aggregationGroup.kind === 'Field') !== true) continue;
 
@@ -1692,16 +1694,18 @@ export class GraphQLService {
 			// filter out graphql pointers, like __typename
 			if (aggregationGroup.name.value.startsWith('__')) continue;
 
-			const aggregateProperty = aggregationGroup.name.value as keyof Aggregate;
+			const operation = aggregationGroup.name.value;
+			const fieldSet = (aggregateFieldSets[operation] ??= new Set<string>());
 
-			query.aggregate[aggregateProperty] =
-				aggregationGroup.selectionSet?.selections
-					// filter out graphql pointers, like __typename
-					.filter((selectionNode) => !(selectionNode as FieldNode)?.name.value.startsWith('__'))
-					.map((selectionNode) => {
-						selectionNode = selectionNode as FieldNode;
-						return selectionNode.name.value;
-					}) ?? [];
+			for (const selectionNode of aggregationGroup.selectionSet?.selections ?? []) {
+				const fieldName = (selectionNode as FieldNode)?.name.value;
+				if (!fieldName || fieldName.startsWith('__')) continue;
+				fieldSet.add(fieldName);
+			}
+		}
+
+		for (const [operation, fieldSet] of Object.entries(aggregateFieldSets)) {
+			query.aggregate[operation as keyof Aggregate] = Array.from(fieldSet);
 		}
 
 		if (query.filter) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-7hmh-pfrp-vcx4 / CVE-2024-39895.

GraphQL aggregate queries accepted duplicated field selections and repeated aggregate blocks without deduplicating or merging them. This allowed a single resolver invocation to generate redundant aggregate work, emit repeated SQL aggregate columns, and in some cases overwrite earlier aggregate blocks.

This PR fixes `getAggregateQuery()` so aggregate selections are merged per operation and deduplicated by field name before they reach the query layer.

This closes the named GraphQL field-duplication DoS and also fixes a latent correctness bug where repeated aggregate blocks like `count { id } count { email }` previously returned only the last block.

### Testing / verification

- Added `aggregate-field-dedup.test.ts` covering:
  - inner field duplication within a single aggregate block
  - repeated outer aggregate blocks
  - merge behavior across repeated outer blocks with distinct and overlapping fields
  - combined outer + inner duplication mini-PoC cases
  - distinct aggregate-operation regression behavior
  - `__typename` skipping
  - empty inner selection sets
  - wildcard `count { * }` deduplication

Also verified against a live SQLite instance and confirmed:
- duplicated GraphQL aggregate fields collapse to a single aggregate result
- repeated outer aggregate blocks merge correctly instead of overwriting earlier fields
- a scaled duplication probe completes quickly and returns the deduplicated result
- distinct operations and distinct fields remain intact

This keeps the fix scoped to the named GraphQL aggregate path without changing REST aggregate handling.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
