### PR TITLE
Conceal sensitive fields in revision history (GHSA-mvv8-v4jj-g47j)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
 - Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
 - Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).
+- Concealed sensitive fields in revision history (GHSA-mvv8-v4jj-g47j / CVE-2026-39943).
 
 ### Acknowledgements
 

--- a/api/src/database/system-data/fields/index.ts
+++ b/api/src/database/system-data/fields/index.ts
@@ -16,7 +16,7 @@ const fieldData = fse.readdirSync(path.resolve(__dirname));
 export const systemFieldRows: FieldMeta[] = [];
 
 for (const filepath of fieldData) {
-	if (filepath.includes('_defaults') || filepath.includes('index')) continue;
+	if (filepath.includes('_defaults') || filepath.includes('index') || !filepath.endsWith('.yaml')) continue;
 
 	const systemFields = requireYAML(path.resolve(__dirname, filepath));
 

--- a/api/src/database/system-data/fields/users.test.ts
+++ b/api/src/database/system-data/fields/users.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { systemFieldRows } from './index.js';
+
+describe('directus_users system fields (GHSA-mvv8-v4jj-g47j)', () => {
+	it('marks external_identifier with the conceal special', () => {
+		const field = systemFieldRows.find((f) => f.collection === 'directus_users' && f.field === 'external_identifier');
+
+		expect(field).toBeDefined();
+		expect(field?.special).toContain('conceal');
+	});
+
+	it('marks auth_data with the conceal special', () => {
+		const field = systemFieldRows.find((f) => f.collection === 'directus_users' && f.field === 'auth_data');
+		expect(field).toBeDefined();
+		expect(field?.special).toContain('conceal');
+	});
+});

--- a/api/src/database/system-data/fields/users.yaml
+++ b/api/src/database/system-data/fields/users.yaml
@@ -180,6 +180,10 @@ fields:
     options:
       iconRight: account_circle
     interface: input
+    special:
+      - conceal
 
   - field: auth_data
     hidden: true
+    special:
+      - conceal

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -458,6 +458,31 @@ describe('Integration Tests', () => {
 				expect(result[0].display_email).toBe('a@b.com');
 			});
 
+			it('masks external_identifier and auth_data when their schema entries carry the conceal special (GHSA-mvv8-v4jj-g47j)', async () => {
+				const service = makeService('directus_users', [
+					['id'],
+					['email'],
+					['first_name'],
+					['external_identifier', ['conceal']],
+					['auth_data', ['conceal']],
+				]);
+
+				const result = (await service.processValues('read', [
+					{
+						id: 'u1',
+						email: 'a@b.c',
+						first_name: 'Probe',
+						external_identifier: 'oauth-google|SENSITIVE-ID',
+						auth_data: '{"refresh_token":"REFRESH-TOKEN-SECRET"}',
+					},
+				])) as any[];
+
+				expect(result[0].external_identifier).toBe('**********');
+				expect(result[0].auth_data).toBe('**********');
+				expect(result[0].email).toBe('a@b.c');
+				expect(result[0].first_name).toBe('Probe');
+			});
+
 			it('masks multiple concealed aliases in a single payload', async () => {
 				const service = usersService();
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-mvv8-v4jj-g47j / CVE-2026-39943.

`directus_revisions` stores both a full item snapshot (`data`) and a change set (`delta`). Those revision payloads already pass through the existing conceal masking path before persistence, but only for fields whose metadata carries `special: ['conceal']`, leaving sensitive `directus_users` fields such as `external_identifier` and `auth_data` in cleartext in revision history. A caller with operator-granted read access to `directus_revisions` could therefore retrieve values that are not normally returned through the standard `directus_users` field allowlist.

This PR closes the leak by marking `directus_users.external_identifier` and `directus_users.auth_data` as concealed in `api/src/database/system-data/fields/users.yaml`. This routes both fields through the existing masking path used by revision snapshot creation and normal read processing. New revisions now store masked values for those fields, and direct reads of those fields are masked consistently as well. This is intentionally a forward-only fix: it does not add read-time permission filtering for revisions, and it does not scrub historical leaked rows from already-used instances (we are in beta).

### Testing / verification

- Added `system-data/fields/users.test.ts` coverage for:
  - `external_identifier` carrying the `conceal` special
  - `auth_data` carrying the `conceal` special
- Added `payload.test.ts` coverage proving `processValues('read', ...)` masks:
  - `external_identifier`
  - `auth_data`
  - while leaving non-sensitive fields such as `email` unchanged

Also verified against a live SQLite instance and confirmed:
- direct reads of `/users/me` now return `external_identifier` and `token` as `**********` while non-sensitive fields remain cleartext
- patching `external_identifier` creates a revision whose `data.external_identifier` and `delta.external_identifier` are both masked
- patching `auth_data` creates a revision whose `data.auth_data` and `delta.auth_data` are both masked
- patching a non-sensitive field such as `first_name` still stores that field in cleartext in revision history
- previously concealed fields (`password`, `token`, `tfa_secret`) remain masked across revisions

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
