### PR TITLE
Fix/input validation 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to CairnCMS are documented in this file. Releases are listed in reverse chronological order. Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-05-06
+## [1.0.0] - 2026-05-15
 
 First public release of CairnCMS.
 
@@ -100,6 +100,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Removed access tokens from admin asset URL generation (GHSA-2ccr-g2rv-h677 / CVE-2024-28238).
 - Closed DOM XSS in layout option template inputs (GHSA-9qrm-48qf-r2rw / CVE-2024-6533).
 - Expanded sensitive-key coverage in flow log redaction.
+- Returned controlled errors for malformed inputs on /auth/password/reset and /utils/hash/verify.
 
 ### Acknowledgements
 

--- a/api/src/controllers/utils.ts
+++ b/api/src/controllers/utils.ts
@@ -1,4 +1,3 @@
-import argon2 from 'argon2';
 import Busboy from 'busboy';
 import { Router } from 'express';
 import Joi from 'joi';
@@ -17,6 +16,7 @@ import { UtilsService } from '../services/utils.js';
 import asyncHandler from '../utils/async-handler.js';
 import { generateHash } from '../utils/generate-hash.js';
 import { sanitizeQuery } from '../utils/sanitize-query.js';
+import { verifyHash } from '../utils/verify-hash.js';
 
 const router = Router();
 
@@ -62,7 +62,7 @@ router.post(
 			throw new InvalidPayloadException(`"hash" is required`);
 		}
 
-		const result = await argon2.verify(req.body.hash, req.body.string);
+		const result = await verifyHash(req.body.hash, req.body.string);
 
 		return res.json({ data: result });
 	})

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -857,5 +857,54 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+
+		describe('resetPassword', () => {
+			describe('bug-exposing — malformed and invalid JWTs map to ForbiddenException', () => {
+				it('throws ForbiddenException on a malformed JWT', async () => {
+					await expect(service.resetPassword('not-a-jwt', 'NewPassw0rd!123')).rejects.toBeInstanceOf(
+						ForbiddenException
+					);
+				});
+
+				it('throws ForbiddenException on an expired JWT', async () => {
+					const expired = jwt.sign({ email: 'a@b.com', scope: 'password-reset', hash: 'h' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+						expiresIn: '-1s',
+					});
+
+					await expect(service.resetPassword(expired, 'NewPassw0rd!123')).rejects.toBeInstanceOf(ForbiddenException);
+				});
+
+				it('throws ForbiddenException on a signature-mismatched JWT', async () => {
+					const wrongSecret = jwt.sign(
+						{ email: 'a@b.com', scope: 'password-reset', hash: 'h' },
+						'completely-different-secret',
+						{ issuer: 'cairncms' }
+					);
+
+					await expect(service.resetPassword(wrongSecret, 'NewPassw0rd!123')).rejects.toBeInstanceOf(
+						ForbiddenException
+					);
+				});
+			});
+
+			describe('regression — existing scope and hash checks still fire', () => {
+				it('throws ForbiddenException on a valid JWT with wrong scope', async () => {
+					const wrongScope = jwt.sign({ email: 'a@b.com', scope: 'other-scope', hash: 'h' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					await expect(service.resetPassword(wrongScope, 'NewPassw0rd!123')).rejects.toBeInstanceOf(ForbiddenException);
+				});
+
+				it('throws ForbiddenException on a valid JWT missing the hash claim', async () => {
+					const noHash = jwt.sign({ email: 'a@b.com', scope: 'password-reset' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					await expect(service.resetPassword(noHash, 'NewPassw0rd!123')).rejects.toBeInstanceOf(ForbiddenException);
+				});
+			});
+		});
 	});
 });

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -492,11 +492,15 @@ export class UsersService extends ItemsService {
 	}
 
 	async resetPassword(token: string, password: string): Promise<void> {
-		const { email, scope, hash } = jwt.verify(token, env['SECRET'] as string, { issuer: 'cairncms' }) as {
-			email: string;
-			scope: string;
-			hash: string;
-		};
+		let payload: { email: string; scope: string; hash: string };
+
+		try {
+			payload = jwt.verify(token, env['SECRET'] as string, { issuer: 'cairncms' }) as typeof payload;
+		} catch {
+			throw new ForbiddenException();
+		}
+
+		const { email, scope, hash } = payload;
 
 		if (scope !== 'password-reset' || !hash) throw new ForbiddenException();
 

--- a/api/src/utils/verify-hash.test.ts
+++ b/api/src/utils/verify-hash.test.ts
@@ -1,0 +1,32 @@
+import argon2 from 'argon2';
+import { describe, expect, it } from 'vitest';
+import { InvalidPayloadException } from '../exceptions/index.js';
+import { verifyHash } from './verify-hash.js';
+
+describe('verifyHash', () => {
+	describe('bug-exposing — malformed hashes map to InvalidPayloadException', () => {
+		it('throws InvalidPayloadException when the hash is not an argon2 hash', async () => {
+			await expect(verifyHash('not-an-argon2-hash', 'anything')).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('error message references the hash being invalid', async () => {
+			await expect(verifyHash('not-a-hash', 'x')).rejects.toThrow(/argon2/);
+		});
+
+		it('throws InvalidPayloadException on an empty hash string', async () => {
+			await expect(verifyHash('', 'anything')).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+	});
+
+	describe('regression — valid hashes still verify', () => {
+		it('returns true when the hash matches the input string', async () => {
+			const hash = await argon2.hash('correct-string');
+			await expect(verifyHash(hash, 'correct-string')).resolves.toBe(true);
+		});
+
+		it('returns false when the hash does not match the input string', async () => {
+			const hash = await argon2.hash('correct-string');
+			await expect(verifyHash(hash, 'wrong-string')).resolves.toBe(false);
+		});
+	});
+});

--- a/api/src/utils/verify-hash.ts
+++ b/api/src/utils/verify-hash.ts
@@ -1,0 +1,10 @@
+import argon2 from 'argon2';
+import { InvalidPayloadException } from '../exceptions/index.js';
+
+export async function verifyHash(hash: string, stringToVerify: string): Promise<boolean> {
+	try {
+		return await argon2.verify(hash, stringToVerify);
+	} catch {
+		throw new InvalidPayloadException(`"hash" must be a valid argon2 hash`);
+	}
+}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Two public endpoints returned `500 INTERNAL_SERVER_ERROR` on malformed input because the underlying library calls were not wrapped. `POST /auth/password/reset` propagated `JsonWebTokenError` / `TokenExpiredError` from `jwt.verify` in `UsersService.resetPassword`. `POST /utils/hash/verify` propagated `TypeError: pchstr must contain a $ as first char` from `argon2.verify` in the controller handler.

This PR wraps both call sites. JWT verification failures map to the existing `ForbiddenException` already thrown by the reset flow at `users.ts:501` and `:514`, preserving the endpoint's public failure contract rather than introducing a new error class. The argon2 verify is extracted to `api/src/utils/verify-hash.ts` (mirroring `generate-hash.ts`) and wraps the call in a `try/catch` that throws `InvalidPayloadException("\"hash\" must be a valid argon2 hash")`. Bare `catch {}` in both places to avoid splitting failure surfaces by underlying error type.

### Testing / verification

- Added `api/src/services/users.test.ts` coverage for `resetPassword`:
	- malformed, expired, and signature-mismatched JWTs throw `ForbiddenException`
	- existing wrong-scope and missing-hash cases still throw via the line-501 path
- Added `api/src/utils/verify-hash.test.ts` for the extracted helper:
	- malformed and empty hashes throw `InvalidPayloadException`
	- valid hash returns `true` or `false` for matching and non-matching strings

Also verified against a SQLite instance:
- `POST /auth/password/reset` with `token: "not-a-jwt"` returns `403 FORBIDDEN`
- `POST /utils/hash/verify` with a malformed hash returns `400 INVALID_PAYLOAD` with `"hash" must be a valid argon2 hash`
- valid `/utils/hash/verify` requests still return `{"data": true}` and `{"data": false}` correctly
- no `JsonWebTokenError` or `TypeError` entries in server logs

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
