### PR TITLE
Expand sensitive-key coverage in flow log redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Deduplicated GraphQL read resolver invocations within a request (GHSA-ph52-67fq-75wj / CVE-2026-35441).
 - Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
 - Closed DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw / CVE-2024-6533).
+- Expanded sensitive-key coverage in flow log redaction.
 
 ### Acknowledgements
 

--- a/api/src/flows.test.ts
+++ b/api/src/flows.test.ts
@@ -71,6 +71,15 @@ describe('buildRevisionData', () => {
 		expect(trigger.method).toBe('POST');
 	});
 
+	test('redacts refresh_token in $trigger.query', () => {
+		const keyedData = makeKeyedData({ query: { refresh_token: TOKEN, page: '1' } });
+		const result = buildRevisionData([], keyedData);
+		const trigger = (result.data as any).$trigger;
+
+		expect(trigger.query.refresh_token).toBe(REDACT_TEXT);
+		expect(trigger.query.page).toBe('1');
+	});
+
 	test('redacts access_token in $trigger.body', () => {
 		const keyedData = makeKeyedData({ body: { access_token: TOKEN, action: 'sync' } });
 		const result = buildRevisionData([], keyedData);
@@ -88,6 +97,30 @@ describe('buildRevisionData', () => {
 
 		expect(trigger.body.refresh_token).toBe(REDACT_TEXT);
 		expect(trigger.body.action).toBe('sync');
+	});
+
+	test('redacts password in $trigger.body and the same value interpolated into a step option', () => {
+		const PASSWORD = 'webhook-supplied-password-1234567890';
+		const keyedData = makeKeyedData({ body: { password: PASSWORD, action: 'sync' } });
+
+		const steps: Step[] = [
+			{
+				operation: 'op-1',
+				key: 'log-pw',
+				status: 'resolve',
+				options: { message: `Received password: ${PASSWORD}`, target: 'audit@example.com' },
+			},
+		];
+
+		const result = buildRevisionData(steps, keyedData);
+		const trigger = (result.data as any).$trigger;
+		const step = result.steps[0] as Step;
+
+		expect(trigger.body.password).toBe(REDACT_TEXT);
+		expect(trigger.body.action).toBe('sync');
+		expect(step.options).not.toBeNull();
+		expect((step.options as Record<string, unknown>)['message']).not.toContain(PASSWORD);
+		expect((step.options as Record<string, unknown>)['target']).toBe('audit@example.com');
 	});
 
 	test('redacts token value carried into a step option by template interpolation', () => {

--- a/api/src/utils/redact-flow-log.test.ts
+++ b/api/src/utils/redact-flow-log.test.ts
@@ -31,6 +31,37 @@ describe('collectSensitiveValues', () => {
 		expect(collected.has(OTHER_TOKEN)).toBe(true);
 	});
 
+	test('collects values at the expanded sensitive-key set (password, token, tfa_secret, etc.)', () => {
+		const pwValue = 'webhook-body-password-1234567890';
+		const tokenValue = 'long-static-token-abcdefghijkl';
+		const tfaValue = 'tfa-secret-mnopqrstuvwxyz';
+		const extIdValue = 'oauth|google|long-external-id';
+		const authDataValue = 'auth-data-blob-9876543210abcd';
+		const credsValue = 'creds-blob-1234567890abcdef';
+		const aiKeyValue = 'sk-ai-key-1234567890abcdefgh';
+
+		const source = {
+			body: {
+				password: pwValue,
+				token: tokenValue,
+				tfa_secret: tfaValue,
+				external_identifier: extIdValue,
+				auth_data: authDataValue,
+				credentials: credsValue,
+				ai_openai_api_key: aiKeyValue,
+			},
+		};
+
+		const collected = collectSensitiveValues(source);
+		expect(collected.has(pwValue)).toBe(true);
+		expect(collected.has(tokenValue)).toBe(true);
+		expect(collected.has(tfaValue)).toBe(true);
+		expect(collected.has(extIdValue)).toBe(true);
+		expect(collected.has(authDataValue)).toBe(true);
+		expect(collected.has(credsValue)).toBe(true);
+		expect(collected.has(aiKeyValue)).toBe(true);
+	});
+
 	test('is case-insensitive on key matching', () => {
 		const source = { Headers: { Authorization: `Bearer ${TOKEN}` } };
 		const collected = collectSensitiveValues(source);
@@ -130,6 +161,36 @@ describe('redactFlowLog — key-based', () => {
 
 		expect(result.records[0].access_token).toBe(REDACT_TEXT);
 		expect(result.records[1].other).toBe('fine');
+	});
+
+	test('redacts the expanded sensitive-key set under arbitrary parent paths', () => {
+		const result = redactFlowLog({
+			$trigger: {
+				body: {
+					password: 'value',
+					token: 'value',
+					tfa_secret: 'value',
+					external_identifier: 'value',
+					auth_data: 'value',
+					credentials: 'value',
+					ai_openai_api_key: 'value',
+					ai_anthropic_api_key: 'value',
+					ai_google_api_key: 'value',
+					ai_openai_compatible_api_key: 'value',
+				},
+			},
+		}) as any;
+
+		expect(result.$trigger.body.password).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.token).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.tfa_secret).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.external_identifier).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.auth_data).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.credentials).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.ai_openai_api_key).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.ai_anthropic_api_key).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.ai_google_api_key).toBe(REDACT_TEXT);
+		expect(result.$trigger.body.ai_openai_compatible_api_key).toBe(REDACT_TEXT);
 	});
 });
 

--- a/api/src/utils/redact-flow-log.ts
+++ b/api/src/utils/redact-flow-log.ts
@@ -1,6 +1,22 @@
 import { REDACT_TEXT } from '../constants.js';
 
-const SENSITIVE_KEYS = new Set<string>(['authorization', 'cookie', 'set-cookie', 'access_token', 'refresh_token']);
+const SENSITIVE_KEYS = new Set<string>([
+	'authorization',
+	'cookie',
+	'set-cookie',
+	'access_token',
+	'refresh_token',
+	'password',
+	'token',
+	'tfa_secret',
+	'external_identifier',
+	'auth_data',
+	'credentials',
+	'ai_openai_api_key',
+	'ai_anthropic_api_key',
+	'ai_google_api_key',
+	'ai_openai_compatible_api_key',
+]);
 
 const MIN_SENSITIVE_VALUE_LENGTH = 12;
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

This is an extra hardening pass on top of #14 that expands the sensitive-key list used by the flow log redaction helper beyond the original token-focused set.

New unit tests cover `collectSensitiveValues` and `redactFlowLog` against the expanded key set under arbitrary paths

New integration tests on `buildRevisionData` verify `body.password` redacts both at the trigger snapshot and at any step option intperpolated from it, and that `query.refresh_token` redacts under the query parent path.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
