### PR TITLE
Exclude conceal fields from search (GHSA-8jpw-gpr4-8cmh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,10 +87,11 @@ These are the changes operators coming from Directus 10 will need to account for
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).
 - Scoped the search query parameter to fields the caller is permitted to read (GHSA-7wq3-jr35-275c / CVE-2025-30352).
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
-- Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
-- Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 - Removed version string from OpenAPI spec responses (GHSA-rmjh-cf9q-pv7q / CVE-2025-53887).
+- Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
+- Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
+- Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
 
 ### Acknowledgements
 

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -5,7 +5,7 @@ import { applySearch } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
-function makeField(name: string, type: 'string' | 'integer' | 'uuid' = 'string'): any {
+function makeField(name: string, type: 'string' | 'integer' | 'uuid' = 'string', special: string[] = []): any {
 	return {
 		field: name,
 		defaultValue: null,
@@ -15,7 +15,7 @@ function makeField(name: string, type: 'string' | 'integer' | 'uuid' = 'string')
 		dbType: type === 'integer' ? 'integer' : type === 'uuid' ? 'uuid' : 'varchar',
 		precision: null,
 		scale: null,
-		special: [],
+		special,
 		note: null,
 		validation: null,
 		alias: false,
@@ -37,6 +37,7 @@ function makeSchema(): SchemaOverview {
 					title: makeField('title'),
 					body: makeField('body'),
 					secret_note: makeField('secret_note'),
+					secret_token: makeField('secret_token', 'string', ['conceal']),
 					rank: makeField('rank', 'integer'),
 				},
 			},
@@ -207,5 +208,68 @@ describe('applySearch — field-permission scoping (GHSA-7wq3-jr35-275c)', () =>
 			expect(sql).not.toContain('secret_note');
 			expect(sql).not.toContain('body');
 		});
+	});
+});
+
+describe('applySearch — conceal-field exclusion (GHSA-8jpw-gpr4-8cmh)', () => {
+	it('non-admin with read permission on a concealed field still does not search it', async () => {
+		const dbQuery = makeBuilder();
+		const accountability = makeAccountability({ permissions: [makePermission(['title', 'secret_token'])] });
+
+		await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+		const { sql } = dbQuery.toSQL();
+
+		expect(sql).toContain('title');
+		expect(sql).not.toContain('secret_token');
+	});
+
+	it('admin caller (admin === true) does not search concealed fields', async () => {
+		const dbQuery = makeBuilder();
+		const accountability = makeAccountability({ admin: true, permissions: [] });
+
+		await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+		const { sql } = dbQuery.toSQL();
+
+		expect(sql).toContain('title');
+		expect(sql).toContain('body');
+		expect(sql).not.toContain('secret_token');
+	});
+
+	it('trusted/null-accountability caller does not search concealed fields', async () => {
+		const dbQuery = makeBuilder();
+
+		await applySearch(makeSchema(), dbQuery, 'foo', 'notes', null);
+
+		const { sql } = dbQuery.toSQL();
+
+		expect(sql).toContain('title');
+		expect(sql).not.toContain('secret_token');
+	});
+
+	it('wildcard ["*"] permission does not widen search to concealed fields', async () => {
+		const dbQuery = makeBuilder();
+		const accountability = makeAccountability({ permissions: [makePermission(['*'])] });
+
+		await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+		const { sql } = dbQuery.toSQL();
+
+		expect(sql).toContain('title');
+		expect(sql).toContain('secret_note');
+		expect(sql).not.toContain('secret_token');
+	});
+
+	it('non-concealed permitted fields are still searched (regression)', async () => {
+		const dbQuery = makeBuilder();
+		const accountability = makeAccountability({ permissions: [makePermission(['title'])] });
+
+		await applySearch(makeSchema(), dbQuery, 'foo', 'notes', accountability);
+
+		const { sql } = dbQuery.toSQL();
+
+		expect(sql).toContain('title');
+		expect(sql).not.toContain('secret_token');
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -780,6 +780,8 @@ export async function applySearch(
 		}
 	}
 
+	searchableFields = searchableFields.filter(([_name, field]) => !field.special?.includes('conceal'));
+
 	dbQuery.andWhere(function () {
 		if (searchableFields.length === 0) {
 			this.whereRaw('1 = 0');


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-8jpw-gpr4-8cmh / CVE-2025-64748.

`applySearch()` already searched across the caller's readable fields, but it did not exclude fields marked with `special: ['conceal']`. That meant a caller who could read a concealed field in masked form could still probe its underlying value through the top-level `search` parameter by checking whether rows appeared.

This PR closes this gap in `api/src/utils/apply-query.ts` by removing concealed fields from the search candidate set after the existing readable-field scoping is applied. Non-concealed readable fields remain searchable. The fix applies equally to non-admin callers, wildcard-permission callers, authenticated admins, and trusted internal callers with `accountability: null`. Because REST and GraphQL both flow through the same search path, both surfaces inherit the fix automatically.

### Testing / verification

- Added `apply-query.test.ts` coverage for:
  - excluding a readable concealed field from search for a non-admin caller
  - excluding concealed fields from search for an authenticated admin caller
  - excluding concealed fields from search for the trusted `accountability: null` path
  - excluding concealed fields from search even when read permissions use wildcard `['*']`
  - preserving search behavior for readable non-concealed fields

Also verified against a live SQLite CairnCMS instance and confirmed:
- a plain item read still returns the concealed field in masked form
- an Editor searching for a concealed cleartext substring returns `0` rows
- an Editor searching for a non-concealed substring still returns the matching row
- an admin searching for the same concealed cleartext substring also returns `0` rows
- GraphQL search returns the same concealed-field exclusion behavior as REST

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
