### PR TITLE
Add parser-bypass regression tests for SSO redirect validator (GHSA-c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
 - Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).
 - Concealed sensitive fields in revision history (GHSA-mvv8-v4jj-g47j / CVE-2026-39943).
+- Added parser-bypass regression coverage for SSO redirect validation (GHSA-cf45-hxwj-4cfj / CVE-2026-35410).
 
 ### Acknowledgements
 

--- a/api/src/utils/validate-redirect.test.ts
+++ b/api/src/utils/validate-redirect.test.ts
@@ -56,6 +56,25 @@ describe('isSafeRedirect — protocol-relative URLs', () => {
 	});
 });
 
+describe('isSafeRedirect — parser-bypass patterns (GHSA-cf45-hxwj-4cfj)', () => {
+	test.each([
+		['leading double-backslash', '\\\\evil.example/path'],
+		['slash then backslash', '/\\evil.example/path'],
+		['slash then double-backslash', '/\\\\evil.example/path'],
+		['backslash then slash', '\\/evil.example/path'],
+		['slash then backslash then slash', '/\\/evil.example/path'],
+		['double-backslash with userinfo', '\\\\user@evil.example/path'],
+		['multiple leading slashes', '////evil.example/path'],
+	])('rejects %s', (_label, redirect) => {
+		expect(isSafeRedirect(redirect)).toBe(false);
+	});
+
+	test('percent-encoded backslashes stay path content (same-origin)', () => {
+		expect(isSafeRedirect('/%5C%5Cevil.example/path')).toBe(true);
+		expect(getSafeRedirect('/%5C%5Cevil.example/path')).toBe('/%5C%5Cevil.example/path');
+	});
+});
+
 describe('isSafeRedirect — non-http(s) schemes', () => {
 	test.each([
 		['javascript', 'javascript:alert(1)'],


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Closes out GHSA-cf45-hxwj-4cfj / CVE-2026-35410.

The production redirect sinks for OAuth2, OpenID, and SAML are already using the shared redirect validation helper in `api/src/utils/validate-redirect.ts`, so this advisory's open-redirect bug class is technically already addressed. What was missing was explicit CI coverage for the advisory's named parser-bypass inputs. The existing helper tests already covered same-origin vs cross-origin redirects in general, but they did not lock in the specific backslash and slash-normalization patterns that motivated this GHSA.

### Testing / verification

- Added `validate-redirect.test.ts` coverage for:
  - `\\evil.example/path`
  - `/\evil.example/path`
  - `/\\evil.example/path`
  - `\/evil.example/path`
  - `/\/evil.example/path`
  - `\\user@evil.example/path`
  - `////evil.example/path`
  - `/%5C%5Cevil.example/path` remaining a safe same-origin path

Confirmed in tests that:
- advisory-shaped parser-bypass redirect inputs are rejected by the shared redirect helper
- the encoded-backslash sibling remains same-origin path content and is not over-blocked
- no production redirect behavior changed; this PR only strengthens regression coverage around the already-deployed helper boundary

This turns the row-7 "already addressed" status into an explicitly tested contract for the advisory's named bypass family.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
