### PR TITLE
Require read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
+- Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 
 ### Acknowledgements

--- a/api/src/flows.test.ts
+++ b/api/src/flows.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { REDACT_TEXT } from './constants.js';
+import * as exceptions from './exceptions/index.js';
 import { buildRevisionData, getFlowManager, type Step } from './flows.js';
 import conditionOp from './operations/condition/index.js';
+
+const { checkAccessSpy } = vi.hoisted(() => ({ checkAccessSpy: vi.fn() }));
+
+vi.mock('./database/index.js', () => ({
+	default: vi.fn(() => ({})),
+}));
+
+vi.mock('./services/authorization.js', () => {
+	const AuthorizationService = vi.fn();
+	AuthorizationService.prototype.checkAccess = checkAccessSpy;
+	return { AuthorizationService };
+});
 
 const TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.HEADER_PAYLOAD_LONG_ENOUGH_TO_BE_REAL_TOKEN';
 
@@ -145,5 +158,185 @@ describe('executeFlow — webhook trigger with failing condition does not leak c
 
 		expect(blob).not.toContain('TOKEN_MARKER_CCC_DO_NOT_LEAK');
 		expect(blob).not.toContain('USER_MARKER_BBB_DO_NOT_LEAK');
+	});
+});
+
+describe('FlowManager._runManualFlow (GHSA-7cvf-pxgp-42fc)', () => {
+	const FLOW_ID = 'manual-flow-id';
+	const TARGET_COLLECTION = 'articles';
+	const TARGET_KEYS = ['article-1', 'article-2'];
+
+	function buildFlow(overrides: { options?: Record<string, unknown> } = {}): any {
+		return {
+			id: FLOW_ID,
+			name: 'Manual Flow',
+			status: 'active',
+			trigger: 'manual',
+			accountability: null,
+			options: { collections: [TARGET_COLLECTION], ...(overrides.options ?? {}) },
+			operation: { id: 'op-1', key: 'log', type: 'log', options: {}, resolve: null, reject: null },
+		};
+	}
+
+	function buildData(
+		bodyOverrides: Record<string, unknown> = { collection: TARGET_COLLECTION, keys: TARGET_KEYS }
+	): any {
+		return {
+			path: `/flows/trigger/${FLOW_ID}`,
+			method: 'POST',
+			headers: {},
+			query: {},
+			body: bodyOverrides,
+		};
+	}
+
+	function buildContext(accountability: Record<string, unknown> | null): any {
+		return { accountability, schema: { collections: {}, relations: [] } as any };
+	}
+
+	const anonAccountability = {
+		user: null,
+		role: null,
+		admin: false,
+		app: false,
+		ip: '127.0.0.1',
+		permissions: [] as any[],
+	};
+
+	const adminAccountability = {
+		user: 'admin-uuid',
+		role: 'role-uuid',
+		admin: true,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [] as any[],
+	};
+
+	const nonAdminWithItemRead = {
+		user: 'user-uuid',
+		role: 'role-uuid',
+		admin: false,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [{ collection: TARGET_COLLECTION, action: 'read', fields: ['*'] } as any],
+	};
+
+	let manager: any;
+	let executeFlowSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		manager = getFlowManager();
+		executeFlowSpy = vi.spyOn(manager, 'executeFlow').mockResolvedValue('executed' as any);
+		checkAccessSpy.mockReset().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('bug-exposing — caller without auth or permission is rejected', () => {
+		it('rejects anonymous caller (accountability.user is null)', async () => {
+			await expect(
+				manager._runManualFlow(buildFlow(), buildData(), buildContext(anonAccountability))
+			).rejects.toBeInstanceOf(exceptions.ForbiddenException);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+		});
+
+		it('rejects when checkAccess on directus_flows fails', async () => {
+			checkAccessSpy.mockImplementation(async (_action: any, collection: any) => {
+				if (collection === 'directus_flows') throw new exceptions.ForbiddenException();
+			});
+
+			await expect(
+				manager._runManualFlow(buildFlow(), buildData(), buildContext(nonAdminWithItemRead))
+			).rejects.toBeInstanceOf(exceptions.ForbiddenException);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+		});
+
+		it('rejects when checkAccess on target items fails (keys path)', async () => {
+			checkAccessSpy.mockImplementation(async (_action: any, collection: any) => {
+				if (collection === TARGET_COLLECTION) throw new exceptions.ForbiddenException();
+			});
+
+			await expect(
+				manager._runManualFlow(buildFlow(), buildData(), buildContext(nonAdminWithItemRead))
+			).rejects.toBeInstanceOf(exceptions.ForbiddenException);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+		});
+
+		it('rejects collection-mode trigger when caller lacks collection read', async () => {
+			const flow = buildFlow({ options: { collections: [TARGET_COLLECTION], requireSelection: false } });
+			const data = buildData({ collection: TARGET_COLLECTION });
+
+			const nonAdminNoCollectionRead = {
+				user: 'user-uuid',
+				role: 'role-uuid',
+				admin: false,
+				app: true,
+				ip: '127.0.0.1',
+				permissions: [] as any[],
+			};
+
+			await expect(manager._runManualFlow(flow, data, buildContext(nonAdminNoCollectionRead))).rejects.toBeInstanceOf(
+				exceptions.ForbiddenException
+			);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+		});
+
+		it('rejects when keys is absent and requireSelection is not false (defensive)', async () => {
+			const flow = buildFlow();
+			const data = buildData({ collection: TARGET_COLLECTION });
+
+			await expect(manager._runManualFlow(flow, data, buildContext(adminAccountability))).rejects.toBeInstanceOf(
+				exceptions.ForbiddenException
+			);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('regression — authorized triggers execute', () => {
+		it('admin caller with keys executes the flow', async () => {
+			await manager._runManualFlow(buildFlow(), buildData(), buildContext(adminAccountability));
+			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('admin caller with no keys and requireSelection: false executes the flow', async () => {
+			const flow = buildFlow({ options: { collections: [TARGET_COLLECTION], requireSelection: false } });
+			const data = buildData({ collection: TARGET_COLLECTION });
+
+			await manager._runManualFlow(flow, data, buildContext(adminAccountability));
+			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('non-admin with item-read permissions and explicit keys executes the flow', async () => {
+			await manager._runManualFlow(buildFlow(), buildData(), buildContext(nonAdminWithItemRead));
+			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
+			expect(checkAccessSpy).toHaveBeenCalledWith('read', 'directus_flows', FLOW_ID);
+			expect(checkAccessSpy).toHaveBeenCalledWith('read', TARGET_COLLECTION, TARGET_KEYS);
+		});
+
+		it('non-admin with collection-level read executes collection-mode flow (no keys + requireSelection: false)', async () => {
+			const flow = buildFlow({ options: { collections: [TARGET_COLLECTION], requireSelection: false } });
+			const data = buildData({ collection: TARGET_COLLECTION });
+
+			await manager._runManualFlow(flow, data, buildContext(nonAdminWithItemRead));
+			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('preserves the existing collection-allowlist check', async () => {
+			const flow = buildFlow({ options: { collections: ['other-collection'] } });
+
+			await expect(manager._runManualFlow(flow, buildData(), buildContext(adminAccountability))).rejects.toBeInstanceOf(
+				exceptions.ForbiddenException
+			);
+
+			expect(executeFlowSpy).not.toHaveBeenCalled();
+			expect(checkAccessSpy).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -22,6 +22,7 @@ import { BaseException } from '@cairncms/exceptions';
 import logger from './logger.js';
 import { getMessenger } from './messenger.js';
 import { ActivityService } from './services/activity.js';
+import { AuthorizationService } from './services/authorization.js';
 import * as services from './services/index.js';
 import { FlowsService } from './services/flows.js';
 import { RevisionsService } from './services/revisions.js';
@@ -248,32 +249,7 @@ class FlowManager {
 
 				this.webhookFlowHandlers[`${method}-${flow.id}`] = handler;
 			} else if (flow.trigger === 'manual') {
-				const handler = (data: unknown, context: Record<string, unknown>) => {
-					const enabledCollections = flow.options?.['collections'] ?? [];
-					const targetCollection = (data as Record<string, any>)?.['body'].collection;
-
-					if (!targetCollection) {
-						logger.warn(`Manual trigger requires "collection" to be specified in the payload`);
-						throw new exceptions.ForbiddenException();
-					}
-
-					if (enabledCollections.length === 0) {
-						logger.warn(`There is no collections configured for this manual trigger`);
-						throw new exceptions.ForbiddenException();
-					}
-
-					if (!enabledCollections.includes(targetCollection)) {
-						logger.warn(`Specified collection must be one of: ${enabledCollections.join(', ')}.`);
-						throw new exceptions.ForbiddenException();
-					}
-
-					if (flow.options['async']) {
-						this.executeFlow(flow, data, context);
-						return undefined;
-					} else {
-						return this.executeFlow(flow, data, context);
-					}
-				};
+				const handler = (data: unknown, context: Record<string, unknown>) => this._runManualFlow(flow, data, context);
 
 				// Default return to $last for manual
 				flow.options['return'] = '$last';
@@ -307,6 +283,60 @@ class FlowManager {
 		this.webhookFlowHandlers = {};
 
 		this.isLoaded = false;
+	}
+
+	private async _runManualFlow(flow: Flow, data: unknown, context: Record<string, unknown>): Promise<unknown> {
+		const accountability = context['accountability'] as Accountability | null | undefined;
+		const schema = context['schema'] as SchemaOverview;
+
+		if (!accountability || !accountability.user) {
+			throw new exceptions.ForbiddenException();
+		}
+
+		const enabledCollections = (flow.options?.['collections'] as string[] | undefined) ?? [];
+		const body = ((data as Record<string, any> | undefined)?.['body'] ?? {}) as Record<string, any>;
+		const targetCollection = body['collection'] as string | undefined;
+		const keys = body['keys'];
+
+		if (!targetCollection) {
+			logger.warn(`Manual trigger requires "collection" to be specified in the payload`);
+			throw new exceptions.ForbiddenException();
+		}
+
+		if (enabledCollections.length === 0) {
+			logger.warn(`There is no collections configured for this manual trigger`);
+			throw new exceptions.ForbiddenException();
+		}
+
+		if (!enabledCollections.includes(targetCollection)) {
+			logger.warn(`Specified collection must be one of: ${enabledCollections.join(', ')}.`);
+			throw new exceptions.ForbiddenException();
+		}
+
+		const authorizationService = new AuthorizationService({ accountability, knex: getDatabase(), schema });
+
+		await authorizationService.checkAccess('read', 'directus_flows', flow.id);
+
+		if (Array.isArray(keys) && keys.length > 0) {
+			await authorizationService.checkAccess('read', targetCollection, keys);
+		} else if (flow.options?.['requireSelection'] === false) {
+			if (accountability.admin !== true) {
+				const hasCollectionRead = accountability.permissions?.some(
+					(perm) => perm.collection === targetCollection && perm.action === 'read'
+				);
+
+				if (!hasCollectionRead) throw new exceptions.ForbiddenException();
+			}
+		} else {
+			throw new exceptions.ForbiddenException();
+		}
+
+		if (flow.options['async']) {
+			this.executeFlow(flow, data, context);
+			return undefined;
+		}
+
+		return this.executeFlow(flow, data, context);
 	}
 
 	private async executeFlow(flow: Flow, data: unknown = null, context: Record<string, unknown> = {}): Promise<unknown> {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-7cvf-pxgp-42fc / CVE-2025-53889.

Manual flow triggers accepted `POST /flows/trigger/:id` requests after only validating the configured collection allowlist. They did not verify that the caller was authenticated or authorized to trigger the flow against the requested collection or items. As a result, a caller who could reach the endpoint and knew a manual flow ID could execute that flow without a dedicated trigger-authorization check.

This PR closes this gap in `api/src/flows.ts` before `executeFlow()` runs. Anonymous callers are rejected and authenticated callers must be able to read the `directus_flows` record being triggered. In keyed mode, callers must also be able to read the requested target items. In collection mode, which is the supported no-selection path when `requireSelection === false`, callers must have collection-level read access to the target collection. Requests that omit keys while selection is still required are rejected defensively. The existing collection allowlist validation remains in place, and webhook-triggered flows are unchanged.

### Testing / verification

- Added `flows.test.ts` coverage for:
  - rejecting anonymous manual triggers
  - rejecting callers who cannot read the target flow
  - rejecting callers who cannot read the requested target items
  - rejecting collection-mode callers without collection read access
  - defensively rejecting missing keys when `requireSelection` is still enforced
  - allowing admin keyed-mode manual triggers
  - allowing admin collection-mode manual triggers
  - allowing authorized non-admin keyed-mode manual triggers
  - allowing authorized non-admin collection-mode manual triggers
  - preserving the existing collection allowlist check

Also verified against a live SQLite instance and confirmed:
- anonymous keyed-mode manual trigger returns `403`
- admin keyed-mode manual trigger returns `204`
- authorized non-admin keyed-mode manual trigger returns `204`
- under-authorized non-admin keyed-mode manual trigger returns `403`
- admin collection-mode manual trigger returns `204`
- authorized non-admin collection-mode manual trigger returns `204`
- under-authorized non-admin collection-mode manual trigger returns `403`
- missing-keys request in selection-required mode returns `403`
- anonymous webhook trigger remains `204` unchanged

Server logs confirmed that only authorized manual triggers executed flows.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
