### PR TITLE
Validate asset transform args before opening source stream (GHSA-j8xj…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
+- Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 
 ### Acknowledgements
 

--- a/api/src/services/assets.test.ts
+++ b/api/src/services/assets.test.ts
@@ -39,6 +39,32 @@ vi.mock('../database/index.js', () => ({
 	default: vi.fn(),
 }));
 
+const { sharpInstance, sharpFactory, loggerErrorSpy } = vi.hoisted(() => {
+	const instance: any = {};
+	instance.timeout = vi.fn(() => instance);
+	instance.rotate = vi.fn(() => instance);
+	instance.resize = vi.fn(() => instance);
+	instance.toFormat = vi.fn(() => instance);
+	instance.on = vi.fn(() => instance);
+	instance.pipe = vi.fn(() => instance);
+	const factory: any = vi.fn(() => instance);
+	factory.counters = vi.fn(() => ({ queue: 0, process: 0 }));
+	return { sharpInstance: instance, sharpFactory: factory, loggerErrorSpy: vi.fn() };
+});
+
+vi.mock('sharp', () => ({ default: sharpFactory }));
+
+vi.mock('../logger.js', () => ({
+	default: {
+		error: loggerErrorSpy,
+		warn: vi.fn(),
+		info: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+	},
+}));
+
 function makeFileRow(overrides: Partial<Record<string, any>> = {}) {
 	return {
 		id: VALID_UUID,
@@ -265,5 +291,135 @@ describe('AssetsService.getAsset (regression — must still open a storage read)
 		expect(storageRead).toHaveBeenCalled();
 		const readPaths = storageRead.mock.calls.map((call) => call[0]);
 		expect(readPaths.some((name) => name.startsWith('11111111-2222-4333-8444-555555555555__'))).toBe(true);
+	});
+});
+
+describe('AssetsService.getAsset uncached-transform pipeline (GHSA-j8xj-7jff-46mx)', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+	const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+	const adminAccountability: Accountability = {
+		user: 'admin-uuid',
+		role: 'role-uuid',
+		admin: true,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [],
+	};
+
+	function buildFakeReadStream() {
+		const handlers: Record<string, (...args: any[]) => void> = {};
+
+		const stream: any = {
+			on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+				handlers[event] = handler;
+				return stream;
+			}),
+			pipe: vi.fn(() => stream),
+			unpipe: vi.fn(() => stream),
+			destroy: vi.fn(),
+			__fireError: (err: Error) => handlers['error']?.(err),
+		};
+
+		return stream;
+	}
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	beforeEach(() => {
+		storageRead.mockReset();
+		storageStat.mockReset().mockResolvedValue({ size: 1024 });
+		storageWrite.mockReset().mockResolvedValue(undefined);
+		checkAccessSpy.mockReset().mockResolvedValue(undefined);
+		storageExists.mockReset().mockImplementation(async (name: string) => name === FILE_DISK_NAME);
+		sharpFactory.mockClear();
+		sharpInstance.timeout.mockClear();
+		sharpInstance.rotate.mockClear();
+		sharpInstance.resize.mockClear();
+		sharpInstance.toFormat.mockClear();
+		sharpInstance.on.mockClear();
+		sharpInstance.pipe.mockClear();
+		loggerErrorSpy.mockReset();
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	it('does not open the source read stream when a transform method throws on apply', async () => {
+		primeKnex(tracker);
+
+		sharpInstance.resize.mockImplementationOnce(() => {
+			throw new Error('sharp: bad resize args');
+		});
+
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+		await expect(service.getAsset(VALID_UUID, { width: 100 })).rejects.toThrow(/bad resize args/);
+
+		expect(storageRead).not.toHaveBeenCalled();
+	});
+
+	it('destroys the source read stream and rethrows when storage.write rejects', async () => {
+		primeKnex(tracker);
+		const fakeReadStream = buildFakeReadStream();
+		storageRead.mockResolvedValue(fakeReadStream);
+		storageWrite.mockRejectedValueOnce(new Error('s3 write failed'));
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+		await expect(service.getAsset(VALID_UUID, { width: 100 })).rejects.toThrow(/s3 write failed/);
+
+		expect(fakeReadStream.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('opens the source read stream on a valid transform (regression)', async () => {
+		primeKnex(tracker);
+		const fakeSourceStream = buildFakeReadStream();
+		const fakeCachedStream = buildFakeReadStream();
+		storageRead.mockResolvedValueOnce(fakeSourceStream).mockResolvedValueOnce(fakeCachedStream);
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+
+		await service.getAsset(VALID_UUID, { width: 100 });
+
+		expect(storageRead).toHaveBeenCalled();
+		expect(storageRead.mock.calls[0]![0]).toBe(FILE_DISK_NAME);
+		expect(fakeSourceStream.destroy).not.toHaveBeenCalled();
+		expect(storageWrite).toHaveBeenCalledTimes(1);
+	});
+
+	it('logs read-stream errors via the error handler while cleanup and rejection flow through the write catch', async () => {
+		primeKnex(tracker);
+		const fakeReadStream = buildFakeReadStream();
+		storageRead.mockResolvedValue(fakeReadStream);
+
+		let rejectWrite: (err: Error) => void = () => undefined;
+
+		storageWrite.mockImplementationOnce(
+			() =>
+				new Promise<void>((_resolve, reject) => {
+					rejectWrite = reject;
+				})
+		);
+
+		const service = new AssetsService({ knex: db, accountability: adminAccountability, schema });
+		const pending = service.getAsset(VALID_UUID, { width: 100 });
+
+		while (fakeReadStream.on.mock.calls.find((c: any[]) => c[0] === 'error') === undefined) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+
+		const readErr = new Error('s3 stream dropped');
+		fakeReadStream.__fireError(readErr);
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(readErr, expect.stringContaining(VALID_UUID));
+
+		rejectWrite(new Error('pipe broken'));
+
+		await expect(pending).rejects.toThrow(/pipe broken/);
+		expect(fakeReadStream.destroy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -105,8 +105,6 @@ export class AssetsService {
 				});
 			}
 
-			const readStream = await storageLocation.read(sourceFilename, range);
-
 			const transformer = sharp({
 				limitInputPixels: Math.pow(env['ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION'], 2),
 				sequentialRead: true,
@@ -121,12 +119,18 @@ export class AssetsService {
 
 			transforms.forEach(([method, ...args]) => (transformer[method] as any).apply(transformer, args));
 
+			const readStream = await storageLocation.read(sourceFilename, range);
+
 			readStream.on('error', (e: Error) => {
 				logger.error(e, `Couldn't transform file ${file.id}`);
-				readStream.unpipe(transformer);
 			});
 
-			await storageLocation.write(transformedFilename, readStream.pipe(transformer), file.type ?? undefined);
+			try {
+				await storageLocation.write(transformedFilename, readStream.pipe(transformer), file.type ?? undefined);
+			} catch (err) {
+				readStream.destroy();
+				throw err;
+			}
 
 			return {
 				stream: await storageLocation.read(transformedFilename, range),


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-j8xj-7jff-46mx / CVE-2025-30225.

Uncached asset transforms opened the source storage stream before the sharp transform configuration was fully applied. If sharp rejected malformed transform arguments during eager validation, the request exited with the S3 `GetObject` stream still open, which could pin sockets in the storage client's pool and degrade later asset reads.

This PR fixes that in two steps:
- build and validate the sharp transform pipeline before opening the source stream
- once the source stream is open, explicitly destroy it if the transform/write path fails

That closes the named malformed-transform leak and also hardens the same uncached-transform path against write-time failures on the already-open stream.

### Testing / verification

- Added `assets.test.ts` coverage for:
  - malformed transform rejection before `storage.read()` is called
  - destroying the source stream when `storage.write()` rejects
  - valid uncached transforms still reading and writing normally
  - read-stream error logging with cleanup and rejection flowing through the write catch

Also verified against a live MinIO-backed instance with `STORAGE_CLOUD_MAX_SOCKETS=4` and confirmed:
- malformed transform requests return an error without issuing `GetObject`
- a burst of malformed transform requests no longer exhausts the socket pool
- a follow-up plain asset GET succeeds immediately after the burst
- valid transforms still generate and cache correctly
- repeated valid transform requests hit the cached variant on subsequent reads

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
