### PR TITLE
Remove stale super_admin_token from /server/info spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Expanded sensitive-key coverage in flow log redaction.
 - Rejected unknown sort field names before SQL generation.
 - Rejected non-object filter query inputs before recursive parsing.
+- Removed stale super_admin_token parameter from the /server/info spec.
 
 ### Acknowledgements
 

--- a/packages/specs/src/paths/server/info.yaml
+++ b/packages/specs/src/paths/server/info.yaml
@@ -2,15 +2,6 @@ get:
   summary: System Info
   description: Perform a system status check and return the options.
   operationId: serverInfo
-  parameters:
-    - description:
-        The first time you create a project, the provided token will be saved and required for subsequent project
-        installs. It can also be found and configured in `/config/__api.json` on your server.
-      in: query
-      name: super_admin_token
-      required: true
-      schema:
-        type: integer
   responses:
     '200':
       content:


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

`packages/specs/src/paths/server/info.yaml` advertised a required query parameter `super_admin_token` (`type: integer`) on `GET /server/info`. The live controller at `api/src/controllers/server.ts:51` and service at `api/src/services/server.ts:31` accept no such parameter. `ServerService.serverInfo()` takes no arguments at all. A repo-wide grep for `super_admin_token` returned exactly one match before this change: the YAML entry itself.

This PR deletes the entire `parameters:` block from the YAML.

### Testing / verification

- `pnpm --filter @cairncms/specs build` (which runs `swagger-cli bundle src/openapi.yaml -o dist/openapi.json`) succeeds with no warnings.
- `grep -c super_admin_token packages/specs/dist/openapi.json` returns `0` after the rebuild, confirming the parameter is gone from the published artifact.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
