### PR TITLE
Remove version from public OpenAPI spec (GHSA-rmjh-cf9q-pv7q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
+- Removed version string from OpenAPI spec responses (GHSA-rmjh-cf9q-pv7q / CVE-2025-53887).
 
 ### Acknowledgements
 

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -436,6 +436,32 @@ describe('Integration Tests', () => {
 						expect(targetSchema).not.toHaveProperty('type');
 					});
 				});
+
+				describe('info (GHSA-rmjh-cf9q-pv7q)', () => {
+					it('does not disclose the running package version as info.version', async () => {
+						const { version: packageVersion } = await import('../utils/package.js');
+						vi.spyOn(CollectionsService.prototype, 'readByQuery').mockResolvedValue([]);
+						vi.spyOn(FieldsService.prototype, 'readAll').mockResolvedValue([]);
+						vi.spyOn(RelationsService.prototype, 'readAll').mockResolvedValue([]);
+
+						const spec = await service.oas.generate();
+
+						expect(typeof spec.info.version).toBe('string');
+						expect(spec.info.version.length).toBeGreaterThan(0);
+						expect(spec.info.version).not.toBe(packageVersion);
+					});
+
+					it('returns a stable info.version for repeated calls against the same spec input', async () => {
+						vi.spyOn(CollectionsService.prototype, 'readByQuery').mockResolvedValue([]);
+						vi.spyOn(FieldsService.prototype, 'readAll').mockResolvedValue([]);
+						vi.spyOn(RelationsService.prototype, 'readAll').mockResolvedValue([]);
+
+						const first = await service.oas.generate();
+						const second = await service.oas.generate();
+
+						expect(first.info.version).toBe(second.info.version);
+					});
+				});
 			});
 		});
 	});

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -1,6 +1,7 @@
 import { spec } from '@cairncms/specs';
 import type { Knex } from 'knex';
 import { cloneDeep, mergeWith } from 'lodash-es';
+import hash from 'object-hash';
 import type {
 	OpenAPIObject,
 	ParameterObject,
@@ -10,7 +11,6 @@ import type {
 	TagObject,
 } from 'openapi3-ts';
 import type { Accountability, Field, Permission, Relation, SchemaOverview, Type } from '@cairncms/types';
-import { version } from '../utils/package.js';
 import { OAS_REQUIRED_SCHEMAS } from '../constants.js';
 import getDatabase from '../database/index.js';
 import env from '../env.js';
@@ -97,13 +97,18 @@ class OASSpecsService implements SpecificationSubService {
 		const paths = await this.generatePaths(permissions, tags);
 		const components = await this.generateComponents(collections, fields, relations, tags);
 
+		const oasDocumentVersion = hash(
+			{ openapi: '3.0.1', tags, paths, components },
+			{ algorithm: 'sha1', encoding: 'hex' }
+		).slice(0, 16);
+
 		const spec: OpenAPIObject = {
 			openapi: '3.0.1',
 			info: {
 				title: 'Dynamic API Specification',
 				description:
 					'This is a dynamically generated API specification for all endpoints existing on the current project.',
-				version: version,
+				version: oasDocumentVersion,
 			},
 			servers: [
 				{


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-rmjh-cf9q-pv7q / CVE-2025-53887.

The OpenAPI document emitted by `SpecificationService.oas.generate()` used the running package version as `info.version`. That exposed the deployed CairnCMS/API version through the OAS spec surface.

This PR stops using the package version for `info.version` and replaces it with a deterministic hash of the generated OAS document shape (`openapi`, `tags`, `paths`, `components`). The result is:
- stable for repeated calls against the same effective spec
- different when the effective spec changes
- different for different permission-scoped spec views
- non-sensitive, because it no longer reveals the server software version

The fix is in the shared OAS generator, so it covers both REST `/server/specs/oas` and GraphQL `server_specs_oas`.

### Testing / verification

- Added `specifications.test.ts` coverage for:
  - `info.version` no longer matching the running package version
  - `info.version` remaining stable across repeated calls for the same spec input

Also verified against a live SQLite instance and confirmed:
- admin REST `/server/specs/oas` returns a stable 16-character hex hash in `info.version`
- repeated admin REST calls return the same hash
- a lower-privileged caller with a narrower spec view gets a different hash
- GraphQL `server_specs_oas` returns the same hash as REST for the same caller
- admin `/server/info` still exposes the real package version intentionally

In this version of the codebase, the REST OAS endpoint was not literally public to anonymous callers; it was gated by system-collection read permissions. The disclosure still existed for lower-privileged authenticated users, and this fix removes the running package version from that surface.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
