### PR TITLE
Close user-enumeration on password reset request (GHSA-jr94-gj3h-c8rf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
 - Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
 - Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
+- Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).
 
 ### Acknowledgements
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -18,6 +18,7 @@ vi.mock('../env', () => {
 	const MOCK_ENV = {
 		SECRET: 'test-secret-for-jwt',
 		PUBLIC_URL: 'http://localhost:8055',
+		PASSWORD_RESET_URL_ALLOW_LIST: 'https://example.com',
 	};
 
 	return {
@@ -28,7 +29,7 @@ vi.mock('../env', () => {
 
 vi.mock('./mail', () => {
 	const MailService = vi.fn();
-	MailService.prototype.send = vi.fn();
+	MailService.prototype.send = vi.fn().mockResolvedValue(undefined);
 
 	return { MailService };
 });
@@ -783,6 +784,77 @@ describe('Integration Tests', () => {
 				expect(tokenMatch).not.toBeNull();
 				const decoded = jwt.decode(tokenMatch[1]) as { email: string };
 				expect(decoded.email).toBe(storedEmail);
+			});
+
+			describe('GHSA-jr94-gj3h-c8rf', () => {
+				it('rejects an invalid reset_url BEFORE the user lookup (non-existing user)', async () => {
+					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(null);
+
+					await expect(service.requestPasswordReset('attacker@example.com', 'https://evil.com')).rejects.toBeInstanceOf(
+						InvalidPayloadException
+					);
+
+					expect(getUserSpy).not.toHaveBeenCalled();
+				});
+
+				it('rejects an invalid reset_url BEFORE the user lookup (inactive user)', async () => {
+					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+						id: 'user-id',
+						role: 'user-role',
+						status: 'suspended',
+						password: 'hashed-password',
+						email: 'suspended@example.com',
+					});
+
+					await expect(
+						service.requestPasswordReset('suspended@example.com', 'https://evil.com')
+					).rejects.toBeInstanceOf(InvalidPayloadException);
+
+					expect(getUserSpy).not.toHaveBeenCalled();
+				});
+
+				it('does not block the response on mail-send latency (active user, valid URL)', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+						id: 'user-id',
+						role: 'user-role',
+						status: 'active',
+						password: 'hashed-password',
+						email: 'active@example.com',
+					});
+
+					(mailService.send as any).mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 750)));
+
+					const t0 = Date.now();
+					await service.requestPasswordReset('active@example.com', 'https://example.com');
+					const elapsed = Date.now() - t0;
+
+					expect(elapsed).toBeLessThan(700);
+					expect(mailService.send).toHaveBeenCalledTimes(1);
+				});
+
+				it('does not propagate mail-send rejection out of the request handler', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+						id: 'user-id',
+						role: 'user-role',
+						status: 'active',
+						password: 'hashed-password',
+						email: 'active@example.com',
+					});
+
+					(mailService.send as any).mockRejectedValueOnce(new Error('SMTP failed'));
+
+					await expect(
+						service.requestPasswordReset('active@example.com', 'https://example.com')
+					).resolves.not.toThrow();
+				});
+
+				it('non-existing user with valid URL still hits the stall and throws ForbiddenException (regression)', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(null);
+
+					await expect(
+						service.requestPasswordReset('nobody@example.com', 'https://example.com')
+					).rejects.toBeInstanceOf(ForbiddenException);
+				});
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -7,6 +7,7 @@ import { cloneDeep, isEmpty } from 'lodash-es';
 import { performance } from 'perf_hooks';
 import getDatabase from '../database/index.js';
 import env from '../env.js';
+import logger from '../logger.js';
 import { RecordNotUniqueException } from '../exceptions/database/record-not-unique.js';
 import { ForbiddenException, InvalidPayloadException, UnprocessableEntityException } from '../exceptions/index.js';
 import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '../types/index.js';
@@ -439,6 +440,10 @@ export class UsersService extends ItemsService {
 	}
 
 	async requestPasswordReset(email: string, url: string | null, subject?: string | null): Promise<void> {
+		if (url && isUrlAllowed(url, env['PASSWORD_RESET_URL_ALLOW_LIST']) === false) {
+			throw new InvalidPayloadException(`Url "${url}" can't be used to reset passwords.`);
+		}
+
 		const STALL_TIME = 500;
 		const timeStart = performance.now();
 
@@ -447,10 +452,6 @@ export class UsersService extends ItemsService {
 		if (user?.status !== 'active') {
 			await stall(STALL_TIME, timeStart);
 			throw new ForbiddenException();
-		}
-
-		if (url && isUrlAllowed(url, env['PASSWORD_RESET_URL_ALLOW_LIST']) === false) {
-			throw new InvalidPayloadException(`Url "${url}" can't be used to reset passwords.`);
 		}
 
 		const mailService = new MailService({
@@ -473,17 +474,19 @@ export class UsersService extends ItemsService {
 
 		const subjectLine = subject ? subject : 'Password Reset Request';
 
-		await mailService.send({
-			to: storedEmail,
-			subject: subjectLine,
-			template: {
-				name: 'password-reset',
-				data: {
-					url: acceptURL,
-					email: storedEmail,
+		mailService
+			.send({
+				to: storedEmail,
+				subject: subjectLine,
+				template: {
+					name: 'password-reset',
+					data: {
+						url: acceptURL,
+						email: storedEmail,
+					},
 				},
-			},
-		});
+			})
+			.catch((err) => logger.warn(err, '[email] password-reset send failed'));
 
 		await stall(STALL_TIME, timeStart);
 	}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-jr94-gj3h-c8rf / CVE-2026-26185.

`UsersService.requestPasswordReset()` exposed user existence through timing on two paths. First, invalid `reset_url` values were rejected before the uniform stall, which made that path observably different from the normal reset flow. Second, valid reset requests for active users awaited `MailService.send(...)`, so SMTP latency was added to the externally observed response time while nonexistent-user requests only hit the stall floor. The controller already normalized the outward response body and status for non-validation failures, but the service still leaked account existence through timing.

This PR closes both timing leaks in `api/src/services/users.ts`. URL allow-list validation now happens before any user lookup, so invalid reset URLs fail uniformly regardless of whether the email exists. For valid reset URLs, password-reset email delivery is now dispatched without awaiting the mail transport, and the request path only waits for the fixed stall floor. Mail-send failures remain server-side only and are logged through a local `.catch(...)`, which matches the controller's existing behavior of not surfacing email transport errors to the caller. Because both REST and GraphQL call the same service method, both surfaces inherit the fix.

### Testing / verification

- Added `users.test.ts` coverage for:
  - rejecting an invalid `reset_url` before any user lookup for a nonexistent user
  - rejecting an invalid `reset_url` before any user lookup for an inactive user
  - proving active-user requests do not block on a mocked `750ms` mail send
  - proving mail-send rejection is not propagated out of the request path
  - preserving the existing stalled `ForbiddenException` behavior for nonexistent users on valid reset URLs

Also verified against a live SQLite instance and confirmed:
- existing-user and nonexistent-user requests with an invalid `reset_url` both return `400` in roughly `10ms`
- existing-user and nonexistent-user requests with a valid `reset_url` both return `204` in roughly `500ms`
- valid reset requests no longer include mail transport latency in the externally observed response time
- the observable behavior is byte-identical across user existence on both the invalid-URL and valid-URL paths

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
