### PR TITLE
Close DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Gated GraphQL SDL specs on GRAPHQL_INTROSPECTION (GHSA-wxwm-3fxv-mrvx / CVE-2026-35413).
 - Deduplicated GraphQL read resolver invocations within a request (GHSA-ph52-67fq-75wj / CVE-2026-35441).
 - Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
+- Closed DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw / CVE-2024-6533).
 
 ### Acknowledgements
 

--- a/app/src/components/v-field-template/v-field-template.test.ts
+++ b/app/src/components/v-field-template/v-field-template.test.ts
@@ -1,0 +1,130 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import VFieldTemplate from './v-field-template.vue';
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getFieldsForCollection: () => [],
+		getFieldsForCollectionSorted: () => [],
+		getField: () => null,
+	}),
+}));
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: () => ({
+		getRelationsForField: () => [],
+		getRelationsForCollection: () => [],
+	}),
+}));
+
+const globalStubs = {
+	VMenu: {
+		template: '<div><slot name="activator" :toggle="() => {}" /><slot /></div>',
+	},
+	VInput: {
+		template: '<div><slot name="input" /><slot name="append" /></div>',
+	},
+	VList: {
+		template: '<div><slot /></div>',
+	},
+	VIcon: { template: '<i />' },
+	FieldListItem: { template: '<div />' },
+};
+
+function makeField(field: string, name: string) {
+	return {
+		field,
+		name,
+		collection: 'probe',
+		type: 'string',
+		meta: null,
+		schema: null,
+	} as any;
+}
+
+function mountWithInject(modelValue: string | null, fields: any[] = []) {
+	return mount(VFieldTemplate, {
+		props: {
+			modelValue,
+			collection: 'probe',
+			inject: { fields, relations: [] },
+		},
+		global: { stubs: globalStubs },
+	});
+}
+
+describe('v-field-template — XSS (GHSA-9qrm-48qf-r2rw)', () => {
+	it('renders <iframe> in stored template as text, not as an iframe element', () => {
+		const malicious = '<iframe srcdoc="alert(1)"></iframe>';
+		const wrapper = mountWithInject(malicious);
+
+		expect(wrapper.find('.content iframe').exists()).toBe(false);
+		expect(wrapper.find('.content').text()).toBe(malicious);
+	});
+
+	it('renders <script> in stored template as text, not as a script element', () => {
+		const malicious = '<script>alert(1)</script>';
+		const wrapper = mountWithInject(malicious);
+
+		expect(wrapper.find('.content script').exists()).toBe(false);
+		expect(wrapper.find('.content').text()).toBe(malicious);
+	});
+
+	it('renders <img onerror=...> as text, not as a live element', () => {
+		const malicious = '<img src=x onerror=alert(1)>';
+		const wrapper = mountWithInject(malicious);
+
+		expect(wrapper.find('.content img').exists()).toBe(false);
+		expect(wrapper.find('.content').text()).toBe(malicious);
+	});
+});
+
+describe('v-field-template — template shape and round-trip', () => {
+	it('renders mixed literal and placeholder parts with the expected DOM shape', () => {
+		const wrapper = mountWithInject('Hello {{name}} <world>', [makeField('name', 'Name')]);
+
+		const spans = wrapper.findAll('.content span.text');
+		const buttons = wrapper.findAll('.content button[data-field="name"]');
+
+		expect(spans).toHaveLength(2);
+		expect(spans[0]!.element.textContent).toBe('Hello ');
+		expect(spans[1]!.element.textContent).toBe(' <world>');
+		expect(buttons).toHaveLength(1);
+		expect(buttons[0]!.element.textContent).toBe('Name');
+	});
+
+	it('round-trips a mixed template via an input event back to the original modelValue', async () => {
+		const wrapper = mountWithInject('Hello {{name}} <world>', [makeField('name', 'Name')]);
+
+		await wrapper.find('.content').trigger('input');
+
+		const emitted = wrapper.emitted('update:modelValue');
+		expect(emitted).toBeTruthy();
+		expect(emitted![emitted!.length - 1]).toEqual(['Hello {{name}} <world>']);
+	});
+
+	it('renders an empty model value as a single empty .text span', () => {
+		const wrapper = mountWithInject('');
+
+		const spans = wrapper.findAll('.content span.text');
+		const buttons = wrapper.findAll('.content button');
+
+		expect(spans).toHaveLength(1);
+		expect(spans[0]!.text()).toBe('');
+		expect(buttons).toHaveLength(0);
+	});
+
+	it('renders multiple placeholders as one button each', () => {
+		const wrapper = mountWithInject('{{first_name}} {{last_name}}', [
+			makeField('first_name', 'First Name'),
+			makeField('last_name', 'Last Name'),
+		]);
+
+		const buttons = wrapper.findAll('.content button[data-field]');
+		expect(buttons).toHaveLength(2);
+		expect(buttons[0]!.attributes('data-field')).toBe('first_name');
+		expect(buttons[0]!.text()).toBe('First Name');
+		expect(buttons[1]!.attributes('data-field')).toBe('last_name');
+		expect(buttons[1]!.text()).toBe('Last Name');
+	});
+});

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -258,38 +258,44 @@ function setContent() {
 	if (!contentEl.value) return;
 
 	if (props.modelValue === null || props.modelValue === '') {
-		contentEl.value.innerHTML = '<span class="text"></span>';
+		const emptySpan = document.createElement('span');
+		emptySpan.className = 'text';
+		contentEl.value.replaceChildren(emptySpan);
 		return;
 	}
 
 	if (props.modelValue !== getInputValue()) {
 		const regex = /({{.*?}})/g;
+		const fragment = document.createDocumentFragment();
 
-		const newInnerHTML = props.modelValue
-			.split(regex)
-			.map((part) => {
-				if (part.startsWith('{{') === false) {
-					return `<span class="text">${part}</span>`;
-				}
+		for (const part of props.modelValue.split(regex)) {
+			if (part.startsWith('{{') === false) {
+				const span = document.createElement('span');
+				span.className = 'text';
+				span.textContent = part;
+				fragment.appendChild(span);
+				continue;
+			}
 
-				const fieldKey = part.replace(/({|})/g, '').trim();
-				const fieldPath = fieldKey.split('.');
+			const fieldKey = part.replace(/({|})/g, '').trim();
+			const fieldPath = fieldKey.split('.');
 
-				for (let i = 0; i < fieldPath.length; i++) {
-					loadFieldRelations(fieldPath.slice(0, i).join('.'));
-				}
+			for (let i = 0; i < fieldPath.length; i++) {
+				loadFieldRelations(fieldPath.slice(0, i).join('.'));
+			}
 
-				const field = findTree(grouplessTree.value, fieldPath);
+			const field = findTree(grouplessTree.value, fieldPath);
+			if (!field) continue;
 
-				if (!field) return '';
+			const button = document.createElement('button');
+			button.setAttribute('contenteditable', 'false');
+			button.dataset['field'] = fieldKey;
+			if (props.disabled) button.disabled = true;
+			button.textContent = field.name;
+			fragment.appendChild(button);
+		}
 
-				return `<button contenteditable="false" data-field="${fieldKey}" ${props.disabled ? 'disabled' : ''}>${
-					field.name
-				}</button>`;
-			})
-			.join('');
-
-		contentEl.value.innerHTML = newInnerHTML;
+		contentEl.value.replaceChildren(fragment);
 	}
 }
 </script>


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves GHSA-9qrm-48qf-r2rw / CVE-2024-6533.

Stored `layout_options` template values were being rebuilt into the `v-field-template` contenteditable input by concatenating HTML strings and assigning the result to `innerHTML`. Literal template segments such as `<iframe ...>`, `<script>...</script>`, or `<img onerror=...>` were therefore parsed as live DOM instead of rendered as text when a user opened the affected layout options sidebar. The vulnerable sink was `app/src/components/v-field-template/v-field-template.vue#setContent()`, and it was reachable from the cards, calendar, and map layout option editors.

This PR removes that HTML-parsing sink. `setContent()` now rebuilds the contenteditable input with explicit DOM node construction: literal segments become `<span class="text">` nodes populated via `textContent`, and placeholders remain `<button data-field="...">` nodes populated via attribute assignment and `textContent`. The resulting DOM shape is preserved for the existing `getInputValue()` logic, caret handling, and styling, but attacker-controlled template content is no longer interpreted as HTML.

### Testing / verification

- Added `app/src/components/v-field-template/v-field-template.test.ts` coverage for:
	- rendering stored `<iframe>` payloads as text instead of DOM elements
	- rendering stored `<script>` payloads as text instead of DOM elements
	- rendering stored `<img onerror=...>` payloads as text instead of DOM elements
	- preserving mixed literal-and-placeholder DOM shape
	- round-tripping mixed templates through the public `input` event path
	- preserving the empty-model rendering shape
	- preserving multi-placeholder rendering

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
