### PR TITLE
Reject non-object filter query inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to CairnCMS are documented in this file. Releases are listed in reverse chronological order. Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-05-06
+## [1.0.0] - 2026-05-15
 
 First public release of CairnCMS.
 
@@ -100,6 +100,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
 - Closed DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw / CVE-2024-6533).
 - Expanded sensitive-key coverage in flow log redaction.
+- Rejected non-object filter query inputs before recursive parsing.
 
 ### Acknowledgements
 

--- a/api/src/utils/sanitize-query.test.ts
+++ b/api/src/utils/sanitize-query.test.ts
@@ -147,6 +147,22 @@ describe('filter', () => {
 
 		expect(sanitizedQuery.filter).toEqual({ field_a: { _eq: 'test' } });
 	});
+
+	test('should throw InvalidQueryException when the filter is a non-JSON string', () => {
+		expect(() => sanitizeQuery({ filter: 'filter' })).toThrow(/filter/i);
+	});
+
+	test('should throw InvalidQueryException when the filter is a single character', () => {
+		expect(() => sanitizeQuery({ filter: 'a' })).toThrow(/filter/i);
+	});
+
+	test('should throw InvalidQueryException when the filter is a number', () => {
+		expect(() => sanitizeQuery({ filter: 42 })).toThrow(/filter/i);
+	});
+
+	test('should throw InvalidQueryException when the filter is an array', () => {
+		expect(() => sanitizeQuery({ filter: ['x'] })).toThrow(/filter/i);
+	});
 });
 
 describe('offset', () => {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -1,6 +1,7 @@
 import type { Accountability, Aggregate, Filter, Query } from '@cairncms/types';
 import { parseFilter, parseJSON } from '@cairncms/utils';
 import { flatten, get, isPlainObject, merge, set } from 'lodash-es';
+import { InvalidQueryException } from '../exceptions/invalid-query.js';
 import logger from '../logger.js';
 import { Meta } from '../types/index.js';
 
@@ -121,6 +122,10 @@ function sanitizeFilter(rawFilter: any, accountability: Accountability | null) {
 		} catch {
 			logger.warn('Invalid value passed for filter query parameter.');
 		}
+	}
+
+	if (filters !== null && (typeof filters !== 'object' || Array.isArray(filters))) {
+		throw new InvalidQueryException('Filter must be an object.');
 	}
 
 	return parseFilter(filters, accountability);

--- a/packages/utils/shared/parse-filter.test.ts
+++ b/packages/utils/shared/parse-filter.test.ts
@@ -240,3 +240,25 @@ describe('', () => {
 		});
 	});
 });
+
+describe('non-object filter inputs', () => {
+	it('does not recurse infinitely when the filter is a top-level string', () => {
+		expect(() => parseFilter('filter' as any, null)).not.toThrow();
+	});
+
+	it('does not recurse infinitely on a single-character string filter', () => {
+		expect(() => parseFilter('a' as any, null)).not.toThrow();
+	});
+
+	it('wraps a top-level string as { _eq: <string> }', () => {
+		expect(parseFilter('filter' as any, null)).toStrictEqual({ _eq: 'filter' });
+	});
+
+	it('wraps a top-level number as { _eq: <number> }', () => {
+		expect(parseFilter(42 as any, null)).toStrictEqual({ _eq: 42 });
+	});
+
+	it('wraps a top-level boolean as { _eq: <boolean> }', () => {
+		expect(parseFilter(true as any, null)).toStrictEqual({ _eq: true });
+	});
+});

--- a/packages/utils/shared/parse-filter.ts
+++ b/packages/utils/shared/parse-filter.ts
@@ -31,6 +31,7 @@ const logicalFilterOperators = ['_and', '_or'];
 const bypassOperators = ['_none', '_some'];
 
 function shiftLogicalOperatorsUp(filter: any): any {
+	if (!isObjectLike(filter)) return filter;
 	const key = Object.keys(filter)[0];
 	if (!key) return filter;
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

A scanner-shaped `?filter=filter` (a non-object value at the top of the filter parameter) reached `shiftLogicalOperatorsUp` in `packages/utils/shared/parse-filter.ts`, where `Object.keys(string)` produced index keys that never matched the logical-operator or `_` prefix conditions. The function recursed on shorter and shorter substrings until the stack overflowed, returning `500 INTERNAL_SERVER_ERROR` (`RangeError: Maximum call stack size exceeded`) on every list endpoint before authentication was checked.

This PR adds an `isObjectLike` early return at the top of `shiftLogicalOperatorsUp` so the recursive descent stops if any callee lands on a non-object value, and a boundary check in `sanitizeFilter` (`api/src/utils/sanitize-query.ts`) that throws `InvalidQueryException("Filter must be an object.")` when the filter input does not parse as a JSON object. REST requests now return `400 INVALID_QUERY` instead of crashing the parser.

### Testing / verification

- Added `packages/utils/shared/parse-filter.test.ts` coverage for non-object filter inputs:
	- string, single-character string, number, and boolean inputs return `{ _eq: <value> }` without recursing
- Added `api/src/utils/sanitize-query.test.ts` coverage for the boundary check:
	- string, single-character, number, and array filter inputs throw before reaching `parseFilter`

Also verified against a live SQLite instance and confirmed:
- `GET /activity?filter=filter`, `/users?filter=filter`, `/files?filter=filter` return `400 INVALID_QUERY` both authenticated and unauthenticated
- numeric and array variants return `400 INVALID_QUERY`
- valid JSON-encoded object filters still return `200`
- GraphQL `directus_users_filter` rejects scalar filter arguments at the schema validator before reaching `sanitizeFilter`
- no `RangeError` or `Maximum call stack` entries in server logs across the probe session

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
