### PR TITLE
Gate GraphQL SDL on GRAPHQL_INTROSPECTION (GHSA-wxwm-3fxv-mrvx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).
 - Concealed sensitive fields in revision history (GHSA-mvv8-v4jj-g47j / CVE-2026-39943).
 - Added parser-bypass regression coverage for SSO redirect validation (GHSA-cf45-hxwj-4cfj / CVE-2026-35410).
+- Gated GraphQL SDL specs on GRAPHQL_INTROSPECTION (GHSA-wxwm-3fxv-mrvx / CVE-2026-35413).
 
 ### Acknowledgements
 

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -186,6 +186,10 @@ export class GraphQLService {
 	getSchema(type: 'schema'): GraphQLSchema;
 	getSchema(type: 'sdl'): GraphQLSchema | string;
 	getSchema(type: 'schema' | 'sdl' = 'schema'): GraphQLSchema | string {
+		if (type === 'sdl' && env['GRAPHQL_INTROSPECTION'] === false) {
+			throw new ForbiddenException();
+		}
+
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this;
 

--- a/api/src/services/graphql/sdl-introspection-gate.test.ts
+++ b/api/src/services/graphql/sdl-introspection-gate.test.ts
@@ -1,0 +1,72 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import env from '../../env.js';
+import { ForbiddenException } from '../../exceptions/index.js';
+import { GraphQLService } from './index.js';
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabase: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const accountability: Accountability = {
+	user: null,
+	role: null,
+	admin: false,
+	app: false,
+	ip: '127.0.0.1',
+};
+
+const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+let originalIntrospection: unknown;
+
+beforeEach(() => {
+	originalIntrospection = env['GRAPHQL_INTROSPECTION'];
+	env['GRAPHQL_INTROSPECTION'] = true;
+});
+
+afterEach(() => {
+	env['GRAPHQL_INTROSPECTION'] = originalIntrospection;
+	vi.restoreAllMocks();
+});
+
+describe('GraphQLService.getSchema — SDL introspection gate (GHSA-wxwm-3fxv-mrvx)', () => {
+	it('throws ForbiddenException for sdl with scope items when GRAPHQL_INTROSPECTION=false', () => {
+		env['GRAPHQL_INTROSPECTION'] = false;
+		const service = new GraphQLService({ accountability, schema, scope: 'items' });
+		expect(() => service.getSchema('sdl')).toThrow(ForbiddenException);
+	});
+
+	it('throws ForbiddenException for sdl with scope system when GRAPHQL_INTROSPECTION=false', () => {
+		env['GRAPHQL_INTROSPECTION'] = false;
+		const service = new GraphQLService({ accountability, schema, scope: 'system' });
+		expect(() => service.getSchema('sdl')).toThrow(ForbiddenException);
+	});
+
+	it('does not throw ForbiddenException for sdl when GRAPHQL_INTROSPECTION=true', () => {
+		const service = new GraphQLService({ accountability, schema, scope: 'items' });
+		expect(() => service.getSchema('sdl')).not.toThrow(ForbiddenException);
+	});
+
+	it('does not throw ForbiddenException for the default schema type regardless of GRAPHQL_INTROSPECTION', () => {
+		env['GRAPHQL_INTROSPECTION'] = false;
+		const offService = new GraphQLService({ accountability, schema, scope: 'items' });
+		expect(() => offService.getSchema()).not.toThrow(ForbiddenException);
+
+		env['GRAPHQL_INTROSPECTION'] = true;
+		const onService = new GraphQLService({ accountability, schema, scope: 'items' });
+		expect(() => onService.getSchema()).not.toThrow(ForbiddenException);
+	});
+
+	it('does not throw ForbiddenException for type schema regardless of GRAPHQL_INTROSPECTION', () => {
+		env['GRAPHQL_INTROSPECTION'] = false;
+		const offService = new GraphQLService({ accountability, schema, scope: 'system' });
+		expect(() => offService.getSchema('schema')).not.toThrow(ForbiddenException);
+
+		env['GRAPHQL_INTROSPECTION'] = true;
+		const onService = new GraphQLService({ accountability, schema, scope: 'system' });
+		expect(() => onService.getSchema('schema')).not.toThrow(ForbiddenException);
+	});
+});


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-wxwm-3fxv-mrvx / CVE-2026-35413.

When `GRAPHQL_INTROSPECTION=false` is configured, standard GraphQL introspection queries such as `__schema` and `__type` through `NoSchemaIntrospectionCustomRule` are already blocked. However, the schema's SDL representation remained available through two separate surfaces: the GraphQL `server_specs_graphql` field and the REST `/server/specs/graphql/:scope?` endpoint. Both surfaces converged on `GraphQLService.getSchema('sdl')`, which had no equivalent gate.

This PR closes this gap at the shared `GraphQLService.getSchema('sdl')` chokepoint. When `GRAPHQL_INTROSPECTION=false`, SDL generation now throws `ForbiddenException`, which produces a `FORBIDDEN` GraphQL error on the resolver surface and an HTTP `403` on the REST surface. Normal runtime schema generation remains unaffected: `getSchema()` and `getSchema('schema')` still work so GraphQL execution continues to function even when SDL export is disabled.

### Testing / verification

- Added `sdl-introspection-gate.test.ts` coverage for:
  - rejecting `getSchema('sdl')` with `GRAPHQL_INTROSPECTION=false` for `items` scope
  - rejecting `getSchema('sdl')` with `GRAPHQL_INTROSPECTION=false` for `system` scope
  - allowing `getSchema('sdl')` when `GRAPHQL_INTROSPECTION=true`
  - preserving `getSchema()` when `GRAPHQL_INTROSPECTION=false`
  - preserving `getSchema('schema')` when `GRAPHQL_INTROSPECTION=false`

Also verified against a live Postgres-backed instance and confirmed:
- with `GRAPHQL_INTROSPECTION=true`, both `server_specs_graphql` and `/server/specs/graphql/:scope?` still return SDL for `items` and `system`
- with `GRAPHQL_INTROSPECTION=false`, `server_specs_graphql` returns GraphQL `FORBIDDEN` errors for both scopes
- with `GRAPHQL_INTROSPECTION=false`, `/server/specs/graphql/:scope?` returns HTTP `403` for both scopes
- standard GraphQL introspection still fails under `GRAPHQL_INTROSPECTION=false` with `GRAPHQL_VALIDATION_EXCEPTION`
- public-role callers are gated the same way as authenticated callers when SDL export is disabled

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
