### PR TITLE
Clean permission references on field deletion (GHSA-9x5g-62gj-wqf2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
+- Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
 - Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 - Removed version string from OpenAPI spec responses (GHSA-rmjh-cf9q-pv7q / CVE-2025-53887).

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -1,0 +1,227 @@
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient, Tracker } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanupPermissionsOnFieldDelete, removeFieldFromFilter } from './fields.js';
+
+vi.mock('../../src/database/index', () => ({
+	__esModule: true,
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+describe('removeFieldFromFilter (GHSA-9x5g-62gj-wqf2)', () => {
+	it('returns null when given null', () => {
+		expect(removeFieldFromFilter(null, 'secret')).toBeNull();
+	});
+
+	it('returns empty object unchanged', () => {
+		expect(removeFieldFromFilter({}, 'secret')).toEqual({});
+	});
+
+	it('drops a single-key clause matching the deleted field', () => {
+		expect(removeFieldFromFilter({ secret: { _eq: 'x' } }, 'secret')).toEqual({});
+	});
+
+	it('preserves sibling clauses keyed by non-deleted fields', () => {
+		expect(removeFieldFromFilter({ secret: { _eq: 'x' }, title: { _neq: '' } }, 'secret')).toEqual({
+			title: { _neq: '' },
+		});
+	});
+
+	it('drops the deleted-field clause inside an _and array', () => {
+		expect(removeFieldFromFilter({ _and: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, 'secret')).toEqual({
+			_and: [{ title: { _neq: '' } }],
+		});
+	});
+
+	it('removes _and entirely when all its clauses reference only the deleted field', () => {
+		expect(removeFieldFromFilter({ _and: [{ secret: { _eq: 'x' } }] }, 'secret')).toEqual({});
+	});
+
+	it('drops the deleted-field clause inside an _or array', () => {
+		expect(removeFieldFromFilter({ _or: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, 'secret')).toEqual({
+			_or: [{ title: { _neq: '' } }],
+		});
+	});
+
+	it('recurses through nested _and / _or', () => {
+		const input = {
+			_or: [{ _and: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, { secret: { _eq: 'y' } }],
+		};
+
+		expect(removeFieldFromFilter(input, 'secret')).toEqual({ _or: [{ _and: [{ title: { _neq: '' } }] }] });
+	});
+
+	it('does not recurse into relational-filter values (cross-collection cleanup is out of scope)', () => {
+		const input = { author: { secret: { _eq: 'x' } } };
+		expect(removeFieldFromFilter(input, 'secret')).toEqual(input);
+	});
+
+	it('keeps unrelated top-level keys when only one references the deleted field', () => {
+		const input = { title: { _eq: 'x' }, body: { _eq: 'y' } };
+		expect(removeFieldFromFilter(input, 'secret')).toEqual(input);
+	});
+});
+
+describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	it('removes the deleted field from a permission row that lists it explicitly', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 1, fields: ['title', 'secret'], permissions: null, validation: null }]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push({ bindings: q.bindings });
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(1);
+		expect(updates[0]!.bindings[0]).toBe('title');
+		expect(updates[0]!.bindings[updates[0]!.bindings.length - 1]).toBe(1);
+	});
+
+	it('writes null when the filtered fields array would be empty', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 10, fields: ['secret'], permissions: null, validation: null }]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push({ bindings: q.bindings });
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(1);
+		expect(updates[0]!.bindings[0]).toBeNull();
+	});
+
+	it('preserves a wildcard fields array', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 2, fields: ['*'], permissions: null, validation: null }]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push(q);
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(0);
+	});
+
+	it('handles CSV-string fields by splitting before filtering', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 3, fields: 'title,secret', permissions: null, validation: null }]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push({ bindings: q.bindings });
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(1);
+		expect(updates[0]!.bindings[0]).toBe('title');
+	});
+
+	it('cleans a JSON-string permissions filter and writes back a JSON string', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([
+				{
+					id: 4,
+					fields: null,
+					permissions: JSON.stringify({ secret: { _eq: 'x' }, title: { _neq: '' } }),
+					validation: null,
+				},
+			]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push({ bindings: q.bindings });
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(1);
+		expect(JSON.parse(updates[0]!.bindings[0] as string)).toEqual({ title: { _neq: '' } });
+	});
+
+	it('cleans validation filter alongside permissions filter on the same row', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([
+				{
+					id: 5,
+					fields: null,
+					permissions: JSON.stringify({ secret: { _eq: 'x' } }),
+					validation: JSON.stringify({ secret: { _eq: 'x' } }),
+				},
+			]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push({ bindings: q.bindings });
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(1);
+		expect(updates[0]!.bindings[0]).toBe('{}');
+		expect(updates[0]!.bindings[1]).toBe('{}');
+	});
+
+	it('does not issue an UPDATE when the row has no references to the deleted field', async () => {
+		tracker.on
+			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
+			.response([
+				{
+					id: 6,
+					fields: ['title'],
+					permissions: JSON.stringify({ title: { _eq: 'x' } }),
+					validation: null,
+				},
+			]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push(q);
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+
+		expect(updates.length).toBe(0);
+	});
+});

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -601,6 +601,8 @@ export class FieldsService {
 				}
 
 				await trx('directus_fields').delete().where({ collection, field });
+
+				await cleanupPermissionsOnFieldDelete(trx, collection, field);
 			});
 
 			const actionEvent = {
@@ -720,6 +722,80 @@ export class FieldsService {
 
 		if (alter) {
 			column.alter();
+		}
+	}
+}
+
+export function removeFieldFromFilter(
+	filter: Record<string, any> | null,
+	fieldName: string
+): Record<string, any> | null {
+	if (filter === null || typeof filter !== 'object') return filter;
+
+	const result: Record<string, any> = {};
+
+	for (const [key, value] of Object.entries(filter)) {
+		if (key === fieldName) continue;
+
+		if (key === '_and' || key === '_or') {
+			if (Array.isArray(value)) {
+				const cleaned = value
+					.map((clause) => removeFieldFromFilter(clause, fieldName))
+					.filter(
+						(clause): clause is Record<string, any> =>
+							clause !== null && typeof clause === 'object' && Object.keys(clause).length > 0
+					);
+
+				if (cleaned.length > 0) result[key] = cleaned;
+			}
+
+			continue;
+		}
+
+		result[key] = value;
+	}
+
+	return result;
+}
+
+export async function cleanupPermissionsOnFieldDelete(trx: Knex, collection: string, field: string): Promise<void> {
+	const permissionRows = await trx
+		.select('id', 'fields', 'permissions', 'validation')
+		.from('directus_permissions')
+		.where({ collection });
+
+	for (const row of permissionRows) {
+		const updates: Record<string, any> = {};
+
+		let fields: string[] | null = null;
+		if (typeof row.fields === 'string') fields = row.fields.split(',');
+		else if (Array.isArray(row.fields)) fields = row.fields;
+
+		if (fields && !fields.includes('*') && fields.includes(field)) {
+			const filtered = fields.filter((f) => f !== field);
+			updates['fields'] = filtered.length > 0 ? filtered.join(',') : null;
+		}
+
+		const parsedPermissions =
+			typeof row.permissions === 'string' && row.permissions ? JSON.parse(row.permissions) : row.permissions ?? null;
+
+		const cleanedPermissions = removeFieldFromFilter(parsedPermissions, field);
+
+		if (JSON.stringify(cleanedPermissions) !== JSON.stringify(parsedPermissions)) {
+			updates['permissions'] = cleanedPermissions === null ? null : JSON.stringify(cleanedPermissions);
+		}
+
+		const parsedValidation =
+			typeof row.validation === 'string' && row.validation ? JSON.parse(row.validation) : row.validation ?? null;
+
+		const cleanedValidation = removeFieldFromFilter(parsedValidation, field);
+
+		if (JSON.stringify(cleanedValidation) !== JSON.stringify(parsedValidation)) {
+			updates['validation'] = cleanedValidation === null ? null : JSON.stringify(cleanedValidation);
+		}
+
+		if (Object.keys(updates).length > 0) {
+			await trx('directus_permissions').update(updates).where({ id: row.id });
 		}
 	}
 }


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-9x5g-62gj-wqf2 / CVE-2025-64746.

When a field was deleted from a collection, `FieldsService.deleteField()` removed the column, relation metadata, and `directus_fields` row, but it left stale references to that field name in `directus_permissions`. If a new field with the same name was later created, those stale references applied to the new field again. The advisory's named PoC is the `fields` list reactivating access to the recreated field, but the same persistence problem also exists on the row's `permissions` and `validation` filters.

This PR adds permission cleanup to the existing field-deletion transaction in `api/src/services/fields.ts`. It removes the deleted field name from `directus_permissions.fields` while preserving wildcard `['*']` rows, and it also removes deleted-field clauses from `permissions` and `validation` filter trees on the same permission row. Relational filter branches are intentionally left untouched, because cross-collection cleanup is outside this advisory's scope. `presets` are also left untouched as they are data pollution rather than permission handling.

### Testing / verification

- Added `fields.test.ts` coverage for:
  - `removeFieldFromFilter()` on single-key, multi-key, `_and`, `_or`, and nested logical filters
  - preserving relational filter branches unchanged
  - removing deleted field names from `directus_permissions.fields`
  - preserving wildcard `fields: ['*']`
  - handling CSV-string `fields` values from the raw DB shape
  - cleaning JSON-string `permissions` and `validation` columns and writing them back correctly
  - skipping updates when a permission row has no stale references

Also verified against a live SQLite instance and confirmed:
- a role with explicit `fields: ['title', 'secret_field']` loses `secret_field` access when the field is deleted
- the permission row's `fields` value is reduced to `['title']`
- recreating `secret_field` does not restore access for that role
- wildcard `fields: ['*']` rows remain unchanged after unrelated field deletion
- a permission filter keyed by the deleted field is cleaned to `{}` on delete

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
