### PR TITLE
Tighten field-deletion cleanup helper signature and boundary tests

### DIFF
--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -14,10 +14,12 @@ vi.mock('../../src/database/index', () => ({
 describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 	let db: MockedFunction<Knex>;
 	let tracker: Tracker;
+	let trx: Knex.Transaction;
 
 	beforeAll(() => {
 		db = vi.mocked(knex.default({ client: MockClient }));
 		tracker = createTracker(db);
+		trx = db as unknown as Knex.Transaction;
 	});
 
 	afterEach(() => {
@@ -36,7 +38,7 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 			return 1;
 		});
 
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(1);
 		expect(updates[0]!.bindings[0]).toBe('title');
@@ -55,7 +57,7 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 			return 1;
 		});
 
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(1);
 		expect(updates[0]!.bindings[0]).toBeNull();
@@ -73,7 +75,7 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 			return 1;
 		});
 
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(0);
 	});
@@ -90,7 +92,7 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 			return 1;
 		});
 
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(1);
 		expect(updates[0]!.bindings[0]).toBe('title');
@@ -108,7 +110,30 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 			return 1;
 		});
 
-		await cleanupPermissionsOnFieldDelete(db, 'articles', 'secret');
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
+
+		expect(updates.length).toBe(0);
+	});
+
+	it('does not modify a permission row when only filter JSON or presets reference the deleted field (Decision #12)', async () => {
+		tracker.on.select('select "id", "fields" from "directus_permissions" where "collection" = ?').response([
+			{
+				id: 42,
+				fields: ['title'],
+				permissions: { _and: [{ secret: { _eq: 'tenant-a' } }, { title: { _nempty: true } }] },
+				validation: { secret: { _eq: 'tenant-a' } },
+				presets: { secret: 'tenant-a' },
+			},
+		]);
+
+		const updates: any[] = [];
+
+		tracker.on.update('directus_permissions').response((q) => {
+			updates.push(q);
+			return 1;
+		});
+
+		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(0);
 	});

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -726,7 +726,11 @@ export class FieldsService {
 	}
 }
 
-export async function cleanupPermissionsOnFieldDelete(trx: Knex, collection: string, field: string): Promise<void> {
+export async function cleanupPermissionsOnFieldDelete(
+	trx: Knex.Transaction,
+	collection: string,
+	field: string
+): Promise<void> {
 	const permissionRows = await trx.select('id', 'fields').from('directus_permissions').where({ collection });
 
 	for (const row of permissionRows) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Pins the narrowed GHSA-9x5g-62gj-wqf2 cleanup contract so it is harder to regress.

This PR does not change runtime behavior.

### Testing / verification

- Added a test covering:
	- `permissions` may reference the deleted field and must not be rewritten
	- `validation` may reference the deleted field and must not be rewritten
	- `presets` may reference the deleted field and must not be rewritten
	- `fields` cleanup remains limited to the explicit allow-list

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
