### PR TITLE
Validate preset ownership on create and update (GHSA-3fff-gqw3-vj86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Deduplicated GraphQL aggregate field selections (GHSA-7hmh-pfrp-vcx4 / CVE-2024-39895).
 - Validated share role on create and update (GHSA-pmf4-v838-29hg / CVE-2025-24353).
 - Extended outbound IP deny-list to the full loopback range (GHSA-68g8-c275-xf2m / CVE-2024-46990).
+- Validated preset ownership on create and update (GHSA-3fff-gqw3-vj86 / CVE-2024-6534).
 
 ### Acknowledgements
 

--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -41,6 +41,9 @@
   permissions:
     user:
       _eq: $CURRENT_USER
+  validation:
+    user:
+      _eq: $CURRENT_USER
 
 - collection: directus_presets
   action: delete

--- a/api/src/services/presets.test.ts
+++ b/api/src/services/presets.test.ts
@@ -1,0 +1,296 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { MockClient, createTracker } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import { ItemsService } from './items.js';
+import { PresetsService } from './presets.js';
+
+vi.mock('../database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const testSchema = {
+	collections: {
+		directus_presets: {
+			collection: 'directus_presets',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: false,
+					generated: true,
+					type: 'integer',
+					dbType: 'integer',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+				user: {
+					field: 'user',
+					defaultValue: null,
+					nullable: true,
+					generated: false,
+					type: 'uuid',
+					dbType: 'uuid',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+				role: {
+					field: 'role',
+					defaultValue: null,
+					nullable: true,
+					generated: false,
+					type: 'uuid',
+					dbType: 'uuid',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+				collection: {
+					field: 'collection',
+					defaultValue: null,
+					nullable: false,
+					generated: false,
+					type: 'string',
+					dbType: 'varchar',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+				layout: {
+					field: 'layout',
+					defaultValue: null,
+					nullable: true,
+					generated: false,
+					type: 'string',
+					dbType: 'varchar',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+			},
+		},
+	},
+	relations: [],
+} as SchemaOverview;
+
+const CALLER_USER = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OTHER_USER = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const PRESET_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+describe('PresetsService — ownership validation (GHSA-3fff-gqw3-vj86)', () => {
+	let db: MockedFunction<Knex>;
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		createTracker(db);
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue(PRESET_ID);
+		vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue([PRESET_ID]);
+		vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue(PRESET_ID);
+		vi.spyOn(ItemsService.prototype, 'updateMany').mockResolvedValue([PRESET_ID]);
+		vi.spyOn(ItemsService.prototype, 'updateBatch').mockResolvedValue([PRESET_ID]);
+	});
+
+	function makeService(overrides: Partial<Accountability> = {}): PresetsService {
+		const accountability: Accountability = {
+			user: CALLER_USER,
+			role: 'role-uuid',
+			admin: false,
+			app: true,
+			ip: '127.0.0.1',
+			...overrides,
+		};
+
+		return new PresetsService({ knex: db, schema: testSchema, accountability });
+	}
+
+	describe('bug-exposing — non-admin reassignment attempts', () => {
+		it('updateOne with a user other than the caller throws ForbiddenException', async () => {
+			const service = makeService();
+			await expect(service.updateOne(PRESET_ID, { user: OTHER_USER })).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('updateMany with a user other than the caller throws ForbiddenException', async () => {
+			const service = makeService();
+			await expect(service.updateMany([PRESET_ID], { user: OTHER_USER })).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('updateBatch with any element having a user other than the caller throws ForbiddenException', async () => {
+			const service = makeService();
+
+			await expect(
+				service.updateBatch([
+					{ id: PRESET_ID, user: CALLER_USER },
+					{ id: PRESET_ID, user: OTHER_USER },
+				])
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('createOne with a user other than the caller throws ForbiddenException (defense-in-depth)', async () => {
+			const service = makeService();
+
+			await expect(
+				service.createOne({ user: OTHER_USER, collection: 'directus_users', layout: 'tabular' })
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('createMany with any element having a user other than the caller throws ForbiddenException', async () => {
+			const service = makeService();
+
+			await expect(
+				service.createMany([
+					{ user: CALLER_USER, collection: 'directus_users' },
+					{ user: OTHER_USER, collection: 'directus_users' },
+				])
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('bug-exposing — non-admin omitted user on create (OR-merge widening defense)', () => {
+		it('createOne without user throws InvalidPayloadException', async () => {
+			const service = makeService();
+
+			await expect(service.createOne({ collection: 'directus_users', layout: 'tabular' })).rejects.toBeInstanceOf(
+				InvalidPayloadException
+			);
+		});
+
+		it('createMany with one element missing user throws InvalidPayloadException', async () => {
+			const service = makeService();
+
+			await expect(
+				service.createMany([
+					{ user: CALLER_USER, collection: 'directus_users' },
+					{ collection: 'directus_users', layout: 'tabular' },
+				])
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+	});
+
+	describe('regression — guard does not reject legitimate writes', () => {
+		it('createOne with caller user is not rejected by the guard', async () => {
+			const service = makeService();
+
+			await expect(
+				service.createOne({ user: CALLER_USER, collection: 'directus_users', layout: 'tabular' })
+			).resolves.toBe(PRESET_ID);
+		});
+
+		it('createMany with all caller-user items is not rejected by the guard', async () => {
+			const service = makeService();
+
+			await expect(
+				service.createMany([
+					{ user: CALLER_USER, collection: 'directus_users' },
+					{ user: CALLER_USER, collection: 'directus_users' },
+				])
+			).resolves.toEqual([PRESET_ID]);
+		});
+
+		it('updateOne with caller user is not rejected by the guard', async () => {
+			const service = makeService();
+			await expect(service.updateOne(PRESET_ID, { user: CALLER_USER })).resolves.toBe(PRESET_ID);
+		});
+
+		it('updateOne without user in payload is not rejected by the guard (non-user field update)', async () => {
+			const service = makeService();
+			await expect(service.updateOne(PRESET_ID, { layout: 'cards' })).resolves.toBe(PRESET_ID);
+		});
+
+		it('updateMany without user in payload is not rejected by the guard', async () => {
+			const service = makeService();
+			await expect(service.updateMany([PRESET_ID], { layout: 'cards' })).resolves.toEqual([PRESET_ID]);
+		});
+
+		it('updateBatch with all caller-user items is not rejected by the guard', async () => {
+			const service = makeService();
+
+			await expect(
+				service.updateBatch([
+					{ id: PRESET_ID, user: CALLER_USER },
+					{ id: PRESET_ID, user: CALLER_USER },
+				])
+			).resolves.toEqual([PRESET_ID]);
+		});
+	});
+
+	describe('regression — admin exemption', () => {
+		it('admin createOne with any user is not rejected by the guard', async () => {
+			const service = makeService({ admin: true });
+
+			await expect(
+				service.createOne({ user: OTHER_USER, collection: 'directus_users', layout: 'tabular' })
+			).resolves.toBe(PRESET_ID);
+		});
+
+		it('admin createOne with no user field is not rejected by the guard', async () => {
+			const service = makeService({ admin: true });
+
+			await expect(service.createOne({ collection: 'directus_users', layout: 'tabular' })).resolves.toBe(PRESET_ID);
+		});
+
+		it('admin updateOne to any user is not rejected by the guard', async () => {
+			const service = makeService({ admin: true });
+			await expect(service.updateOne(PRESET_ID, { user: OTHER_USER })).resolves.toBe(PRESET_ID);
+		});
+
+		it('admin createMany with mixed users is not rejected by the guard', async () => {
+			const service = makeService({ admin: true });
+
+			await expect(
+				service.createMany([
+					{ user: CALLER_USER, collection: 'directus_users' },
+					{ user: OTHER_USER, collection: 'directus_users' },
+				])
+			).resolves.toEqual([PRESET_ID]);
+		});
+	});
+
+	describe('defensive boundaries', () => {
+		it('null accountability rejects user-setting create', async () => {
+			const service = new PresetsService({ knex: db, schema: testSchema, accountability: null });
+
+			await expect(
+				service.createOne({ user: OTHER_USER, collection: 'directus_users', layout: 'tabular' })
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('non-admin caller with null user rejects any user-setting create', async () => {
+			const service = makeService({ user: null });
+
+			await expect(
+				service.createOne({ user: OTHER_USER, collection: 'directus_users', layout: 'tabular' })
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+});

--- a/api/src/services/presets.ts
+++ b/api/src/services/presets.ts
@@ -1,8 +1,63 @@
-import type { AbstractServiceOptions } from '../types/index.js';
+import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '../types/index.js';
 import { ItemsService } from './items.js';
 
 export class PresetsService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {
 		super('directus_presets', options);
+	}
+
+	private validatePresetOwnership(data: Partial<Item>, options: { requireUser?: boolean } = {}): void {
+		if (this.accountability?.admin === true) return;
+
+		const hasUser = 'user' in data;
+
+		if (options.requireUser && !hasUser) {
+			throw new InvalidPayloadException('"user" is required on preset creation');
+		}
+
+		if (!hasUser) return;
+
+		const callerUser = this.accountability?.user ?? null;
+		const requestedUser = (data['user'] as string | null | undefined) ?? null;
+
+		if (callerUser === null) {
+			throw new ForbiddenException();
+		}
+
+		if (requestedUser !== callerUser) {
+			throw new ForbiddenException();
+		}
+	}
+
+	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		this.validatePresetOwnership(data, { requireUser: true });
+		return super.createOne(data, opts);
+	}
+
+	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		for (const item of data) {
+			this.validatePresetOwnership(item, { requireUser: true });
+		}
+
+		return super.createMany(data, opts);
+	}
+
+	override async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		this.validatePresetOwnership(data);
+		return super.updateOne(key, data, opts);
+	}
+
+	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		this.validatePresetOwnership(data);
+		return super.updateMany(keys, data, opts);
+	}
+
+	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		for (const item of data) {
+			this.validatePresetOwnership(item);
+		}
+
+		return super.updateBatch(data, opts);
 	}
 }


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-3fff-gqw3-vj86 / CVE-2024-6534.

`directus_presets` create validation already required `user == $CURRENT_USER`, but update validation did not. That allowed a non-admin user to update a preset they owned and reassign its `user` field to another user.

This PR fixes this in two places:
- adds the missing update-side validation rule for `directus_presets`
- adds a service-layer ownership guard in `PresetsService` across all preset write paths

Note that YAML validation alone closes the default advisory PoC, but a normal admin-UI permission workflow can reopen the reassignment path by adding an overlapping custom preset permission without explicit validation (verified via probe). A policy decision was made to make this PR a bit broader in order to keep that from becoming exploitable.

### Testing / verification

- Added `presets.test.ts` covering:
  - non-admin reassignment rejection across all five preset write paths
  - non-admin create rejection when `user` is omitted or set to another user
  - legitimate non-admin writes that keep ownership unchanged
  - admin exemption on create and update paths
  - defensive null-accountability and null-user boundaries

Also verified against a live SQLite instance and confirmed:
- the advisory `PATCH /presets/:id` reassignment PoC now returns `403`
- batch and keys-based update variants also reject reassignment
- non-user-field updates still work
- non-admin create with another user or with no user is rejected
- admin can still create presets on behalf of another user

This closes the named preset reassignment bug and also prevents the same ownership invariant from being reopened through overlapping custom preset permissions.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
