### PR TITLE
Clean the fields array on permissions for deleted fields (GHSA-9x5g-6…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 - Removed version string from OpenAPI spec responses (GHSA-rmjh-cf9q-pv7q / CVE-2025-53887).
 - Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
-- Cleaned permission references to deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
+- Cleaned the `fields` array on permissions for deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
 - Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
 - Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).
 - Concealed sensitive fields in revision history (GHSA-mvv8-v4jj-g47j / CVE-2026-39943).

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -3,67 +3,13 @@ import knex from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import type { MockedFunction } from 'vitest';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { cleanupPermissionsOnFieldDelete, removeFieldFromFilter } from './fields.js';
+import { cleanupPermissionsOnFieldDelete } from './fields.js';
 
 vi.mock('../../src/database/index', () => ({
 	__esModule: true,
 	default: vi.fn(),
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
 }));
-
-describe('removeFieldFromFilter (GHSA-9x5g-62gj-wqf2)', () => {
-	it('returns null when given null', () => {
-		expect(removeFieldFromFilter(null, 'secret')).toBeNull();
-	});
-
-	it('returns empty object unchanged', () => {
-		expect(removeFieldFromFilter({}, 'secret')).toEqual({});
-	});
-
-	it('drops a single-key clause matching the deleted field', () => {
-		expect(removeFieldFromFilter({ secret: { _eq: 'x' } }, 'secret')).toEqual({});
-	});
-
-	it('preserves sibling clauses keyed by non-deleted fields', () => {
-		expect(removeFieldFromFilter({ secret: { _eq: 'x' }, title: { _neq: '' } }, 'secret')).toEqual({
-			title: { _neq: '' },
-		});
-	});
-
-	it('drops the deleted-field clause inside an _and array', () => {
-		expect(removeFieldFromFilter({ _and: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, 'secret')).toEqual({
-			_and: [{ title: { _neq: '' } }],
-		});
-	});
-
-	it('removes _and entirely when all its clauses reference only the deleted field', () => {
-		expect(removeFieldFromFilter({ _and: [{ secret: { _eq: 'x' } }] }, 'secret')).toEqual({});
-	});
-
-	it('drops the deleted-field clause inside an _or array', () => {
-		expect(removeFieldFromFilter({ _or: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, 'secret')).toEqual({
-			_or: [{ title: { _neq: '' } }],
-		});
-	});
-
-	it('recurses through nested _and / _or', () => {
-		const input = {
-			_or: [{ _and: [{ secret: { _eq: 'x' } }, { title: { _neq: '' } }] }, { secret: { _eq: 'y' } }],
-		};
-
-		expect(removeFieldFromFilter(input, 'secret')).toEqual({ _or: [{ _and: [{ title: { _neq: '' } }] }] });
-	});
-
-	it('does not recurse into relational-filter values (cross-collection cleanup is out of scope)', () => {
-		const input = { author: { secret: { _eq: 'x' } } };
-		expect(removeFieldFromFilter(input, 'secret')).toEqual(input);
-	});
-
-	it('keeps unrelated top-level keys when only one references the deleted field', () => {
-		const input = { title: { _eq: 'x' }, body: { _eq: 'y' } };
-		expect(removeFieldFromFilter(input, 'secret')).toEqual(input);
-	});
-});
 
 describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 	let db: MockedFunction<Knex>;
@@ -80,8 +26,8 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 
 	it('removes the deleted field from a permission row that lists it explicitly', async () => {
 		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([{ id: 1, fields: ['title', 'secret'], permissions: null, validation: null }]);
+			.select('select "id", "fields" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 1, fields: ['title', 'secret'] }]);
 
 		const updates: any[] = [];
 
@@ -99,8 +45,8 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 
 	it('writes null when the filtered fields array would be empty', async () => {
 		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([{ id: 10, fields: ['secret'], permissions: null, validation: null }]);
+			.select('select "id", "fields" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 10, fields: ['secret'] }]);
 
 		const updates: any[] = [];
 
@@ -117,8 +63,8 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 
 	it('preserves a wildcard fields array', async () => {
 		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([{ id: 2, fields: ['*'], permissions: null, validation: null }]);
+			.select('select "id", "fields" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 2, fields: ['*'] }]);
 
 		const updates: any[] = [];
 
@@ -134,8 +80,8 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 
 	it('handles CSV-string fields by splitting before filtering', async () => {
 		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([{ id: 3, fields: 'title,secret', permissions: null, validation: null }]);
+			.select('select "id", "fields" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 3, fields: 'title,secret' }]);
 
 		const updates: any[] = [];
 
@@ -150,68 +96,10 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 		expect(updates[0]!.bindings[0]).toBe('title');
 	});
 
-	it('cleans a JSON-string permissions filter and writes back a JSON string', async () => {
-		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([
-				{
-					id: 4,
-					fields: null,
-					permissions: JSON.stringify({ secret: { _eq: 'x' }, title: { _neq: '' } }),
-					validation: null,
-				},
-			]);
-
-		const updates: any[] = [];
-
-		tracker.on.update('directus_permissions').response((q) => {
-			updates.push({ bindings: q.bindings });
-			return 1;
-		});
-
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
-
-		expect(updates.length).toBe(1);
-		expect(JSON.parse(updates[0]!.bindings[0] as string)).toEqual({ title: { _neq: '' } });
-	});
-
-	it('cleans validation filter alongside permissions filter on the same row', async () => {
-		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([
-				{
-					id: 5,
-					fields: null,
-					permissions: JSON.stringify({ secret: { _eq: 'x' } }),
-					validation: JSON.stringify({ secret: { _eq: 'x' } }),
-				},
-			]);
-
-		const updates: any[] = [];
-
-		tracker.on.update('directus_permissions').response((q) => {
-			updates.push({ bindings: q.bindings });
-			return 1;
-		});
-
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
-
-		expect(updates.length).toBe(1);
-		expect(updates[0]!.bindings[0]).toBe('{}');
-		expect(updates[0]!.bindings[1]).toBe('{}');
-	});
-
 	it('does not issue an UPDATE when the row has no references to the deleted field', async () => {
 		tracker.on
-			.select('select "id", "fields", "permissions", "validation" from "directus_permissions" where "collection" = ?')
-			.response([
-				{
-					id: 6,
-					fields: ['title'],
-					permissions: JSON.stringify({ title: { _eq: 'x' } }),
-					validation: null,
-				},
-			]);
+			.select('select "id", "fields" from "directus_permissions" where "collection" = ?')
+			.response([{ id: 6, fields: ['title'] }]);
 
 		const updates: any[] = [];
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -726,76 +726,20 @@ export class FieldsService {
 	}
 }
 
-export function removeFieldFromFilter(
-	filter: Record<string, any> | null,
-	fieldName: string
-): Record<string, any> | null {
-	if (filter === null || typeof filter !== 'object') return filter;
-
-	const result: Record<string, any> = {};
-
-	for (const [key, value] of Object.entries(filter)) {
-		if (key === fieldName) continue;
-
-		if (key === '_and' || key === '_or') {
-			if (Array.isArray(value)) {
-				const cleaned = value
-					.map((clause) => removeFieldFromFilter(clause, fieldName))
-					.filter(
-						(clause): clause is Record<string, any> =>
-							clause !== null && typeof clause === 'object' && Object.keys(clause).length > 0
-					);
-
-				if (cleaned.length > 0) result[key] = cleaned;
-			}
-
-			continue;
-		}
-
-		result[key] = value;
-	}
-
-	return result;
-}
-
 export async function cleanupPermissionsOnFieldDelete(trx: Knex, collection: string, field: string): Promise<void> {
-	const permissionRows = await trx
-		.select('id', 'fields', 'permissions', 'validation')
-		.from('directus_permissions')
-		.where({ collection });
+	const permissionRows = await trx.select('id', 'fields').from('directus_permissions').where({ collection });
 
 	for (const row of permissionRows) {
-		const updates: Record<string, any> = {};
-
 		let fields: string[] | null = null;
 		if (typeof row.fields === 'string') fields = row.fields.split(',');
 		else if (Array.isArray(row.fields)) fields = row.fields;
 
-		if (fields && !fields.includes('*') && fields.includes(field)) {
-			const filtered = fields.filter((f) => f !== field);
-			updates['fields'] = filtered.length > 0 ? filtered.join(',') : null;
-		}
+		if (!fields || fields.includes('*') || !fields.includes(field)) continue;
 
-		const parsedPermissions =
-			typeof row.permissions === 'string' && row.permissions ? JSON.parse(row.permissions) : row.permissions ?? null;
+		const filtered = fields.filter((f) => f !== field);
 
-		const cleanedPermissions = removeFieldFromFilter(parsedPermissions, field);
-
-		if (JSON.stringify(cleanedPermissions) !== JSON.stringify(parsedPermissions)) {
-			updates['permissions'] = cleanedPermissions === null ? null : JSON.stringify(cleanedPermissions);
-		}
-
-		const parsedValidation =
-			typeof row.validation === 'string' && row.validation ? JSON.parse(row.validation) : row.validation ?? null;
-
-		const cleanedValidation = removeFieldFromFilter(parsedValidation, field);
-
-		if (JSON.stringify(cleanedValidation) !== JSON.stringify(parsedValidation)) {
-			updates['validation'] = cleanedValidation === null ? null : JSON.stringify(cleanedValidation);
-		}
-
-		if (Object.keys(updates).length > 0) {
-			await trx('directus_permissions').update(updates).where({ id: row.id });
-		}
+		await trx('directus_permissions')
+			.update({ fields: filtered.length > 0 ? filtered.join(',') : null })
+			.where({ id: row.id });
 	}
 }


### PR DESCRIPTION
…2gj-wqf2)

## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Commit c9f10ac80a was the start of a broader CairnCMS move toward handling destructive admin diagnostics differently and more helpfully. That work is not ready yet as the scope has changed, and this is blocking other work. So this PR keeps the acceptable deleted-field fix for field visibility, but stops rewriting `permissions` and `validation` filter JSON during field deletion. For now, CairnCMS narrows back to the smaller safe boundary and leaves the broader admin-contract work for a later PR.

### Testing / verification

- Updated tests covering:
	- explicit `fields` cleanup
	- `null` when the cleaned field list becomes empty
	- wildcard preservation
	- CSV-string `fields`
	- no-op behavior when the field is not referenced

Also verified against a live instance and confirmed:
- deleting a field no longer rewrites `permissions`
- deleting a field no longer rewrites `validation`
- explicit `fields` references are still cleaned
- read-path access no longer broadens after field deletion

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
