### PR TITLE
Reject unknown sort fields before SQL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to CairnCMS are documented in this file. Releases are listed in reverse chronological order. Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-05-06
+## [1.0.0] - 2026-05-15
 
 First public release of CairnCMS.
 
@@ -100,6 +100,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
 - Closed DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw / CVE-2024-6533).
 - Expanded sensitive-key coverage in flow log redaction.
+- Rejected unknown sort field names before SQL generation.
 
 ### Acknowledgements
 

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -1,7 +1,8 @@
 import type { Accountability, Permission, SchemaOverview } from '@cairncms/types';
 import knex from 'knex';
 import { describe, expect, it } from 'vitest';
-import { applySearch } from './apply-query.js';
+import { InvalidQueryException } from '../exceptions/invalid-query.js';
+import { applySearch, applySort } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -271,5 +272,45 @@ describe('applySearch — conceal-field exclusion (GHSA-8jpw-gpr4-8cmh)', () => 
 
 		expect(sql).toContain('title');
 		expect(sql).not.toContain('secret_token');
+	});
+});
+
+describe('applySort — unknown column validation', () => {
+	function callApplySort(sort: string[]) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applySort(knexInstance, makeSchema(), dbQuery, sort, 'notes', {});
+	}
+
+	describe('bug-exposing — unknown sort fields raise InvalidQueryException', () => {
+		it('throws InvalidQueryException when the sort field does not exist', () => {
+			expect(() => callApplySort(['sort'])).toThrow(InvalidQueryException);
+		});
+
+		it('throws InvalidQueryException with descending prefix on a missing field', () => {
+			expect(() => callApplySort(['-sort'])).toThrow(InvalidQueryException);
+		});
+
+		it('throws InvalidQueryException when one of several sort fields is missing', () => {
+			expect(() => callApplySort(['title', 'nonexistent'])).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the unknown field', () => {
+			expect(() => callApplySort(['nonexistent'])).toThrow(/nonexistent/);
+		});
+	});
+
+	describe('regression — valid sorts continue to work', () => {
+		it('accepts a known field ascending', () => {
+			expect(() => callApplySort(['title'])).not.toThrow();
+		});
+
+		it('accepts a known field descending', () => {
+			expect(() => callApplySort(['-title'])).not.toThrow();
+		});
+
+		it('accepts multiple known fields', () => {
+			expect(() => callApplySort(['title', '-rank'])).not.toThrow();
+		});
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -282,6 +282,12 @@ export function applySort(
 			const { relation, relationType } = getRelationInfo(relations, collection, pathRoot);
 
 			if (!relation || ['m2o', 'a2o'].includes(relationType ?? '')) {
+				const isFunctional = column[0]!.includes('(') && column[0]!.includes(')');
+
+				if (!isFunctional && !relation && !schema.collections[collection]?.fields?.[pathRoot]) {
+					throw new InvalidQueryException(`Invalid sort column "${pathRoot}"`);
+				}
+
 				return {
 					order,
 					column: returnRecords ? column[0] : (getColumn(knex, collection, column[0]!, false, schema) as any),


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

The single-segment non-relational path in `applySort` passed sort column names straight to `getColumn` without verifying they exist in the collection. A request like `?sort=sort` on `directus_users` produced `ORDER BY directus_users.sort` in the SQL, the database rejected the statement, and the raw error text (e.g. `SQLITE_ERROR: no such column: directus_users.sort`) was reflected to the caller in the response body.

This PR adds a schema lookup inside the existing resolution boundary. When the path is single-segment, non-functional, and not a relation, the column must exist in `schema.collections[collection].fields` or `applySort` throws `InvalidQueryException("Invalid sort column \"<field>\"")`. Functional and relational paths are unchanged.

### Testing / verification

- Added `api/src/utils/apply-query.test.ts` coverage for `applySort`:
	- unknown field, descending prefix on unknown, and mixed valid-plus-unknown raise `InvalidQueryException`
	- regressions for known fields ascending, descending, and combined still pass

Also verified against a SQLite instance:
- `?sort=sort`, `?sort=-sort`, and `?sort=email,nonexistent` return `400 INVALID_QUERY` with the named column
- `?sort=email` and `?sort=year(timestamp)` still return `200`
- no SQL error strings in server logs


## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
