### PR TITLE
Deduplicate GraphQL read resolvers within a request (GHSA-ph52-67fq-7…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Concealed sensitive fields in revision history (GHSA-mvv8-v4jj-g47j / CVE-2026-39943).
 - Added parser-bypass regression coverage for SSO redirect validation (GHSA-cf45-hxwj-4cfj / CVE-2026-35410).
 - Gated GraphQL SDL specs on GRAPHQL_INTROSPECTION (GHSA-wxwm-3fxv-mrvx / CVE-2026-35413).
+- Deduplicated GraphQL read resolver invocations within a request (GHSA-ph52-67fq-75wj / CVE-2026-35441).
 
 ### Acknowledgements
 

--- a/api/src/services/graphql/alias-amp-dedup.test.ts
+++ b/api/src/services/graphql/alias-amp-dedup.test.ts
@@ -1,0 +1,326 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { GraphQLResolveInfo } from 'graphql';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabase: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+	getSchemaInspector: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../database/helpers/index.js', () => ({
+	getHelpers: vi.fn().mockReturnValue({
+		date: {},
+		st: {},
+		schema: { changeNullable: vi.fn() },
+		sequence: {},
+	}),
+}));
+
+const { GraphQLService } = await import('./index.js');
+const { CollectionsService } = await import('../collections.js');
+const { FieldsService } = await import('../fields.js');
+const { RelationsService } = await import('../relations.js');
+const { ServerService } = await import('../server.js');
+const { SpecificationService } = await import('../specifications.js');
+const { UsersService } = await import('../users.js');
+
+const adminAccountability: Accountability = {
+	user: 'admin-uuid',
+	role: 'admin-role',
+	admin: true,
+	app: true,
+	ip: '127.0.0.1',
+};
+
+function makeSchema(collection = 'probe_items'): SchemaOverview {
+	return {
+		collections: {
+			[collection]: {
+				collection,
+				primary: 'id',
+				singleton: false,
+				note: null,
+				sortField: null,
+				accountability: 'all',
+				fields: {
+					id: {
+						field: 'id',
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						type: 'integer',
+						dbType: 'integer',
+						precision: null,
+						scale: null,
+						special: [],
+						note: null,
+						alias: false,
+						validation: null,
+					},
+				},
+			},
+		},
+		relations: [],
+	} as unknown as SchemaOverview;
+}
+
+function field(name: string) {
+	return { kind: 'Field', name: { kind: 'Name', value: name } };
+}
+
+function arg(name: string, value: { kind: string; value: any }) {
+	return { kind: 'Argument', name: { kind: 'Name', value: name }, value };
+}
+
+function makeInfo(opts: {
+	fieldName: string;
+	args?: any[];
+	selections?: any[];
+	variableValues?: Record<string, any>;
+}): GraphQLResolveInfo {
+	return {
+		fieldName: opts.fieldName,
+		fieldNodes: [
+			{
+				kind: 'Field',
+				name: { kind: 'Name', value: opts.fieldName },
+				arguments: opts.args ?? [],
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: opts.selections ?? [field('id')],
+				},
+			},
+		],
+		fragments: {},
+		variableValues: opts.variableValues ?? {},
+	} as unknown as GraphQLResolveInfo;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('GraphQLService.resolveQuery — dedup contract (GHSA-ph52-67fq-75wj)', () => {
+	it('two sequential calls with identical info call read exactly once', async () => {
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'items' });
+		const readSpy = vi.spyOn(service, 'read').mockResolvedValue([{ id: 1 }] as any);
+
+		await service.resolveQuery(makeInfo({ fieldName: 'probe_items' }));
+		await service.resolveQuery(makeInfo({ fieldName: 'probe_items' }));
+
+		expect(readSpy).toHaveBeenCalledOnce();
+	});
+
+	it('two concurrent calls with identical info call read exactly once', async () => {
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'items' });
+		const readSpy = vi.spyOn(service, 'read').mockResolvedValue([{ id: 1 }] as any);
+
+		await Promise.all([
+			service.resolveQuery(makeInfo({ fieldName: 'probe_items' })),
+			service.resolveQuery(makeInfo({ fieldName: 'probe_items' })),
+		]);
+
+		expect(readSpy).toHaveBeenCalledOnce();
+	});
+
+	it('different arg values produce separate read calls', async () => {
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'items' });
+		const readSpy = vi.spyOn(service, 'read').mockResolvedValue([] as any);
+
+		await service.resolveQuery(
+			makeInfo({
+				fieldName: 'probe_items',
+				args: [arg('limit', { kind: 'IntValue', value: '5' })],
+			})
+		);
+		await service.resolveQuery(
+			makeInfo({
+				fieldName: 'probe_items',
+				args: [arg('limit', { kind: 'IntValue', value: '10' })],
+			})
+		);
+
+		expect(readSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('fragment-spread expansion produces the same cache key as inline selections', async () => {
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'items' });
+		const readSpy = vi.spyOn(service, 'read').mockResolvedValue([] as any);
+
+		const inlineInfo = makeInfo({
+			fieldName: 'probe_items',
+			selections: [field('id'), field('name')],
+		});
+
+		const fragmentInfo: GraphQLResolveInfo = {
+			fieldName: 'probe_items',
+			fieldNodes: [
+				{
+					kind: 'Field',
+					name: { kind: 'Name', value: 'probe_items' },
+					arguments: [],
+					selectionSet: {
+						kind: 'SelectionSet',
+						selections: [
+							{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'probeFields' } },
+						],
+					},
+				},
+			],
+			fragments: {
+				probeFields: {
+					kind: 'FragmentDefinition',
+					name: { kind: 'Name', value: 'probeFields' },
+					typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'probe_items' } },
+					selectionSet: {
+						kind: 'SelectionSet',
+						selections: [field('id'), field('name')],
+					},
+				},
+			},
+			variableValues: {},
+		} as unknown as GraphQLResolveInfo;
+
+		await service.resolveQuery(inlineInfo);
+		await service.resolveQuery(fragmentInfo);
+
+		expect(readSpy).toHaveBeenCalledOnce();
+	});
+
+	it('different selection sets produce separate read calls', async () => {
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'items' });
+		const readSpy = vi.spyOn(service, 'read').mockResolvedValue([] as any);
+
+		await service.resolveQuery(
+			makeInfo({
+				fieldName: 'probe_items',
+				selections: [field('id')],
+			})
+		);
+		await service.resolveQuery(
+			makeInfo({
+				fieldName: 'probe_items',
+				selections: [field('id'), field('name')],
+			})
+		);
+
+		expect(readSpy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('GraphQLService system resolvers — dedup contract (GHSA-ph52-67fq-75wj)', () => {
+	it('resolveSystemCollections shares one readByQuery across sequential calls', async () => {
+		const spy = vi.spyOn(CollectionsService.prototype, 'readByQuery').mockResolvedValue([] as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemCollections();
+		await (service as any).resolveSystemCollections();
+
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('resolveSystemFieldsInCollection keys on args: same args dedup, different args do not', async () => {
+		const spy = vi.spyOn(FieldsService.prototype, 'readAll').mockResolvedValue([] as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemFieldsInCollection({ collection: 'a' });
+		await (service as any).resolveSystemFieldsInCollection({ collection: 'a' });
+		await (service as any).resolveSystemFieldsInCollection({ collection: 'b' });
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenNthCalledWith(1, 'a');
+		expect(spy).toHaveBeenNthCalledWith(2, 'b');
+	});
+
+	it('resolveSystemFieldsByName distinguishes argument combinations', async () => {
+		const spy = vi.spyOn(FieldsService.prototype, 'readOne').mockResolvedValue({} as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemFieldsByName({ collection: 'a', field: 'x' });
+		await (service as any).resolveSystemFieldsByName({ collection: 'a', field: 'y' });
+		await (service as any).resolveSystemFieldsByName({ collection: 'b', field: 'x' });
+		await (service as any).resolveSystemFieldsByName({ collection: 'a', field: 'x' });
+
+		expect(spy).toHaveBeenCalledTimes(3);
+	});
+
+	it('resolveSystemRelations shares one readAll across sequential calls', async () => {
+		const spy = vi.spyOn(RelationsService.prototype, 'readAll').mockResolvedValue([] as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemRelations();
+		await (service as any).resolveSystemRelations();
+
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('resolveSystemUsersMe keys on selections: same selections dedup, different selections do not', async () => {
+		const spy = vi.spyOn(UsersService.prototype, 'readOne').mockResolvedValue({} as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		const infoA = makeInfo({
+			fieldName: 'users_me',
+			selections: [field('id')],
+		});
+		const infoB = makeInfo({
+			fieldName: 'users_me',
+			selections: [field('id'), field('email')],
+		});
+
+		await (service as any).resolveSystemUsersMe({}, infoA);
+		await (service as any).resolveSystemUsersMe({}, infoA);
+		await (service as any).resolveSystemUsersMe({}, infoB);
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it('resolveSystemServerInfo shares one serverInfo across sequential calls', async () => {
+		const spy = vi.spyOn(ServerService.prototype, 'serverInfo').mockResolvedValue({} as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemServerInfo();
+		await (service as any).resolveSystemServerInfo();
+
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('resolveSystemServerSpecsOas shares one oas.generate across sequential calls', async () => {
+		const sample = new SpecificationService({ accountability: adminAccountability, schema: makeSchema() });
+		const oasProto = Object.getPrototypeOf(sample.oas);
+		const spy = vi.spyOn(oasProto, 'generate').mockResolvedValue({} as any);
+
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemServerSpecsOas();
+		await (service as any).resolveSystemServerSpecsOas();
+
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('resolveSystemServerSpecsGraphql keys on scope: same scope dedup, different scope does not', async () => {
+		const spy = vi
+			.spyOn(GraphQLService.prototype, 'getSchema')
+			.mockImplementation(((type: any) => (type === 'sdl' ? 'sdl-stub' : ({} as any))) as any);
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveSystemServerSpecsGraphql({ scope: 'items' });
+		await (service as any).resolveSystemServerSpecsGraphql({ scope: 'items' });
+		await (service as any).resolveSystemServerSpecsGraphql({ scope: 'system' });
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('GraphQLService.resolveServerHealth — memoization preserved (advisory #3 regression)', () => {
+	it('runs ServerService.health() exactly once across sequential calls', async () => {
+		const spy = vi.spyOn(ServerService.prototype, 'health').mockResolvedValue({ status: 'ok' });
+		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
+
+		await (service as any).resolveServerHealth();
+		await (service as any).resolveServerHealth();
+
+		expect(spy).toHaveBeenCalledOnce();
+	});
+});

--- a/api/src/services/graphql/alias-amp-dedup.test.ts
+++ b/api/src/services/graphql/alias-amp-dedup.test.ts
@@ -135,6 +135,7 @@ describe('GraphQLService.resolveQuery — dedup contract (GHSA-ph52-67fq-75wj)',
 				args: [arg('limit', { kind: 'IntValue', value: '5' })],
 			})
 		);
+
 		await service.resolveQuery(
 			makeInfo({
 				fieldName: 'probe_items',
@@ -163,9 +164,7 @@ describe('GraphQLService.resolveQuery — dedup contract (GHSA-ph52-67fq-75wj)',
 					arguments: [],
 					selectionSet: {
 						kind: 'SelectionSet',
-						selections: [
-							{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'probeFields' } },
-						],
+						selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'probeFields' } }],
 					},
 				},
 			],
@@ -199,6 +198,7 @@ describe('GraphQLService.resolveQuery — dedup contract (GHSA-ph52-67fq-75wj)',
 				selections: [field('id')],
 			})
 		);
+
 		await service.resolveQuery(
 			makeInfo({
 				fieldName: 'probe_items',
@@ -264,6 +264,7 @@ describe('GraphQLService system resolvers — dedup contract (GHSA-ph52-67fq-75w
 			fieldName: 'users_me',
 			selections: [field('id')],
 		});
+
 		const infoB = makeInfo({
 			fieldName: 'users_me',
 			selections: [field('id'), field('email')],
@@ -303,6 +304,7 @@ describe('GraphQLService system resolvers — dedup contract (GHSA-ph52-67fq-75w
 		const spy = vi
 			.spyOn(GraphQLService.prototype, 'getSchema')
 			.mockImplementation(((type: any) => (type === 'sdl' ? 'sdl-stub' : ({} as any))) as any);
+
 		const service = new GraphQLService({ accountability: adminAccountability, schema: makeSchema(), scope: 'system' });
 
 		await (service as any).resolveSystemServerSpecsGraphql({ scope: 'items' });

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -127,10 +127,12 @@ export class GraphQLService {
 
 	private dedup<T>(key: string, thunk: () => Promise<T>): Promise<T> {
 		let cached = this.resolverCache.get(key) as Promise<T> | undefined;
+
 		if (!cached) {
 			cached = thunk();
 			this.resolverCache.set(key, cached);
 		}
+
 		return cached;
 	}
 
@@ -161,6 +163,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.serverInfo();
 		});
 	}
@@ -180,6 +183,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				scope: args['scope'] ?? 'items',
 			});
+
 			return Promise.resolve(service.getSchema('sdl'));
 		});
 	}
@@ -190,6 +194,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return collectionsService.readByQuery();
 		});
 	}
@@ -201,6 +206,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return collectionsService.readOne(args['name']);
 		});
 	}
@@ -211,6 +217,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readAll();
 		});
 	}
@@ -222,6 +229,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readAll(args['collection']);
 		});
 	}
@@ -233,6 +241,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readOne(args['collection'], args['field']);
 		});
 	}
@@ -243,6 +252,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readAll();
 		});
 	}
@@ -254,6 +264,7 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readAll(args['collection']);
 		});
 	}
@@ -265,14 +276,17 @@ export class GraphQLService {
 				accountability: this.accountability,
 				schema: this.schema,
 			});
+
 			return service.readOne(args['collection'], args['field']);
 		});
 	}
 
 	private resolveSystemUsersMe(args: Record<string, any>, info: GraphQLResolveInfo): Promise<Partial<Item> | null> {
 		if (!this.accountability?.user) return Promise.resolve(null);
+
 		const selections =
 			this.replaceFragmentsInSelections(info.fieldNodes[0]?.selectionSet?.selections, info.fragments) || [];
+
 		const query = this.getQuery(args, selections, info.variableValues);
 		const key = 'users_me:' + this.stableStringify({ user: this.accountability.user, query });
 		return this.dedup(key, () => {

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -116,11 +116,30 @@ export class GraphQLService {
 
 	private serverHealthPromise: Promise<Record<string, any>> | null = null;
 
+	private resolverCache: Map<string, Promise<unknown>> = new Map();
+
 	constructor(options: AbstractServiceOptions & { scope: 'items' | 'system' }) {
 		this.accountability = options?.accountability || null;
 		this.knex = options?.knex || getDatabase();
 		this.schema = options.schema;
 		this.scope = options.scope;
+	}
+
+	private dedup<T>(key: string, thunk: () => Promise<T>): Promise<T> {
+		let cached = this.resolverCache.get(key) as Promise<T> | undefined;
+		if (!cached) {
+			cached = thunk();
+			this.resolverCache.set(key, cached);
+		}
+		return cached;
+	}
+
+	private stableStringify(value: unknown): string {
+		if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'undefined';
+		if (Array.isArray(value)) return '[' + value.map((v) => this.stableStringify(v)).join(',') + ']';
+		const obj = value as Record<string, unknown>;
+		const keys = Object.keys(obj).sort();
+		return '{' + keys.map((k) => JSON.stringify(k) + ':' + this.stableStringify(obj[k])).join(',') + '}';
 	}
 
 	private resolveServerHealth(): Promise<Record<string, any>> {
@@ -134,6 +153,132 @@ export class GraphQLService {
 		}
 
 		return this.serverHealthPromise;
+	}
+
+	private resolveSystemServerInfo(): Promise<Record<string, any>> {
+		return this.dedup('server_info', () => {
+			const service = new ServerService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.serverInfo();
+		});
+	}
+
+	private resolveSystemServerSpecsOas(): Promise<Record<string, any>> {
+		return this.dedup('server_specs_oas', () => {
+			const service = new SpecificationService({ schema: this.schema, accountability: this.accountability });
+			return service.oas.generate();
+		});
+	}
+
+	private resolveSystemServerSpecsGraphql(args: Record<string, any>): Promise<string | GraphQLSchema> {
+		const key = 'server_specs_graphql:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const service = new GraphQLService({
+				schema: this.schema,
+				accountability: this.accountability,
+				scope: args['scope'] ?? 'items',
+			});
+			return Promise.resolve(service.getSchema('sdl'));
+		});
+	}
+
+	private resolveSystemCollections(): Promise<any[]> {
+		return this.dedup('collections', () => {
+			const collectionsService = new CollectionsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return collectionsService.readByQuery();
+		});
+	}
+
+	private resolveSystemCollectionsByName(args: Record<string, any>): Promise<any> {
+		const key = 'collections_by_name:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const collectionsService = new CollectionsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return collectionsService.readOne(args['name']);
+		});
+	}
+
+	private resolveSystemFields(): Promise<any[]> {
+		return this.dedup('fields', () => {
+			const service = new FieldsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readAll();
+		});
+	}
+
+	private resolveSystemFieldsInCollection(args: Record<string, any>): Promise<any[]> {
+		const key = 'fields_in_collection:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const service = new FieldsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readAll(args['collection']);
+		});
+	}
+
+	private resolveSystemFieldsByName(args: Record<string, any>): Promise<any> {
+		const key = 'fields_by_name:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const service = new FieldsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readOne(args['collection'], args['field']);
+		});
+	}
+
+	private resolveSystemRelations(): Promise<any[]> {
+		return this.dedup('relations', () => {
+			const service = new RelationsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readAll();
+		});
+	}
+
+	private resolveSystemRelationsInCollection(args: Record<string, any>): Promise<any[]> {
+		const key = 'relations_in_collection:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const service = new RelationsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readAll(args['collection']);
+		});
+	}
+
+	private resolveSystemRelationsByName(args: Record<string, any>): Promise<any> {
+		const key = 'relations_by_name:' + this.stableStringify({ args });
+		return this.dedup(key, () => {
+			const service = new RelationsService({
+				accountability: this.accountability,
+				schema: this.schema,
+			});
+			return service.readOne(args['collection'], args['field']);
+		});
+	}
+
+	private resolveSystemUsersMe(args: Record<string, any>, info: GraphQLResolveInfo): Promise<Partial<Item> | null> {
+		if (!this.accountability?.user) return Promise.resolve(null);
+		const selections =
+			this.replaceFragmentsInSelections(info.fieldNodes[0]?.selectionSet?.selections, info.fragments) || [];
+		const query = this.getQuery(args, selections, info.variableValues);
+		const key = 'users_me:' + this.stableStringify({ user: this.accountability.user, query });
+		return this.dedup(key, () => {
+			const service = new UsersService({ schema: this.schema, accountability: this.accountability });
+			return service.readOne(this.accountability!.user!, query);
+		});
 	}
 
 	/**
@@ -1332,10 +1477,6 @@ export class GraphQLService {
 		}
 	}
 
-	/**
-	 * Generic resolver that's used for every "regular" items/system query. Converts the incoming GraphQL AST / fragments into
-	 * CairnCMS' query structure which is then executed by the services.
-	 */
 	async resolveQuery(info: GraphQLResolveInfo): Promise<Partial<Item> | null> {
 		let collection = info.fieldName;
 		if (this.scope === 'system') collection = `directus_${collection}`;
@@ -1374,13 +1515,21 @@ export class GraphQLService {
 			query.limit = 1;
 		}
 
-		// Transform count(a.b.c) into a.b.count(c)
 		if (query.fields?.length) {
 			for (let fieldIndex = 0; fieldIndex < query.fields.length; fieldIndex++) {
 				query.fields[fieldIndex] = parseFilterFunctionPath(query.fields[fieldIndex]!);
 			}
 		}
 
+		const key = 'resolveQuery:' + this.stableStringify({ collection, query });
+		return this.dedup(key, () => this.resolveQueryImpl(collection, args, query)) as Promise<Partial<Item> | null>;
+	}
+
+	private async resolveQueryImpl(
+		collection: string,
+		args: Record<string, any>,
+		query: Query
+	): Promise<Partial<Item> | null> {
 		const result = await this.read(collection, query);
 
 		if (args['id']) {
@@ -1992,10 +2141,7 @@ export class GraphQLService {
 			},
 			server_specs_oas: {
 				type: GraphQLJSON,
-				resolve: async () => {
-					const service = new SpecificationService({ schema: this.schema, accountability: this.accountability });
-					return await service.oas.generate();
-				},
+				resolve: () => this.resolveSystemServerSpecsOas(),
 			},
 			server_specs_graphql: {
 				type: GraphQLString,
@@ -2008,15 +2154,7 @@ export class GraphQLService {
 						},
 					}),
 				},
-				resolve: async (_, args) => {
-					const service = new GraphQLService({
-						schema: this.schema,
-						accountability: this.accountability,
-						scope: args['scope'] ?? 'items',
-					});
-
-					return service.getSchema('sdl');
-				},
+				resolve: (_, args) => this.resolveSystemServerSpecsGraphql(args),
 			},
 			server_ping: {
 				type: GraphQLString,
@@ -2024,14 +2162,7 @@ export class GraphQLService {
 			},
 			server_info: {
 				type: ServerInfo,
-				resolve: async () => {
-					const service = new ServerService({
-						accountability: this.accountability,
-						schema: this.schema,
-					});
-
-					return await service.serverInfo();
-				},
+				resolve: () => this.resolveSystemServerInfo(),
 			},
 			server_health: {
 				type: GraphQLJSON,
@@ -2425,14 +2556,7 @@ export class GraphQLService {
 			schemaComposer.Query.addFields({
 				collections: {
 					type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Collection.getType()))),
-					resolve: async () => {
-						const collectionsService = new CollectionsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await collectionsService.readByQuery();
-					},
+					resolve: () => this.resolveSystemCollections(),
 				},
 
 				collections_by_name: {
@@ -2440,14 +2564,7 @@ export class GraphQLService {
 					args: {
 						name: new GraphQLNonNull(GraphQLString),
 					},
-					resolve: async (_, args) => {
-						const collectionsService = new CollectionsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await collectionsService.readOne(args['name']);
-					},
+					resolve: (_, args) => this.resolveSystemCollectionsByName(args),
 				},
 			});
 		}
@@ -2494,28 +2611,14 @@ export class GraphQLService {
 			schemaComposer.Query.addFields({
 				fields: {
 					type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Field.getType()))),
-					resolve: async () => {
-						const service = new FieldsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readAll();
-					},
+					resolve: () => this.resolveSystemFields(),
 				},
 				fields_in_collection: {
 					type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Field.getType()))),
 					args: {
 						collection: new GraphQLNonNull(GraphQLString),
 					},
-					resolve: async (_, args) => {
-						const service = new FieldsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readAll(args['collection']);
-					},
+					resolve: (_, args) => this.resolveSystemFieldsInCollection(args),
 				},
 				fields_by_name: {
 					type: Field,
@@ -2523,14 +2626,7 @@ export class GraphQLService {
 						collection: new GraphQLNonNull(GraphQLString),
 						field: new GraphQLNonNull(GraphQLString),
 					},
-					resolve: async (_, args) => {
-						const service = new FieldsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readOne(args['collection'], args['field']);
-					},
+					resolve: (_, args) => this.resolveSystemFieldsByName(args),
 				},
 			});
 		}
@@ -2568,28 +2664,14 @@ export class GraphQLService {
 			schemaComposer.Query.addFields({
 				relations: {
 					type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Relation.getType()))),
-					resolve: async () => {
-						const service = new RelationsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readAll();
-					},
+					resolve: () => this.resolveSystemRelations(),
 				},
 				relations_in_collection: {
 					type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Relation.getType()))),
 					args: {
 						collection: new GraphQLNonNull(GraphQLString),
 					},
-					resolve: async (_, args) => {
-						const service = new RelationsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readAll(args['collection']);
-					},
+					resolve: (_, args) => this.resolveSystemRelationsInCollection(args),
 				},
 				relations_by_name: {
 					type: Relation,
@@ -2597,14 +2679,7 @@ export class GraphQLService {
 						collection: new GraphQLNonNull(GraphQLString),
 						field: new GraphQLNonNull(GraphQLString),
 					},
-					resolve: async (_, args) => {
-						const service = new RelationsService({
-							accountability: this.accountability,
-							schema: this.schema,
-						});
-
-						return await service.readOne(args['collection'], args['field']);
-					},
+					resolve: (_, args) => this.resolveSystemRelationsByName(args),
 				},
 			});
 		}
@@ -2797,19 +2872,7 @@ export class GraphQLService {
 			schemaComposer.Query.addFields({
 				users_me: {
 					type: ReadCollectionTypes['directus_users']!,
-					resolve: async (_, args, __, info) => {
-						if (!this.accountability?.user) return null;
-						const service = new UsersService({ schema: this.schema, accountability: this.accountability });
-
-						const selections = this.replaceFragmentsInSelections(
-							info.fieldNodes[0]?.selectionSet?.selections,
-							info.fragments
-						);
-
-						const query = this.getQuery(args, selections || [], info.variableValues);
-
-						return await service.readOne(this.accountability.user, query);
-					},
+					resolve: (_, args, __, info) => this.resolveSystemUsersMe(args, info),
 				},
 			});
 		}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-ph52-67fq-75wj / CVE-2026-35441.

The GraphQL read path executed each aliased resolver invocation independently within a single request. That meant an authenticated caller could repeat the same expensive resolver under many aliases and force repeated service and database work without any request-scoped deduplication. The `server_health` memoization from GHSA-6q22-g298-grjh only covered the one parameterless resolver. The broader alias-amplification surface remained open across both the generic `resolveQuery(...)` path and several custom system read resolvers that bypass it.

This PR adds request-scoped promise deduplication to `GraphQLService` and applies it across the full read-resolver surface. Generic collection reads now deduplicate on the normalized `{ collection, query }` shape, and the custom DB- or CPU-hitting system read resolvers now deduplicate on resolver-specific keys derived from the actual execution inputs. `users_me` is keyed on `{ user, query }` because its underlying `readOne(...)` call depends on the normalized query built from the selection set. That normalized-query keying also closes the fragment-spread bypass discovered during review: semantically identical inline and fragment-expanded selections now share the same cache key instead of bypassing dedup through raw AST syntax differences.

### Testing / verification

- Added `alias-amp-dedup.test.ts` coverage for:
  - sequential and concurrent dedup on `resolveQuery(...)`
  - distinct-args separation on `resolveQuery(...)`
  - fragment-spread vs inline selection equivalence on `resolveQuery(...)`
  - distinct-selection separation on `resolveQuery(...)`
  - dedup behavior on custom read resolvers including `collections`, `fields_in_collection`, `fields_by_name`, `relations`, `users_me`, `server_info`, `server_specs_oas`, and `server_specs_graphql`
  - preserving the existing `server_health` memoization behavior

Also verified against a live Postgres instance and confirmed:
- repeated aliases of the same read resolver now share one execution path rather than re-running the same work per alias
- `users(limit: 1)` aliases still return the expected result sets after the dedup change
- `server_specs_graphql` remains functional and scope-sensitive under normal operation
- standard `__schema` introspection behavior is unchanged
- fragment-spread and inline selection variants return identical data while now sharing the same normalized dedup key

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
