### PR TITLE
Rename tsconfig.node20-esm to tsconfig.node22-esm

### DIFF
--- a/api/src/cli/templates/README.md
+++ b/api/src/cli/templates/README.md
@@ -5,7 +5,7 @@ A CairnCMS project.
 ## Requirements
 
 - Docker with Compose v2 (Docker Desktop on macOS / Windows; Docker Engine + the compose plugin on Linux). On Apple Silicon, enable Rosetta in Docker Desktop settings. The default PostGIS image is amd64-only.
-- Node 20+ on the host if you use the bundled `npm start` / `npm stop` / `npm logs` shortcuts. They are thin wrappers around `docker compose`; if you'd rather skip Node, run the equivalent `docker compose --project-directory cairncms -f cairncms/docker-compose.yml ...` commands directly.
+- Node 22+ on the host if you use the bundled `npm start` / `npm stop` / `npm logs` shortcuts. They are thin wrappers around `docker compose`; if you'd rather skip Node, run the equivalent `docker compose --project-directory cairncms -f cairncms/docker-compose.yml ...` commands directly.
 
 ## This scaffold is for local development
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../tsconfig.node20-esm.json",
+	"extends": "../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/cairncms/README.md
+++ b/cairncms/README.md
@@ -8,7 +8,7 @@
 npm install -g cairncms
 ```
 
-Node 20 or newer is required. `pnpm` and `yarn` work too.
+Node 22 or newer is required. `pnpm` and `yarn` work too.
 
 ## Quick start
 

--- a/packages/composables/tsconfig.json
+++ b/packages/composables/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist",
 		"lib": ["es2022", "DOM"]

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/exceptions/tsconfig.json
+++ b/packages/exceptions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/extensions-sdk/tsconfig.json
+++ b/packages/extensions-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/format-title/tsconfig.json
+++ b/packages/format-title/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage-driver-azure/tsconfig.json
+++ b/packages/storage-driver-azure/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage-driver-cloudinary/tsconfig.json
+++ b/packages/storage-driver-cloudinary/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage-driver-gcs/tsconfig.json
+++ b/packages/storage-driver-gcs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage-driver-local/tsconfig.json
+++ b/packages/storage-driver-local/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage-driver-s3/tsconfig.json
+++ b/packages/storage-driver-s3/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/update-check/tsconfig.json
+++ b/packages/update-check/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.node20-esm.json",
+	"extends": "../../tsconfig.node22-esm.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	},

--- a/tsconfig.node22-esm.json
+++ b/tsconfig.node22-esm.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-	"display": "CairnCMS Node 20 ESM",
+	"display": "CairnCMS Node 22 ESM",
 	"compilerOptions": {
 		"lib": ["es2022"],
 		"module": "es2022",


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Cleanup of "Node 20" references left behind after 22 bump, including the shared `tsconfig.node20-esm.json` (extended by 16 package and api tsconfigs) and two operator-facing READMEs, which made the baseline bump look incomplete and could cause confusion.

This PR is naming alignment only. No runtime behavior change.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
