### PR TITLE
Set X-Content-Type-Options: nosniff globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Returned controlled errors for malformed inputs on /auth/password/reset and /utils/hash/verify.
 - Rejected unknown sort field names before SQL generation.
 - Rejected non-object filter query inputs before recursive parsing.
+- Set X-Content-Type-Options: nosniff on all responses.
 
 ### Acknowledgements
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -132,6 +132,8 @@ export default async function createApp(): Promise<express.Application> {
 		)
 	);
 
+	app.use(helmet.noSniff());
+
 	if (env['HSTS_ENABLED']) {
 		app.use(helmet.hsts(getConfigFromEnv('HSTS_', ['HSTS_ENABLED'])));
 	}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

CairnCMS responses did not set `X-Content-Type-Options`. The header instructs browsers to refuse MIME-sniffing on the response body, which closes a class of attack where a response with a permissive or guessable `Content-Type` is reinterpreted as another content type by the browser. The header only matters for content rendered in a browser, so there is no compatibility tradeoff for legitimate API clients.

This PR adds `app.use(helmet.noSniff())` to the global middleware chain in `api/src/app.ts` between the existing CSP and HSTS registrations. The middleware is unconditional; there is no operator-side reason to opt out.

### Testing / verification

Live SQLite probe against `/server/ping`, `/server/info`, `/extensions/displays`, `/admin`, `/auth/login`, and `/graphql`: all responses return `X-Content-Type-Options: nosniff`.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
