### PR TITLE
Scope search query parameter to permitted readable fields (GHSA-7wq3-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Extended outbound IP deny-list to the full loopback range (GHSA-68g8-c275-xf2m / CVE-2024-46990).
 - Validated preset ownership on create and update (GHSA-3fff-gqw3-vj86 / CVE-2024-6534).
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
+- Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 
 ### Acknowledgements
 

--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -1,4 +1,4 @@
-import type { Item, Query, SchemaOverview } from '@cairncms/types';
+import type { Accountability, Item, Query, SchemaOverview } from '@cairncms/types';
 import { toArray } from '@cairncms/utils';
 import type { Knex } from 'knex';
 import { clone, cloneDeep, isNil, merge, pick, uniq } from 'lodash-es';
@@ -35,6 +35,8 @@ type RunASTOptions = {
 	 * Whether or not to strip out non-requested required fields automatically (eg IDs / FKs)
 	 */
 	stripNonRequested?: boolean;
+
+	accountability?: Accountability | null;
 };
 
 /**
@@ -75,7 +77,7 @@ export default async function runAST(
 		);
 
 		// The actual knex query builder instance. This is a promise that resolves with the raw items from the db
-		const dbQuery = await getDBQuery(schema, knex, collection, fieldNodes, query);
+		const dbQuery = await getDBQuery(schema, knex, collection, fieldNodes, query, options?.accountability ?? null);
 
 		const rawItems: Item | Item[] = await dbQuery;
 
@@ -107,7 +109,11 @@ export default async function runAST(
 						},
 					});
 
-					nestedItems = (await runAST(node, schema, { knex, nested: true })) as Item[] | null;
+					nestedItems = (await runAST(node, schema, {
+						knex,
+						nested: true,
+						accountability: options?.accountability ?? null,
+					})) as Item[] | null;
 
 					if (nestedItems) {
 						items = mergeWithParentItems(schema, nestedItems, items!, nestedNode)!;
@@ -124,7 +130,11 @@ export default async function runAST(
 					query: { limit: -1 },
 				});
 
-				nestedItems = (await runAST(node, schema, { knex, nested: true })) as Item[] | null;
+				nestedItems = (await runAST(node, schema, {
+					knex,
+					nested: true,
+					accountability: options?.accountability ?? null,
+				})) as Item[] | null;
 
 				if (nestedItems) {
 					// Merge all fetched nested records with the parent items
@@ -244,7 +254,8 @@ async function getDBQuery(
 	knex: Knex,
 	table: string,
 	fieldNodes: (FieldNode | FunctionFieldNode)[],
-	query: Query
+	query: Query,
+	accountability?: Accountability | null
 ): Promise<Knex.QueryBuilder> {
 	const preProcess = getColumnPreprocessor(knex, schema, table);
 	const queryCopy = clone(query);
@@ -255,7 +266,8 @@ async function getDBQuery(
 	// Queries with aggregates and groupBy will not have duplicate result
 	if (queryCopy.aggregate || queryCopy.group) {
 		const flatQuery = knex.select(fieldNodes.map(preProcess)).from(table);
-		return await applyQuery(knex, table, flatQuery, queryCopy, schema).query;
+		return await applyQuery(knex, table, flatQuery, queryCopy, schema, { accountability: accountability ?? null })
+			.query;
 	}
 
 	const primaryKey = schema.collections[table]!.primary;
@@ -278,6 +290,7 @@ async function getDBQuery(
 		aliasMap,
 		isInnerQuery: true,
 		hasMultiRelationalSort,
+		accountability: accountability ?? null,
 	});
 
 	const needsInnerQuery = hasMultiRelationalSort || hasMultiRelationalFilter;

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -397,6 +397,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			knex: this.knex,
 			// GraphQL requires relational keys to be returned regardless
 			stripNonRequested: opts?.stripNonRequested !== undefined ? opts.stripNonRequested : true,
+			accountability: this.accountability,
 		});
 
 		if (records === null) {

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -1,0 +1,211 @@
+import type { Accountability, Permission, SchemaOverview } from '@cairncms/types';
+import knex from 'knex';
+import { describe, expect, it } from 'vitest';
+import { applySearch } from './apply-query.js';
+
+const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
+
+function makeField(name: string, type: 'string' | 'integer' | 'uuid' = 'string'): any {
+	return {
+		field: name,
+		defaultValue: null,
+		nullable: true,
+		generated: false,
+		type,
+		dbType: type === 'integer' ? 'integer' : type === 'uuid' ? 'uuid' : 'varchar',
+		precision: null,
+		scale: null,
+		special: [],
+		note: null,
+		validation: null,
+		alias: false,
+	};
+}
+
+function makeSchema(): SchemaOverview {
+	return {
+		collections: {
+			notes: {
+				collection: 'notes',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					title: makeField('title'),
+					body: makeField('body'),
+					secret_note: makeField('secret_note'),
+					rank: makeField('rank', 'integer'),
+				},
+			},
+		},
+		relations: [],
+	} as unknown as SchemaOverview;
+}
+
+function makeBuilder() {
+	return knex.default({ client: 'sqlite3', useNullAsDefault: true }).from('notes').select('*');
+}
+
+function makePermission(fields: string[] | null): Permission {
+	return {
+		id: 1,
+		role: 'role-uuid',
+		collection: 'notes',
+		action: 'read',
+		permissions: null,
+		validation: null,
+		presets: null,
+		fields,
+	};
+}
+
+function makeAccountability(overrides: Partial<Accountability> = {}): Accountability {
+	return {
+		user: 'user-uuid',
+		role: 'role-uuid',
+		admin: false,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [makePermission(['title', 'body'])],
+		...overrides,
+	};
+}
+
+describe('applySearch — field-permission scoping (GHSA-7wq3-jr35-275c)', () => {
+	describe('bug-exposing — restricted field excluded from search', () => {
+		it('non-admin caller with read permission on a subset of searchable fields scopes search to that subset', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [makePermission(['title', 'body'])] });
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).toContain('body');
+			expect(sql).not.toContain('secret_note');
+		});
+
+		it('non-admin caller with empty read fields produces a forced-false predicate', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [makePermission([])] });
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('1 = 0');
+			expect(sql).not.toContain('title');
+			expect(sql).not.toContain('secret_note');
+		});
+
+		it('non-admin caller with no matching read permission for the collection produces a forced-false predicate', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [] });
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('1 = 0');
+		});
+
+		it('non-admin caller whose only allowed field has a non-matching type for the search term produces a forced-false predicate', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [makePermission(['id'])] });
+
+			await applySearch(makeSchema(), dbQuery, 'not-a-uuid', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).not.toContain('LOWER(`notes`.`id`)');
+			expect(sql).toContain('1 = 0');
+		});
+	});
+
+	describe('regression guards — bypass paths preserved', () => {
+		it('admin caller (admin === true) bypasses the filter and searches all type-matching fields', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ admin: true, permissions: [] });
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).toContain('body');
+			expect(sql).toContain('secret_note');
+		});
+
+		it('null accountability bypasses the filter (internal/trusted-caller convention)', async () => {
+			const dbQuery = makeBuilder();
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', null);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).toContain('secret_note');
+		});
+
+		it('undefined accountability bypasses the filter (no accountability argument)', async () => {
+			const dbQuery = makeBuilder();
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes');
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).toContain('secret_note');
+		});
+
+		it('wildcard fields (["*"]) on the read permission bypasses the field filter', async () => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [makePermission(['*'])] });
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).toContain('secret_note');
+		});
+	});
+
+	describe('public-role enumeration (the advisory PoC surface)', () => {
+		it('public-role-shaped accountability with restricted read fields scopes search away from secret fields', async () => {
+			const dbQuery = makeBuilder();
+
+			const accountability: Accountability = {
+				user: null,
+				role: PUBLIC_ROLE_ID,
+				admin: false,
+				app: false,
+				ip: '127.0.0.1',
+				permissions: [
+					{
+						id: 99,
+						role: PUBLIC_ROLE_ID,
+						collection: 'notes',
+						action: 'read',
+						permissions: null,
+						validation: null,
+						presets: null,
+						fields: ['title'],
+					},
+				],
+			};
+
+			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).toContain('title');
+			expect(sql).not.toContain('secret_note');
+			expect(sql).not.toContain('body');
+		});
+	});
+});

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -1,4 +1,5 @@
 import type {
+	Accountability,
 	Aggregate,
 	ClientFilterOperator,
 	FieldFunction,
@@ -35,7 +36,12 @@ export default function applyQuery(
 	dbQuery: Knex.QueryBuilder,
 	query: Query,
 	schema: SchemaOverview,
-	options?: { aliasMap?: AliasMap; isInnerQuery?: boolean; hasMultiRelationalSort?: boolean | undefined }
+	options?: {
+		aliasMap?: AliasMap;
+		isInnerQuery?: boolean;
+		hasMultiRelationalSort?: boolean | undefined;
+		accountability?: Accountability | null;
+	}
 ) {
 	const aliasMap: AliasMap = options?.aliasMap ?? Object.create(null);
 	let hasMultiRelationalFilter = false;
@@ -55,7 +61,7 @@ export default function applyQuery(
 	}
 
 	if (query.search) {
-		applySearch(schema, dbQuery, query.search, collection);
+		applySearch(schema, dbQuery, query.search, collection, options?.accountability);
 	}
 
 	if (query.group) {
@@ -755,21 +761,53 @@ export async function applySearch(
 	schema: SchemaOverview,
 	dbQuery: Knex.QueryBuilder,
 	searchQuery: string,
-	collection: string
+	collection: string,
+	accountability?: Accountability | null
 ): Promise<void> {
-	const fields = Object.entries(schema.collections[collection]!.fields);
+	const allFields = Object.entries(schema.collections[collection]!.fields);
+
+	let searchableFields = allFields;
+
+	if (accountability && accountability.admin !== true) {
+		const readPermission = accountability.permissions?.find(
+			(perm) => perm.collection === collection && perm.action === 'read'
+		);
+
+		const allowed = readPermission?.fields ?? [];
+
+		if (!allowed.includes('*')) {
+			searchableFields = allFields.filter(([name]) => allowed.includes(name));
+		}
+	}
 
 	dbQuery.andWhere(function () {
-		fields.forEach(([name, field]) => {
+		if (searchableFields.length === 0) {
+			this.whereRaw('1 = 0');
+			return;
+		}
+
+		let emitted = false;
+
+		searchableFields.forEach(([name, field]) => {
 			if (['text', 'string'].includes(field.type)) {
 				this.orWhereRaw(`LOWER(??) LIKE ?`, [`${collection}.${name}`, `%${searchQuery.toLowerCase()}%`]);
+				emitted = true;
 			} else if (['bigInteger', 'integer', 'decimal', 'float'].includes(field.type)) {
 				const number = Number(searchQuery);
-				if (!isNaN(number)) this.orWhere({ [`${collection}.${name}`]: number });
+
+				if (!isNaN(number)) {
+					this.orWhere({ [`${collection}.${name}`]: number });
+					emitted = true;
+				}
 			} else if (field.type === 'uuid' && validate(searchQuery)) {
 				this.orWhere({ [`${collection}.${name}`]: searchQuery });
+				emitted = true;
 			}
 		});
+
+		if (!emitted) {
+			this.whereRaw('1 = 0');
+		}
 	});
 }
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-7wq3-jr35-275c / CVE-2025-30352.

The `search` query parameter searched across every searchable field in a collection, including fields the caller was not allowed to read. That allowed users to infer values in restricted fields from whether rows matched the search term.

This PR scopes search to fields the caller is permitted to read.

For non-admin callers, search now only generates predicates for readable fields on the target collection. If the caller has no readable searchable fields, or none of their readable fields are type-compatible with the search term, the search is forced to return no matches.

The fix is applied in the shared query layer, so it covers REST, GraphQL, and nested/deep search through the same path.

### Testing / verification

- Added `apply-query.test.ts` covering:
  - restricted fields excluded from search predicates
  - public-role-shaped accountability
  - empty-field and no-permission forced-false behavior
  - type-incompatible readable-field forced-false behavior
  - admin, wildcard, and internal null-accountability regressions

Also verified against a live SQLite instance and confirmed:
- searching for a value present only in a restricted field returns no rows for a restricted user
- searching a visible field still returns the expected rows
- admin search still covers restricted fields
- GraphQL search inherits the same restriction
- nested/deep search inherits the same restriction through recursive query execution

This closes the named search-based field-enumeration path without redesigning the broader permission model.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
