### PR TITLE
Remove access tokens from admin asset URL generation (GHSA-2ccr-g2rv-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Added parser-bypass regression coverage for SSO redirect validation (GHSA-cf45-hxwj-4cfj / CVE-2026-35410).
 - Gated GraphQL SDL specs on GRAPHQL_INTROSPECTION (GHSA-wxwm-3fxv-mrvx / CVE-2026-35413).
 - Deduplicated GraphQL read resolver invocations within a request (GHSA-ph52-67fq-75wj / CVE-2026-35441).
+- Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
 
 ### Acknowledgements
 

--- a/api/src/controllers/assets.test.ts
+++ b/api/src/controllers/assets.test.ts
@@ -43,10 +43,15 @@ vi.mock('../env.js', () => {
 		ASSETS_TRANSFORM_MAX_CONCURRENT: 25,
 		ASSETS_TRANSFORM_TIMEOUT: '7500ms',
 		ASSETS_INVALID_IMAGE_SENSITIVITY_LEVEL: 'warning',
+		REFRESH_TOKEN_COOKIE_NAME: 'cairncms_refresh_token',
 	};
 
 	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
 });
+
+vi.mock('../middleware/extract-cookie-session.js', () => ({
+	default: (_req: any, _res: any, next: any) => next(),
+}));
 
 import assetsRouter from './assets.js';
 

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -8,6 +8,7 @@ import getDatabase from '../database/index.js';
 import env from '../env.js';
 import { InvalidQueryException, RangeNotSatisfiableException } from '../exceptions/index.js';
 import logger from '../logger.js';
+import extractCookieSession from '../middleware/extract-cookie-session.js';
 import useCollection from '../middleware/use-collection.js';
 import { AssetsService } from '../services/assets.js';
 import { PayloadService } from '../services/payload.js';
@@ -21,6 +22,7 @@ import { getMilliseconds } from '../utils/get-milliseconds.js';
 const router = Router();
 
 router.use(useCollection('directus_files'));
+router.use(extractCookieSession);
 
 router.get(
 	'/:pk/:filename?',

--- a/api/src/middleware/extract-cookie-session.test.ts
+++ b/api/src/middleware/extract-cookie-session.test.ts
@@ -1,0 +1,183 @@
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabase: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../env.js', () => {
+	const MOCK_ENV = { REFRESH_TOKEN_COOKIE_NAME: 'cairncms_refresh_token', SECRET: 'test' };
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+const lookupSessionSpy = vi.fn();
+
+vi.mock('../services/authentication.js', () => ({
+	AuthenticationService: vi.fn().mockImplementation(() => ({ lookupSession: lookupSessionSpy })),
+}));
+
+const getPermissionsSpy = vi.fn();
+
+vi.mock('../utils/get-permissions.js', () => ({
+	getPermissions: getPermissionsSpy,
+}));
+
+const { handler } = await import('./extract-cookie-session.js');
+
+const schema = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+const cannedPermissions = [{ collection: 'directus_files', action: 'read' }];
+
+function defaultPublic(): Accountability {
+	return { user: null, role: null, admin: false, app: false, ip: '127.0.0.1' };
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+	return {
+		token: null,
+		cookies: {},
+		schema,
+		accountability: defaultPublic(),
+		...overrides,
+	} as unknown as Request;
+}
+
+beforeEach(() => {
+	lookupSessionSpy.mockReset();
+	getPermissionsSpy.mockReset();
+	getPermissionsSpy.mockResolvedValue(cannedPermissions);
+});
+
+describe('extract-cookie-session middleware (GHSA-2ccr-g2rv-h677)', () => {
+	it('populates accountability and recomputes permissions for an active user with a valid cookie', async () => {
+		lookupSessionSpy.mockResolvedValue({
+			user_id: 'admin-uuid',
+			user_status: 'active',
+			role_id: 'admin-role-uuid',
+			role_admin_access: true,
+			role_app_access: true,
+		});
+
+		const req = makeReq({ cookies: { cairncms_refresh_token: 'valid-cookie' } });
+		const res = {} as Response;
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, res, next);
+
+		expect(req.accountability!.user).toBe('admin-uuid');
+		expect(req.accountability!.role).toBe('admin-role-uuid');
+		expect(req.accountability!.admin).toBe(true);
+		expect(req.accountability!.app).toBe(true);
+		expect(req.accountability!.permissions).toEqual(cannedPermissions);
+		expect(getPermissionsSpy).toHaveBeenCalledOnce();
+		expect(next).toHaveBeenCalledOnce();
+	});
+
+	it('leaves accountability at default when no cookie is present', async () => {
+		const req = makeReq();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability).toEqual(defaultPublic());
+		expect(lookupSessionSpy).not.toHaveBeenCalled();
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('no-ops when a Bearer token is already set', async () => {
+		const req = makeReq({ token: 'existing-jwt', cookies: { cairncms_refresh_token: 'valid-cookie' } });
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability).toEqual(defaultPublic());
+		expect(lookupSessionSpy).not.toHaveBeenCalled();
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('no-ops when accountability already has a user populated', async () => {
+		const req = makeReq({
+			accountability: { ...defaultPublic(), user: 'someone-else', role: 'their-role' },
+			cookies: { cairncms_refresh_token: 'valid-cookie' },
+		});
+
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability!.user).toBe('someone-else');
+		expect(lookupSessionSpy).not.toHaveBeenCalled();
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('leaves accountability at default when lookupSession returns null (expired or invalid)', async () => {
+		lookupSessionSpy.mockResolvedValue(null);
+		const req = makeReq({ cookies: { cairncms_refresh_token: 'expired' } });
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability).toEqual(defaultPublic());
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('skips populating accountability when the user is suspended', async () => {
+		lookupSessionSpy.mockResolvedValue({
+			user_id: 'suspended-uuid',
+			user_status: 'suspended',
+			role_id: 'role-uuid',
+			role_admin_access: false,
+			role_app_access: true,
+		});
+
+		const req = makeReq({ cookies: { cairncms_refresh_token: 'valid-cookie' } });
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability).toEqual(defaultPublic());
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('no-ops when authenticate filter produced a custom accountability', async () => {
+		const customAccountability = { admin: true, user: null, role: null, app: false, ip: '127.0.0.1' } as Accountability;
+
+		const req = makeReq({
+			accountability: customAccountability,
+			cookies: { cairncms_refresh_token: 'valid-cookie' },
+		});
+
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability).toEqual(customAccountability);
+		expect(lookupSessionSpy).not.toHaveBeenCalled();
+		expect(getPermissionsSpy).not.toHaveBeenCalled();
+	});
+
+	it('populates share accountability fields when the session is a share', async () => {
+		lookupSessionSpy.mockResolvedValue({
+			share_id: 'share-uuid',
+			share_role: 'share-role-uuid',
+			share_collection: 'articles',
+			share_item: 'article-42',
+		});
+
+		const req = makeReq({ cookies: { cairncms_refresh_token: 'valid-share-cookie' } });
+		const next = vi.fn() as unknown as NextFunction;
+
+		await handler(req, {} as Response, next);
+
+		expect(req.accountability!.share).toBe('share-uuid');
+		expect(req.accountability!.role).toBe('share-role-uuid');
+		expect(req.accountability!.share_scope).toEqual({ collection: 'articles', item: 'article-42' });
+		expect(req.accountability!.admin).toBe(false);
+		expect(req.accountability!.app).toBe(false);
+		expect(req.accountability!.permissions).toEqual(cannedPermissions);
+		expect(getPermissionsSpy).toHaveBeenCalledOnce();
+	});
+});

--- a/api/src/middleware/extract-cookie-session.ts
+++ b/api/src/middleware/extract-cookie-session.ts
@@ -1,0 +1,48 @@
+import type { RequestHandler } from 'express';
+import env from '../env.js';
+import { AuthenticationService } from '../services/authentication.js';
+import asyncHandler from '../utils/async-handler.js';
+import { getPermissions } from '../utils/get-permissions.js';
+
+export const handler: RequestHandler = async (req, _res, next) => {
+	if (req.token) return next();
+	if (!req.accountability) return next();
+
+	const isDefaultPublic =
+		req.accountability.user === null &&
+		req.accountability.role === null &&
+		req.accountability.admin === false &&
+		req.accountability.app === false &&
+		req.accountability.share === undefined;
+
+	if (!isDefaultPublic) return next();
+
+	const cookieName = env['REFRESH_TOKEN_COOKIE_NAME'] as string;
+	const refreshToken = req.cookies?.[cookieName];
+	if (!refreshToken) return next();
+
+	const authService = new AuthenticationService({ accountability: null, schema: req.schema });
+	const record = await authService.lookupSession(refreshToken);
+	if (!record) return next();
+
+	if (record.user_id && (record.user_status as string) !== 'active') return next();
+
+	if (record.user_id) {
+		req.accountability.user = record.user_id;
+		req.accountability.role = record.role_id;
+		req.accountability.admin = record.role_admin_access === true || (record.role_admin_access as unknown) === 1;
+		req.accountability.app = record.role_app_access === true || (record.role_app_access as unknown) === 1;
+	} else if (record.share_id) {
+		req.accountability.share = record.share_id;
+		req.accountability.role = record.share_role;
+		req.accountability.share_scope = { collection: record.share_collection, item: record.share_item };
+		req.accountability.app = false;
+		req.accountability.admin = false;
+	}
+
+	req.accountability.permissions = await getPermissions(req.accountability, req.schema);
+
+	return next();
+};
+
+export default asyncHandler(handler);

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -20,6 +20,30 @@ import { TFAService } from './tfa.js';
 
 const loginAttemptsLimiter = createRateLimiter('RATE_LIMITER', { duration: 0 });
 
+export interface SessionRecord {
+	session_expires: Date;
+	user_id: string;
+	user_first_name: string;
+	user_last_name: string;
+	user_email: string;
+	user_password: string;
+	user_status: User['status'];
+	user_provider: string;
+	user_external_identifier: string;
+	user_auth_data: string;
+	role_id: string;
+	role_admin_access: boolean;
+	role_app_access: boolean;
+	share_id: string;
+	share_item: string;
+	share_role: string;
+	share_collection: string;
+	share_start: Date;
+	share_end: Date;
+	share_times_used: number;
+	share_max_uses: number;
+}
+
 export class AuthenticationService {
 	knex: Knex;
 	accountability: Accountability | null;
@@ -248,14 +272,8 @@ export class AuthenticationService {
 		};
 	}
 
-	async refresh(refreshToken: string): Promise<Record<string, any>> {
-		const { nanoid } = await import('nanoid');
-		const STALL_TIME = env['LOGIN_STALL_TIME'];
-		const timeStart = performance.now();
-
-		if (!refreshToken) {
-			throw new InvalidCredentialsException();
-		}
+	async lookupSession(refreshToken: string): Promise<SessionRecord | null> {
+		if (!refreshToken) return null;
 
 		const record = await this.knex
 			.select({
@@ -296,6 +314,20 @@ export class AuthenticationService {
 				subQuery.whereNull('d.date_start').orWhere('d.date_start', '<=', new Date());
 			})
 			.first();
+
+		return record ?? null;
+	}
+
+	async refresh(refreshToken: string): Promise<Record<string, any>> {
+		const { nanoid } = await import('nanoid');
+		const STALL_TIME = env['LOGIN_STALL_TIME'];
+		const timeStart = performance.now();
+
+		if (!refreshToken) {
+			throw new InvalidCredentialsException();
+		}
+
+		const record = await this.lookupSession(refreshToken);
 
 		if (!record || (!record.share_id && !record.user_id)) {
 			throw new InvalidCredentialsException();

--- a/app/src/api.ts
+++ b/app/src/api.ts
@@ -2,7 +2,6 @@ import { logout, LogoutReason, refresh } from '@/auth';
 import { useRequestsStore } from '@/stores/requests';
 import { getRootPath } from '@/utils/get-root-path';
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { addQueryToPath } from './utils/add-query-to-path';
 import PQueue, { Options, DefaultAddOptions } from 'p-queue';
 
 const api = axios.create({
@@ -99,17 +98,6 @@ api.interceptors.request.use(onRequest);
 api.interceptors.response.use(onResponse, onError);
 
 export default api;
-
-export function getToken(): string | null {
-	return api.defaults.headers.common['Authorization']?.split(' ')[1] || null;
-}
-
-export function addTokenToURL(url: string, token?: string): string {
-	const accessToken = token || getToken();
-	if (!accessToken) return url;
-
-	return addQueryToPath(url, { access_token: accessToken });
-}
 
 export async function replaceQueue(options?: Options<any, DefaultAddOptions>) {
 	await queue.onIdle();

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -85,7 +85,7 @@
 </template>
 
 <script setup lang="ts">
-import api, { addTokenToURL } from '@/api';
+import api from '@/api';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
 import { useRelationPermissionsM2O } from '@/composables/use-relation-permissions';
 import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
@@ -148,8 +148,7 @@ const src = computed(() => {
 
 	if (image.value.type.includes('image')) {
 		const fit = props.crop ? 'cover' : 'contain';
-		const url = `/assets/${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`;
-		return addTokenToURL(url);
+		return `/assets/${image.value.id}?key=system-large-${fit}&cache-buster=${image.value.modified_on}`;
 	}
 
 	return null;

--- a/app/src/interfaces/input-rich-text-html/useImage.ts
+++ b/app/src/interfaces/input-rich-text-html/useImage.ts
@@ -1,4 +1,3 @@
-import { getToken } from '@/api';
 import { i18n } from '@/lang';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getPublicURL } from '@/utils/get-root-path';
@@ -87,7 +86,7 @@ export default function useImage(
 					width: selectedPreset.value ? selectedPreset.value.width ?? undefined : width,
 					height: selectedPreset.value ? selectedPreset.value.height ?? undefined : height,
 					transformationKey,
-					previewUrl: replaceUrlAccessToken(imageUrl, imageToken.value ?? getToken()),
+					previewUrl: replaceUrlAccessToken(imageUrl, imageToken.value),
 				};
 			} else {
 				imageSelection.value = null;
@@ -121,7 +120,7 @@ export default function useImage(
 			alt: image.title,
 			width: image.width,
 			height: image.height,
-			previewUrl: replaceUrlAccessToken(assetUrl, imageToken.value ?? getToken()),
+			previewUrl: replaceUrlAccessToken(assetUrl, imageToken.value),
 		};
 	}
 

--- a/app/src/interfaces/input-rich-text-html/useMedia.ts
+++ b/app/src/interfaces/input-rich-text-html/useMedia.ts
@@ -1,4 +1,3 @@
-import { getToken } from '@/api';
 import { i18n } from '@/lang';
 import { getPublicURL } from '@/utils/get-root-path';
 import { computed, Ref, ref, watch } from 'vue';
@@ -81,7 +80,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 				sourceUrl: newSource,
 			};
 
-			mediaSelection.value.previewUrl = replaceUrlAccessToken(newSource, imageToken.value || getToken());
+			mediaSelection.value.previewUrl = replaceUrlAccessToken(newSource, imageToken.value);
 		},
 	});
 
@@ -133,7 +132,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 			if (sourceUrl === undefined) return;
 
 			// Add temporarily access token for preview
-			const previewUrl = replaceUrlAccessToken(sourceUrl, imageToken.value || getToken());
+			const previewUrl = replaceUrlAccessToken(sourceUrl, imageToken.value);
 
 			mediaSelection.value = {
 				tag: tag === 'audio' ? 'audio' : tag === 'iframe' ? 'iframe' : 'video',
@@ -179,7 +178,7 @@ export default function useMedia(editor: Ref<any>, imageToken: Ref<string | unde
 			height: media.height || 150,
 			tag,
 			type: media.type,
-			previewUrl: replaceUrlAccessToken(sourceUrl, imageToken.value || getToken()),
+			previewUrl: replaceUrlAccessToken(sourceUrl, imageToken.value),
 		};
 	}
 

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -131,7 +131,7 @@ import { defineComponent, computed, ref, watch } from 'vue';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { formatFilesize } from '@/utils/format-filesize';
 import { localizedFormat } from '@/utils/localized-format';
-import api, { addTokenToURL } from '@/api';
+import api from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 import { userName } from '@/utils/user-name';
 
@@ -162,7 +162,7 @@ export default defineComponent({
 		const { folder, folderLink } = useFolder();
 
 		const fileLink = computed(() => {
-			return addTokenToURL(`${getRootPath()}assets/${props.file.id}`);
+			return `${getRootPath()}assets/${props.file.id}`;
 		});
 
 		return {

--- a/app/src/utils/get-asset-url.test.ts
+++ b/app/src/utils/get-asset-url.test.ts
@@ -1,4 +1,3 @@
-import { addTokenToURL } from '@/api';
 import { getAssetUrl } from '@/utils/get-asset-url';
 import { cryptoStub } from '@/__utils__/crypto';
 import { expect, test, vi } from 'vitest';
@@ -12,26 +11,30 @@ Object.defineProperty(window, 'URL', {
 	value: URL,
 });
 
-test('Get asset url', () => {
+test('Get asset url returns bare URL without access_token query', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://example.com/');
 	const output = getAssetUrl('test.jpg');
-	expect(output).toBe(`https://example.com${addTokenToURL('/assets/test.jpg')}`);
+	expect(output).toBe('https://example.com/assets/test.jpg');
+	expect(new URL(output).searchParams.has('access_token')).toBe(false);
 });
 
-test('Get asset url for download', () => {
+test('Get asset url for download keeps the download flag and omits access_token', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://example.com/');
 	const output = getAssetUrl('test.jpg', true);
-	expect(output).toBe(`https://example.com${addTokenToURL('/assets/test.jpg?download=')}`);
+	expect(output).toBe('https://example.com/assets/test.jpg?download=');
+	expect(new URL(output).searchParams.has('access_token')).toBe(false);
 });
 
-test('Subdirectory Install: Get asset url', () => {
+test('Subdirectory Install: Get asset url returns bare URL', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://example.com/subdirectory/');
 	const output = getAssetUrl('test.jpg');
-	expect(output).toBe(`https://example.com/subdirectory${addTokenToURL('/assets/test.jpg')}`);
+	expect(output).toBe('https://example.com/subdirectory/assets/test.jpg');
+	expect(new URL(output).searchParams.has('access_token')).toBe(false);
 });
 
-test('Subdirectory Install: Get asset url for download', () => {
+test('Subdirectory Install: Get asset url for download omits access_token', () => {
 	vi.mocked(getPublicURL).mockReturnValueOnce('https://example.com/subdirectory/');
 	const output = getAssetUrl('test.jpg', true);
-	expect(output).toBe(`https://example.com/subdirectory${addTokenToURL('/assets/test.jpg?download=')}`);
+	expect(output).toBe('https://example.com/subdirectory/assets/test.jpg?download=');
+	expect(new URL(output).searchParams.has('access_token')).toBe(false);
 });

--- a/app/src/utils/get-asset-url.ts
+++ b/app/src/utils/get-asset-url.ts
@@ -1,4 +1,3 @@
-import { addTokenToURL } from '@/api';
 import { getPublicURL } from '@/utils/get-root-path';
 
 export function getAssetUrl(filename: string, isDownload?: boolean): string {
@@ -8,5 +7,5 @@ export function getAssetUrl(filename: string, isDownload?: boolean): string {
 		assetUrl.searchParams.set('download', '');
 	}
 
-	return addTokenToURL(assetUrl.href);
+	return assetUrl.href;
 }

--- a/app/src/views/private/components/file-preview.vue
+++ b/app/src/views/private/components/file-preview.vue
@@ -19,7 +19,6 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
 import { readableMimeType } from '@/utils/readable-mime-type';
-import { addTokenToURL } from '@/api';
 import { getRootPath } from '@/utils/get-root-path';
 
 interface Props {
@@ -60,7 +59,7 @@ const isSVG = computed(() => props.mime.includes('svg'));
 const maxHeight = computed(() => Math.min(props.height ?? 528, 528) + 'px');
 const isSmall = computed(() => props.height < 528);
 
-const authenticatedSrc = computed(() => addTokenToURL(getRootPath() + props.src));
+const authenticatedSrc = computed(() => getRootPath() + props.src);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -124,7 +124,7 @@
 </template>
 
 <script lang="ts">
-import api, { addTokenToURL } from '@/api';
+import api from '@/api';
 import { computed, defineComponent, nextTick, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -204,7 +204,7 @@ export default defineComponent({
 		const randomId = ref<string>(nanoid());
 
 		const imageURL = computed(() => {
-			return addTokenToURL(`${getRootPath()}assets/${props.id}?${randomId.value}`);
+			return `${getRootPath()}assets/${props.id}?${randomId.value}`;
 		});
 
 		const dimensionsString = computed(() => {

--- a/app/src/views/private/components/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar.vue
@@ -51,7 +51,6 @@
 </template>
 
 <script lang="ts">
-import { addTokenToURL } from '@/api';
 import { useAppStore } from '@/stores/app';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
@@ -76,7 +75,7 @@ export default defineComponent({
 
 		const avatarURL = computed<string | null>(() => {
 			if (!userStore.currentUser || !('avatar' in userStore.currentUser) || !userStore.currentUser?.avatar) return null;
-			return addTokenToURL(`${getRootPath()}assets/${userStore.currentUser.avatar.id}?key=system-medium-cover`);
+			return `${getRootPath()}assets/${userStore.currentUser.avatar.id}?key=system-medium-cover`;
 		});
 
 		const avatarError: Ref<null | Event> = ref(null);


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-2ccr-g2rv-h677 / CVE-2024-28238.

Authenticated asset URLs were being generated in the admin app with the session bearer token appended as `?access_token=...`. This exposed live tokens to URL-bearing surfaces such as browser history, referrer headers, intermediary logs, copied links, and server access logs. The backend also explicitly accepted `access_token` in the query string, so the tokenized URLs were functional rather than inert.

This PR prevents generating tokenized asset URLs in first-party admin flows and switches same-origin asset reads to a cookie-backed authentication path scoped to the asset router. Asset requests can now derive accountability from the existing refresh-token cookie when the request is otherwise still at default-public accountability, and the middleware recomputes permissions so asset authorization sees the authenticated user or share session rather than the stale public permission set computed earlier in the global middleware chain. Bearer-header auth and legacy query-token auth remain accepted server-side for backward compatibility, but the admin app no longer emits session bearer tokens into asset URLs.

### Testing / verification

- Added `api/src/middleware/extract-cookie-session.test.ts` coverage for:
  - populating accountability and recomputing permissions for active user sessions
  - leaving requests unchanged when no cookie is present
  - no-op behavior when Bearer or query-token auth is already present
  - skipping suspended sessions
  - populating share-session accountability
  - preserving custom accountability produced by the `authenticate` filter hook
- Added `AuthenticationService.refresh()` regression coverage for:
  - preserving the suspended-user rejection path
  - preserving invalid inactive-user rejection
- Updated `app/src/utils/get-asset-url.test.ts` to assert asset URLs no longer include `access_token`

Also verified against a live Postgres-backed instance and confirmed:
- cookie-only authenticated asset requests succeed for admin users
- Bearer-header asset requests continue to work unchanged
- legacy `?access_token=...` asset URLs still work for backward compatibility
- unauthenticated asset requests still fail when the file is not public
- invalid refresh-token cookies do not authenticate the asset request
- the built admin bundle no longer contains first-party `addTokenToURL` asset generation or default Authorization-header injection artifacts for these asset URLs

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
