### PR TITLE
Extend outbound IP deny-list to the full loopback range (GHSA-68g8-c2…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Masked concealed fields routed through query aliases (GHSA-p8v3-m643-4xqx / CVE-2024-34708).
 - Deduplicated GraphQL aggregate field selections (GHSA-7hmh-pfrp-vcx4 / CVE-2024-39895).
 - Validated share role on create and update (GHSA-pmf4-v838-29hg / CVE-2025-24353).
+- Extended outbound IP deny-list to the full loopback range (GHSA-68g8-c275-xf2m / CVE-2024-46990).
 
 ### Acknowledgements
 

--- a/api/src/request/validate-ip.test.ts
+++ b/api/src/request/validate-ip.test.ts
@@ -113,7 +113,7 @@ test.each([
 	['dotted-decimal mixed', '::ffff:127.0.0.1'],
 	['compressed hex', '::ffff:7f00:1'],
 	['fully expanded', '0:0:0:0:0:ffff:7f00:1'],
-])('Denies IPv4-mapped IPv6 loopback (%s) via the 0.0.0.0 local-interface branch', async (_label, mapped) => {
+])('Denies IPv4-mapped IPv6 loopback (%s) when 0.0.0.0 is in the deny-list', async (_label, mapped) => {
 	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
 
 	vi.mocked(os.networkInterfaces).mockReturnValue({
@@ -137,7 +137,7 @@ test('Native IPv4 entry in deny list is still denied (regression)', async () => 
 	await expectDenied('169.254.169.254', DENY_URL);
 });
 
-test('Native IPv4 loopback is still denied via local-interface branch (regression)', async () => {
+test('Native IPv4 loopback is still denied when 0.0.0.0 is in the deny-list (regression)', async () => {
 	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
 
 	vi.mocked(os.networkInterfaces).mockReturnValue({
@@ -164,4 +164,108 @@ test('Non-mapped IPv6 address that is not in the deny list passes through', asyn
 test('Plain IPv4 address that is not in the deny list passes through', async () => {
 	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['169.254.169.254'] });
 	await expectAllowed('198.51.100.1', DENY_URL);
+});
+
+function mockOnlyLoopbackInterface() {
+	vi.mocked(os.networkInterfaces).mockReturnValue({
+		lo0: [
+			{
+				address: '127.0.0.1',
+				netmask: '255.0.0.0',
+				family: 'IPv4',
+				mac: '00:00:00:00:00:00',
+				internal: true,
+				cidr: '127.0.0.1/8',
+			},
+		],
+	});
+}
+
+test('GHSA-68g8-c275-xf2m: 127.0.0.2 is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('127.0.0.2', DENY_URL);
+});
+
+test('GHSA-68g8-c275-xf2m: 127.127.127.127 is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('127.127.127.127', DENY_URL);
+});
+
+test('GHSA-68g8-c275-xf2m: 127.255.255.254 is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('127.255.255.254', DENY_URL);
+});
+
+test('GHSA-68g8-c275-xf2m: IPv6 loopback ::1 is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('::1', DENY_URL);
+});
+
+test('GHSA-68g8-c275-xf2m: IPv4-mapped IPv6 loopback-range form is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('::ffff:127.0.0.2', DENY_URL);
+});
+
+test('regression: 127.0.0.1 still denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('127.0.0.1', DENY_URL);
+});
+
+test('regression: public IP still passes when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectAllowed('8.8.8.8', DENY_URL);
+});
+
+test('regression: empty deny-list lets any IP through', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: [] });
+	await expectAllowed('127.0.0.2', DENY_URL);
+});
+
+test('regression: literal 127.0.0.1 in deny-list (without 0.0.0.0) does not block 127.0.0.2', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['127.0.0.1'] });
+	mockOnlyLoopbackInterface();
+	await expectAllowed('127.0.0.2', DENY_URL);
+});
+
+test('regression: literal 127.0.0.1 in deny-list (without 0.0.0.0) still blocks exact 127.0.0.1', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['127.0.0.1'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('127.0.0.1', DENY_URL);
+});
+
+test('regression: 0.0.0.0 in deny-list still catches a bound non-loopback interface address', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+
+	vi.mocked(os.networkInterfaces).mockReturnValue({
+		eth0: [
+			{
+				address: '192.168.1.5',
+				netmask: '255.255.255.0',
+				family: 'IPv4',
+				mac: '00:00:00:00:00:00',
+				internal: false,
+				cidr: '192.168.1.5/24',
+			},
+		],
+	});
+
+	await expectDenied('192.168.1.5', DENY_URL);
+});
+
+test('composition with GHSA-wv3h-5fx7-966h: IPv4-mapped IPv6 of 127.0.0.1 is denied when 0.0.0.0 is in the deny-list', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['0.0.0.0'] });
+	mockOnlyLoopbackInterface();
+	await expectDenied('::ffff:127.0.0.1', DENY_URL);
+});
+
+test('composition with GHSA-wv3h-5fx7-966h: IPv4-mapped IPv6 of 169.254.169.254 is denied via canonical match', async () => {
+	vi.mocked(getEnv).mockReturnValue({ IMPORT_IP_DENY_LIST: ['169.254.169.254'] });
+	await expectDenied('::ffff:169.254.169.254', DENY_URL);
 });

--- a/api/src/request/validate-ip.ts
+++ b/api/src/request/validate-ip.ts
@@ -16,6 +16,14 @@ function canonicalize(ip: string): string {
 	}
 }
 
+function isLoopback(ip: string): boolean {
+	try {
+		return ipaddr.parse(ip).range() === 'loopback';
+	} catch {
+		return false;
+	}
+}
+
 export function validateIPSync(ip: string, url: string): void {
 	const env = getEnv();
 	const canonical = canonicalize(ip);
@@ -25,6 +33,10 @@ export function validateIPSync(ip: string, url: string): void {
 	}
 
 	if (env['IMPORT_IP_DENY_LIST'].includes('0.0.0.0')) {
+		if (isLoopback(canonical)) {
+			throw new Error(`Requested URL "${url}" resolves to a denied IP address`);
+		}
+
 		const networkInterfaces = os.networkInterfaces();
 
 		for (const networkInfo of Object.values(networkInterfaces)) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-68g8-c275-xf2m / CVE-2024-46990.

Outbound request validation treated `0.0.0.0` in `IMPORT_IP_DENY_LIST` as “deny exact local interface addresses.” That blocked `127.0.0.1`, but it did not block the rest of the IPv4 loopback range unless the exact address was bound on an interface. Requests to addresses like `127.0.0.2` could still reach localhost.

This PR extends that check to deny the full loopback range when `0.0.0.0` is present in the deny-list. It now rejects any IP whose parsed range is loopback, covering IPv4 `127.0.0.0/8`, IPv6 `::1`, and IPv4-mapped IPv6 loopback forms after existing canonicalization.

The existing bound-interface check is preserved for non-loopback interface addresses.

### Testing / verification

- Added `validate-ip.test.ts` coverage for:
  - loopback-range bypass forms including `127.0.0.2`, `127.127.127.127`, and `127.255.255.254`
  - IPv6 loopback `::1`
  - IPv4-mapped IPv6 loopback forms
  - gating behavior when `0.0.0.0` is absent from the deny-list
  - regression coverage for the earlier IPv4-mapped IPv6 SSRF fix
  - regression coverage for non-loopback bound interface addresses

Also verified against a live SQLite instance and confirmed:
- requests to multiple loopback-range addresses are rejected through the agent-layer SSRF enforcement path
- IPv6 loopback is rejected
- public IPs are not over-blocked by the new check
- existing `127.0.0.1` denial behavior remains intact

This keeps the fix scoped to the named loopback-range bypass without changing the broader operator-facing meaning of explicit non-loopback deny-list entries.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
