### PR TITLE
Avoid opening storage read streams for asset HEAD requests (GHSA-rv78…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Validated preset ownership on create and update (GHSA-3fff-gqw3-vj86 / CVE-2024-6534).
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
+- Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
 
 ### Acknowledgements
 

--- a/api/src/controllers/assets.test.ts
+++ b/api/src/controllers/assets.test.ts
@@ -1,0 +1,144 @@
+import type { Request, Response, NextFunction } from 'express';
+import express from 'express';
+import { Readable } from 'node:stream';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const VALID_UUID = '11111111-2222-4333-8444-555555555555';
+
+const { getAssetSpy, statAssetSpy } = vi.hoisted(() => ({
+	getAssetSpy: vi.fn(),
+	statAssetSpy: vi.fn(),
+}));
+
+vi.mock('../services/assets.js', () => {
+	const AssetsService = vi.fn();
+	AssetsService.prototype.getAsset = getAssetSpy;
+	AssetsService.prototype.statAsset = statAssetSpy;
+	return { AssetsService };
+});
+
+vi.mock('../services/payload.js', () => {
+	const PayloadService = vi.fn();
+	PayloadService.prototype.processValues = vi.fn(async () => undefined);
+	return { PayloadService };
+});
+
+vi.mock('../database/index.js', () => ({
+	default: () => ({
+		select: () => ({
+			from: () => ({
+				first: async () => undefined,
+			}),
+		}),
+	}),
+}));
+
+vi.mock('../env.js', () => {
+	const MOCK_ENV = {
+		ASSETS_CACHE_TTL: '30d',
+		ASSETS_TRANSFORM_MAX_OPERATIONS: 5,
+		ASSETS_CONTENT_SECURITY_POLICY: {},
+		ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION: 6000,
+		ASSETS_TRANSFORM_MAX_CONCURRENT: 25,
+		ASSETS_TRANSFORM_TIMEOUT: '7500ms',
+		ASSETS_INVALID_IMAGE_SENSITIVITY_LEVEL: 'warning',
+	};
+
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+import assetsRouter from './assets.js';
+
+function buildApp() {
+	const app = express();
+
+	app.use((req: Request, _res: Response, next: NextFunction) => {
+		(req as any).accountability = {
+			user: 'admin-uuid',
+			role: 'role-uuid',
+			admin: true,
+			app: true,
+			ip: '127.0.0.1',
+			permissions: [],
+		};
+
+		(req as any).schema = { collections: {}, relations: [] };
+		next();
+	});
+
+	app.use('/assets', assetsRouter);
+	return app;
+}
+
+function fakeFile() {
+	return {
+		id: VALID_UUID,
+		filename_disk: `${VALID_UUID}.jpg`,
+		filename_download: 'photo.jpg',
+		type: 'image/jpeg',
+		filesize: 1024,
+		width: 800,
+		height: 600,
+		modified_on: '2026-05-13T00:00:00.000Z',
+		storage: 's3',
+	};
+}
+
+describe('GET/HEAD /assets/:pk (GHSA-rv78-qqrq-73m5)', () => {
+	beforeEach(() => {
+		getAssetSpy.mockReset().mockResolvedValue({
+			stream: Readable.from(Buffer.from('test-body')),
+			file: fakeFile(),
+			stat: { size: 9 },
+		});
+
+		statAssetSpy.mockReset().mockResolvedValue({
+			file: fakeFile(),
+			stat: { size: 1024 },
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('HEAD request', () => {
+		it('does not invoke AssetsService.getAsset', async () => {
+			const app = buildApp();
+
+			const res = await request(app).head(`/assets/${VALID_UUID}`);
+
+			expect(res.status).toBe(200);
+			expect(getAssetSpy).not.toHaveBeenCalled();
+			expect(statAssetSpy).toHaveBeenCalledWith(VALID_UUID, expect.anything(), undefined);
+		});
+
+		it('omits Content-Length when statAsset returns stat: null (uncached transform)', async () => {
+			statAssetSpy.mockResolvedValue({
+				file: { ...fakeFile(), type: 'image/avif' },
+				stat: null,
+			});
+
+			const app = buildApp();
+			const res = await request(app).head(`/assets/${VALID_UUID}?width=313&format=avif`);
+
+			expect(res.status).toBe(200);
+			expect(res.headers['content-length']).toBeUndefined();
+			expect(res.headers['content-type']).toBe('image/avif');
+			expect(getAssetSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('GET request (regression)', () => {
+		it('invokes AssetsService.getAsset', async () => {
+			const app = buildApp();
+
+			const res = await request(app).get(`/assets/${VALID_UUID}`);
+
+			expect(res.status).toBe(200);
+			expect(getAssetSpy).toHaveBeenCalledWith(VALID_UUID, expect.anything(), undefined);
+			expect(statAssetSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -185,6 +185,36 @@ router.get(
 			}
 		}
 
+		if (req.method.toLowerCase() === 'head') {
+			const { file, stat } = await service.statAsset(id, transformation, range);
+
+			const filename = req.params['filename'] ?? file.filename_download;
+			res.attachment(filename);
+			res.setHeader('Content-Type', file.type);
+			res.setHeader('Accept-Ranges', 'bytes');
+
+			res.setHeader('Cache-Control', getCacheControlHeader(req, getMilliseconds(env['ASSETS_CACHE_TTL']), false, true));
+
+			res.setHeader('Vary', vary.join(', '));
+
+			const unixTime = Date.parse(file.modified_on);
+
+			if (!Number.isNaN(unixTime)) {
+				res.setHeader('Last-Modified', new Date(unixTime).toUTCString());
+			}
+
+			if ('download' in req.query === false) {
+				res.setHeader('Content-Disposition', contentDisposition(filename, { type: 'inline' }));
+			}
+
+			if (stat) {
+				res.setHeader('Content-Length', stat.size);
+			}
+
+			res.status(200);
+			return res.end();
+		}
+
 		const { stream, file, stat } = await service.getAsset(id, transformation, range);
 
 		const filename = req.params['filename'] ?? file.filename_download;
@@ -211,14 +241,6 @@ router.get(
 
 		if ('download' in req.query === false) {
 			res.setHeader('Content-Disposition', contentDisposition(filename, { type: 'inline' }));
-		}
-
-		if (req.method.toLowerCase() === 'head') {
-			res.status(200);
-			res.setHeader('Accept-Ranges', 'bytes');
-			res.setHeader('Content-Length', stat.size);
-
-			return res.end();
 		}
 
 		let isDataSent = false;

--- a/api/src/services/assets.test.ts
+++ b/api/src/services/assets.test.ts
@@ -1,0 +1,269 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient, Tracker } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForbiddenException, RangeNotSatisfiableException } from '../exceptions/index.js';
+import { AssetsService } from './assets.js';
+
+const VALID_UUID = '11111111-2222-4333-8444-555555555555';
+const INVALID_UUID = 'not-a-uuid';
+const FILE_DISK_NAME = '11111111-2222-4333-8444-555555555555.jpg';
+
+const storageRead = vi.fn<[string, any?], Promise<any>>();
+const storageStat = vi.fn<[string], Promise<{ size: number }>>(async () => ({ size: 1024 }));
+const storageExists = vi.fn<[string], Promise<boolean>>(async () => true);
+const storageWrite = vi.fn<[string, any, any?], Promise<void>>(async () => undefined);
+
+vi.mock('../storage/index.js', () => ({
+	getStorage: vi.fn(async () => ({
+		location: () => ({
+			read: storageRead,
+			stat: storageStat,
+			exists: storageExists,
+			write: storageWrite,
+		}),
+	})),
+}));
+
+const checkAccessSpy = vi.fn();
+
+vi.mock('./authorization.js', () => ({
+	AuthorizationService: vi.fn().mockImplementation(() => ({
+		checkAccess: checkAccessSpy,
+	})),
+}));
+
+vi.mock('../database/index.js', () => ({
+	default: vi.fn(),
+}));
+
+function makeFileRow(overrides: Partial<Record<string, any>> = {}) {
+	return {
+		id: VALID_UUID,
+		filename_disk: FILE_DISK_NAME,
+		filename_download: 'photo.jpg',
+		type: 'image/jpeg',
+		filesize: 1024,
+		width: 800,
+		height: 600,
+		modified_on: '2026-05-13T00:00:00.000Z',
+		storage: 's3',
+		...overrides,
+	};
+}
+
+function primeKnex(tracker: Tracker, fileRow: Record<string, any> | null = makeFileRow()) {
+	tracker.on.select('directus_settings').response({});
+
+	if (fileRow) {
+		tracker.on.select('directus_files').response([fileRow]);
+	} else {
+		tracker.on.select('directus_files').response([]);
+	}
+}
+
+describe('AssetsService.statAsset (GHSA-rv78-qqrq-73m5)', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+	const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+	const adminAccountability: Accountability = {
+		user: 'admin-uuid',
+		role: 'role-uuid',
+		admin: true,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [],
+	};
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	beforeEach(() => {
+		storageRead.mockReset();
+		storageStat.mockReset().mockResolvedValue({ size: 1024 });
+		storageExists.mockReset().mockResolvedValue(true);
+		storageWrite.mockReset().mockResolvedValue(undefined);
+		checkAccessSpy.mockReset().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	describe('no transformation requested', () => {
+		it('returns stat from the source file and never opens a read stream', async () => {
+			primeKnex(tracker);
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+			const result = await service.statAsset(VALID_UUID, {});
+
+			expect(result.file.id).toBe(VALID_UUID);
+			expect(result.stat).toEqual({ size: 1024 });
+			expect(storageStat).toHaveBeenCalledWith(FILE_DISK_NAME);
+			expect(storageRead).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('transformation requested, cached variant exists', () => {
+		it('returns stat from the cached variant filename, not the source filename', async () => {
+			primeKnex(tracker);
+			storageExists.mockImplementation(async (name: string) => name !== FILE_DISK_NAME || true);
+			storageStat.mockImplementation(async (name: string) => ({ size: name === FILE_DISK_NAME ? 1024 : 256 }));
+
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+			const result = await service.statAsset(VALID_UUID, { width: 100 });
+
+			expect(result.stat).not.toBeNull();
+			expect(result.stat!.size).toBe(256);
+			expect(storageRead).not.toHaveBeenCalled();
+
+			const statCalls = storageStat.mock.calls.map((call) => call[0]);
+
+			expect(
+				statCalls.some((name) => name !== FILE_DISK_NAME && name.startsWith('11111111-2222-4333-8444-555555555555__'))
+			).toBe(true);
+		});
+	});
+
+	describe('transformation requested, cached variant does NOT exist', () => {
+		it('returns { file, stat: null } without triggering sharp or reading the source', async () => {
+			primeKnex(tracker);
+			storageExists.mockImplementation(async (name: string) => name === FILE_DISK_NAME);
+
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+			const result = await service.statAsset(VALID_UUID, { width: 313, format: 'avif' });
+
+			expect(result.stat).toBeNull();
+			expect(storageRead).not.toHaveBeenCalled();
+			expect(storageWrite).not.toHaveBeenCalled();
+		});
+
+		it('sets file.type to the requested format even when stat is null', async () => {
+			primeKnex(tracker);
+			storageExists.mockImplementation(async (name: string) => name === FILE_DISK_NAME);
+
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+			const result = await service.statAsset(VALID_UUID, { format: 'webp' });
+
+			expect(result.file.type).toBe('image/webp');
+			expect(result.stat).toBeNull();
+		});
+	});
+
+	describe('permission and validation gating', () => {
+		it('invokes checkAccess for non-admin callers when the file is not a system public key', async () => {
+			primeKnex(tracker);
+
+			const nonAdminAccountability: Accountability = {
+				user: 'user-uuid',
+				role: 'role-uuid',
+				admin: false,
+				app: true,
+				ip: '127.0.0.1',
+				permissions: [],
+			};
+
+			const service = new AssetsService({ knex: db, accountability: nonAdminAccountability, schema });
+			await service.statAsset(VALID_UUID, {});
+
+			expect(checkAccessSpy).toHaveBeenCalledWith('read', 'directus_files', VALID_UUID);
+		});
+
+		it('throws ForbiddenException for invalid UUIDs', async () => {
+			primeKnex(tracker);
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+			await expect(service.statAsset(INVALID_UUID, {})).rejects.toBeInstanceOf(ForbiddenException);
+			expect(storageRead).not.toHaveBeenCalled();
+		});
+
+		it('throws ForbiddenException when the file row is missing', async () => {
+			primeKnex(tracker, null);
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+			await expect(service.statAsset(VALID_UUID, {})).rejects.toBeInstanceOf(ForbiddenException);
+			expect(storageRead).not.toHaveBeenCalled();
+		});
+
+		it('throws ForbiddenException when the source file is missing from storage', async () => {
+			primeKnex(tracker);
+			storageExists.mockResolvedValue(false);
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+			await expect(service.statAsset(VALID_UUID, {})).rejects.toBeInstanceOf(ForbiddenException);
+			expect(storageRead).not.toHaveBeenCalled();
+		});
+
+		it('throws RangeNotSatisfiableException for a malformed range', async () => {
+			primeKnex(tracker);
+			const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+			await expect(service.statAsset(VALID_UUID, {}, {})).rejects.toBeInstanceOf(RangeNotSatisfiableException);
+			expect(storageRead).not.toHaveBeenCalled();
+		});
+	});
+});
+
+describe('AssetsService.getAsset (regression — must still open a storage read)', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+	const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+	const adminAccountability: Accountability = {
+		user: 'admin-uuid',
+		role: 'role-uuid',
+		admin: true,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [],
+	};
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	beforeEach(() => {
+		storageRead.mockReset().mockResolvedValue({
+			on: vi.fn(),
+			pipe: vi.fn(),
+			destroy: vi.fn(),
+		});
+
+		storageStat.mockReset().mockResolvedValue({ size: 1024 });
+		storageExists.mockReset().mockResolvedValue(true);
+		storageWrite.mockReset().mockResolvedValue(undefined);
+		checkAccessSpy.mockReset().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	it('opens a storage read on the non-transform path', async () => {
+		primeKnex(tracker);
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+		await service.getAsset(VALID_UUID, {});
+
+		expect(storageRead).toHaveBeenCalled();
+		expect(storageRead.mock.calls[0]![0]).toBe(FILE_DISK_NAME);
+	});
+
+	it('opens a storage read on the transform-cached path', async () => {
+		primeKnex(tracker);
+		storageExists.mockImplementation(async () => true);
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+		await service.getAsset(VALID_UUID, { width: 100 });
+
+		expect(storageRead).toHaveBeenCalled();
+		const readPaths = storageRead.mock.calls.map((call) => call[0]);
+		expect(readPaths.some((name) => name.startsWith('11111111-2222-4333-8444-555555555555__'))).toBe(true);
+	});
+});

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -22,6 +22,17 @@ import { getMilliseconds } from '../utils/get-milliseconds.js';
 import * as TransformationUtils from '../utils/transformations.js';
 import { AuthorizationService } from './authorization.js';
 
+type StorageLocation = Awaited<ReturnType<typeof getStorage>>['location'] extends (name: string) => infer L ? L : never;
+
+type ResolvedAsset = {
+	file: File;
+	storageLocation: StorageLocation;
+	sourceFilename: string;
+	transforms: Transformation[];
+	transformedFilename: string | null;
+	transformedExists: boolean;
+};
+
 export class AssetsService {
 	knex: Knex;
 	accountability: Accountability | null;
@@ -33,107 +44,46 @@ export class AssetsService {
 		this.authorizationService = new AuthorizationService(options);
 	}
 
+	async statAsset(
+		id: string,
+		transformation: TransformationParams,
+		range?: Range
+	): Promise<{ file: any; stat: Stat | null }> {
+		const { file, storageLocation, sourceFilename, transformedFilename, transformedExists } = await this._resolveAsset(
+			id,
+			transformation,
+			range
+		);
+
+		if (transformedFilename) {
+			if (transformedExists) {
+				return { file, stat: await storageLocation.stat(transformedFilename) };
+			}
+
+			return { file, stat: null };
+		}
+
+		return { file, stat: await storageLocation.stat(sourceFilename) };
+	}
+
 	async getAsset(
 		id: string,
 		transformation: TransformationParams,
 		range?: Range
 	): Promise<{ stream: Readable; file: any; stat: Stat }> {
-		const storage = await getStorage();
+		const { file, storageLocation, sourceFilename, transforms, transformedFilename, transformedExists } =
+			await this._resolveAsset(id, transformation, range);
 
-		const publicSettings = await this.knex
-			.select('project_logo', 'public_background', 'public_foreground')
-			.from('directus_settings')
-			.first();
-
-		const systemPublicKeys = Object.values(publicSettings || {});
-
-		/**
-		 * This is a little annoying. Postgres will error out if you're trying to search in `where`
-		 * with a wrong type. In case of directus_files where id is a uuid, we'll have to verify the
-		 * validity of the uuid ahead of time.
-		 */
-		const isValidUUID = validateUUID(id, 4);
-
-		if (isValidUUID === false) throw new ForbiddenException();
-
-		if (systemPublicKeys.includes(id) === false && this.accountability?.admin !== true) {
-			await this.authorizationService.checkAccess('read', 'directus_files', id);
-		}
-
-		const file = (await this.knex.select('*').from('directus_files').where({ id }).first()) as File;
-
-		if (!file) throw new ForbiddenException();
-
-		const exists = await storage.location(file.storage).exists(file.filename_disk);
-
-		if (!exists) throw new ForbiddenException();
-
-		if (range) {
-			const missingRangeLimits = range.start === undefined && range.end === undefined;
-			const endBeforeStart = range.start !== undefined && range.end !== undefined && range.end <= range.start;
-			const startOverflow = range.start !== undefined && range.start >= file.filesize;
-			const endUnderflow = range.end !== undefined && range.end <= 0;
-
-			if (missingRangeLimits || endBeforeStart || startOverflow || endUnderflow) {
-				throw new RangeNotSatisfiableException(range);
-			}
-
-			const lastByte = file.filesize - 1;
-
-			if (range.end) {
-				if (range.start === undefined) {
-					// fetch chunk from tail
-					range.start = file.filesize - range.end;
-					range.end = lastByte;
-				}
-
-				if (range.end >= file.filesize) {
-					// fetch entire file
-					range.end = lastByte;
-				}
-			}
-
-			if (range.start) {
-				if (range.end === undefined) {
-					// fetch entire file
-					range.end = lastByte;
-				}
-
-				if (range.start < 0) {
-					// fetch file from head
-					range.start = 0;
-				}
-			}
-		}
-
-		const type = file.type;
-		const transforms = TransformationUtils.resolvePreset(transformation, file);
-
-		if (type && transforms.length > 0 && SUPPORTED_IMAGE_TRANSFORM_FORMATS.includes(type)) {
-			const maybeNewFormat = TransformationUtils.maybeExtractFormat(transforms);
-
-			const assetFilename =
-				path.basename(file.filename_disk, path.extname(file.filename_disk)) +
-				getAssetSuffix(transforms) +
-				(maybeNewFormat ? `.${maybeNewFormat}` : path.extname(file.filename_disk));
-
-			const exists = await storage.location(file.storage).exists(assetFilename);
-
-			if (maybeNewFormat) {
-				file.type = contentType(assetFilename) || null;
-			}
-
-			if (exists) {
+		if (transformedFilename) {
+			if (transformedExists) {
 				return {
-					stream: await storage.location(file.storage).read(assetFilename, range),
+					stream: await storageLocation.read(transformedFilename, range),
 					file,
-					stat: await storage.location(file.storage).stat(assetFilename),
+					stat: await storageLocation.stat(transformedFilename),
 				};
 			}
 
-			// Check image size before transforming. Processing an image that's too large for the
-			// system memory will kill the API. Sharp technically checks for this too in it's
-			// limitInputPixels, but we should have that check applied before starting the read streams
+			// Dimension precheck must precede the read stream; sharp's own limitInputPixels fires too late.
 			const { width, height } = file;
 
 			if (
@@ -155,7 +105,7 @@ export class AssetsService {
 				});
 			}
 
-			const readStream = await storage.location(file.storage).read(file.filename_disk, range);
+			const readStream = await storageLocation.read(sourceFilename, range);
 
 			const transformer = sharp({
 				limitInputPixels: Math.pow(env['ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION'], 2),
@@ -176,18 +126,117 @@ export class AssetsService {
 				readStream.unpipe(transformer);
 			});
 
-			await storage.location(file.storage).write(assetFilename, readStream.pipe(transformer), type);
+			await storageLocation.write(transformedFilename, readStream.pipe(transformer), file.type ?? undefined);
 
 			return {
-				stream: await storage.location(file.storage).read(assetFilename, range),
-				stat: await storage.location(file.storage).stat(assetFilename),
+				stream: await storageLocation.read(transformedFilename, range),
+				stat: await storageLocation.stat(transformedFilename),
 				file,
 			};
-		} else {
-			const readStream = await storage.location(file.storage).read(file.filename_disk, range);
-			const stat = await storage.location(file.storage).stat(file.filename_disk);
-			return { stream: readStream, file, stat };
 		}
+
+		const readStream = await storageLocation.read(sourceFilename, range);
+		const stat = await storageLocation.stat(sourceFilename);
+		return { stream: readStream, file, stat };
+	}
+
+	private async _resolveAsset(id: string, transformation: TransformationParams, range?: Range): Promise<ResolvedAsset> {
+		const storage = await getStorage();
+
+		const publicSettings = await this.knex
+			.select('project_logo', 'public_background', 'public_foreground')
+			.from('directus_settings')
+			.first();
+
+		const systemPublicKeys = Object.values(publicSettings || {});
+
+		// Postgres errors when a non-UUID string is used in a WHERE on a UUID column; validate up front.
+		const isValidUUID = validateUUID(id, 4);
+
+		if (isValidUUID === false) throw new ForbiddenException();
+
+		if (systemPublicKeys.includes(id) === false && this.accountability?.admin !== true) {
+			await this.authorizationService.checkAccess('read', 'directus_files', id);
+		}
+
+		const file = (await this.knex.select('*').from('directus_files').where({ id }).first()) as File;
+
+		if (!file) throw new ForbiddenException();
+
+		const storageLocation = storage.location(file.storage);
+		const exists = await storageLocation.exists(file.filename_disk);
+
+		if (!exists) throw new ForbiddenException();
+
+		if (range) {
+			const missingRangeLimits = range.start === undefined && range.end === undefined;
+			const endBeforeStart = range.start !== undefined && range.end !== undefined && range.end <= range.start;
+			const startOverflow = range.start !== undefined && range.start >= file.filesize;
+			const endUnderflow = range.end !== undefined && range.end <= 0;
+
+			if (missingRangeLimits || endBeforeStart || startOverflow || endUnderflow) {
+				throw new RangeNotSatisfiableException(range);
+			}
+
+			const lastByte = file.filesize - 1;
+
+			if (range.end) {
+				if (range.start === undefined) {
+					range.start = file.filesize - range.end;
+					range.end = lastByte;
+				}
+
+				if (range.end >= file.filesize) {
+					range.end = lastByte;
+				}
+			}
+
+			if (range.start) {
+				if (range.end === undefined) {
+					range.end = lastByte;
+				}
+
+				if (range.start < 0) {
+					range.start = 0;
+				}
+			}
+		}
+
+		const type = file.type;
+		const transforms = TransformationUtils.resolvePreset(transformation, file);
+
+		if (!type || transforms.length === 0 || !SUPPORTED_IMAGE_TRANSFORM_FORMATS.includes(type)) {
+			return {
+				file,
+				storageLocation,
+				sourceFilename: file.filename_disk,
+				transforms,
+				transformedFilename: null,
+				transformedExists: false,
+			};
+		}
+
+		const maybeNewFormat = TransformationUtils.maybeExtractFormat(transforms);
+
+		const transformedFilename =
+			path.basename(file.filename_disk, path.extname(file.filename_disk)) +
+			getAssetSuffix(transforms) +
+			(maybeNewFormat ? `.${maybeNewFormat}` : path.extname(file.filename_disk));
+
+		if (maybeNewFormat) {
+			file.type = contentType(transformedFilename) || null;
+		}
+
+		const transformedExists = await storageLocation.exists(transformedFilename);
+
+		return {
+			file,
+			storageLocation,
+			sourceFilename: file.filename_disk,
+			transforms,
+			transformedFilename,
+			transformedExists,
+		};
 	}
 }
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-rv78-qqrq-73m5 / CVE-2025-30350.

`HEAD /assets/:id` opened the storage read stream through `AssetsService.getAsset()` before the controller returned the HEAD response. On S3-backed storage, those unconsumed streams held HTTP sockets in the SDK pool, so a burst of HEAD requests could exhaust `STORAGE_CLOUD_MAX_SOCKETS` and make later asset reads fail or stall.

This PR gives HEAD requests a stat-only path. The controller now branches before `getAsset()`, and `AssetsService.statAsset()` performs the same asset resolution, permission checks, and range validation without opening a body stream.

For transformed assets, cached variants still return an accurate `Content-Length` from storage stat. Uncached transformed HEAD requests no longer trigger the transform pipeline just to compute a response length; they return headers without `Content-Length` instead.

### Testing / verification

- Added `assets.test.ts` controller coverage for:
  - HEAD using `statAsset()` instead of `getAsset()`
  - GET continuing to use `getAsset()`
  - uncached transformed HEAD responses omitting `Content-Length`
- Added `assets.test.ts` service coverage for:
  - `statAsset()` returning stats without calling `storage.read()`
  - cached and uncached transform behavior
  - permission, UUID, existence, and range validation parity
  - `getAsset()` regression coverage on existing GET paths

Also verified against a live MinIO-backed instance with `STORAGE_CLOUD_MAX_SOCKETS=4` and confirmed:
- HEAD requests issue only metadata object calls and never a body-bearing `GetObject`
- 50 concurrent HEAD requests complete without exhausting the socket pool
- a follow-up GET succeeds immediately after the HEAD burst
- GET behavior is unchanged for both plain assets and generated transforms
- cached transformed HEAD responses preserve accurate `Content-Length`
- uncached transformed HEAD responses omit `Content-Length` and do not trigger a transform

This closes the named HEAD-driven socket exhaustion path and deliberately avoids unnecessary transform work on uncached transformed HEAD requests.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
