### PR TITLE
Redact access_token query parameter from request logs (GHSA-vw58-ph65…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Validated share role on create and update (GHSA-pmf4-v838-29hg / CVE-2025-24353).
 - Extended outbound IP deny-list to the full loopback range (GHSA-68g8-c275-xf2m / CVE-2024-46990).
 - Validated preset ownership on create and update (GHSA-3fff-gqw3-vj86 / CVE-2024-6534).
+- Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 
 ### Acknowledgements
 

--- a/api/src/logger.test.ts
+++ b/api/src/logger.test.ts
@@ -39,6 +39,70 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
+describe('req.query.access_token', () => {
+	test('Should redact access_token query parameter (GHSA-vw58-ph65-6rxp)', () => {
+		const instance = pino(httpLoggerOptions, stream);
+
+		instance.info({
+			req: {
+				query: {
+					access_token: 'test-access-token-value',
+				},
+			},
+		});
+
+		expect(logOutput.mock.calls[0][0]).toMatchObject({
+			req: {
+				query: {
+					access_token: REDACT_TEXT,
+				},
+			},
+		});
+	});
+
+	test('Should leave non-sensitive query parameters unchanged', () => {
+		const instance = pino(httpLoggerOptions, stream);
+
+		instance.info({
+			req: {
+				query: {
+					fields: 'id,name',
+				},
+			},
+		});
+
+		expect(logOutput.mock.calls[0][0]).toMatchObject({
+			req: {
+				query: {
+					fields: 'id,name',
+				},
+			},
+		});
+	});
+
+	test('Should redact access_token while preserving other query parameters in the same payload', () => {
+		const instance = pino(httpLoggerOptions, stream);
+
+		instance.info({
+			req: {
+				query: {
+					access_token: 'test-access-token-value',
+					fields: 'id,name',
+				},
+			},
+		});
+
+		expect(logOutput.mock.calls[0][0]).toMatchObject({
+			req: {
+				query: {
+					access_token: REDACT_TEXT,
+					fields: 'id,name',
+				},
+			},
+		});
+	});
+});
+
 describe('req.headers.authorization', () => {
 	test('Should redact bearer token in Authorization header', () => {
 		const instance = pino(httpLoggerOptions, stream);

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -12,7 +12,7 @@ import { getConfigFromEnv } from './utils/get-config-from-env.js';
 const pinoOptions: LoggerOptions = {
 	level: env['LOG_LEVEL'] || 'info',
 	redact: {
-		paths: ['req.headers.authorization', 'req.headers.cookie'],
+		paths: ['req.headers.authorization', 'req.headers.cookie', 'req.query.access_token'],
 		censor: REDACT_TEXT,
 	},
 };
@@ -20,7 +20,7 @@ const pinoOptions: LoggerOptions = {
 export const httpLoggerOptions: LoggerOptions = {
 	level: env['LOG_LEVEL'] || 'info',
 	redact: {
-		paths: ['req.headers.authorization', 'req.headers.cookie'],
+		paths: ['req.headers.authorization', 'req.headers.cookie', 'req.query.access_token'],
 		censor: REDACT_TEXT,
 	},
 };
@@ -50,7 +50,7 @@ if (env['LOG_STYLE'] !== 'raw') {
 
 if (env['LOG_STYLE'] === 'raw') {
 	httpLoggerOptions.redact = {
-		paths: ['req.headers.authorization', 'req.headers.cookie', 'res.headers'],
+		paths: ['req.headers.authorization', 'req.headers.cookie', 'req.query.access_token', 'res.headers'],
 		censor: (value, pathParts) => {
 			const path = pathParts.join('.');
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-vw58-ph65-6rxp / CVE-2024-47822.

When `access_token` was passed in the query string, request logging scrubbed the token from the URL string but not from the serialized `req.query` object. Under `LOG_STYLE=raw`, that allowed access tokens to be written into structured request logs.

This PR adds `req.query.access_token` to the logger redaction paths.

The named advisory surface is raw-mode express request logging. This PR also adds the same redact path to the other logger configurations so the behavior stays consistent across the existing logger setup.

### Testing / verification

- Added `logger.test.ts` coverage for:
  - redacting `req.query.access_token` in raw-mode structured logs
  - preserving non-sensitive query parameters
  - mixed query payloads where only `access_token` is redacted

Also verified at the existing raw-mode logger test seam and confirmed:
- `req.query.access_token` is replaced with the standard redaction sentinel
- other query parameters remain intact
- existing authorization, cookie, and `set-cookie` redaction behavior is unchanged

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
