### PR TITLE
Narrow manual flow trigger to drop directus_flows read gate (GHSA-7cv…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Avoided opening storage read streams for asset HEAD requests (GHSA-rv78-qqrq-73m5 / CVE-2025-30350).
 - Validated asset transform args before opening the source stream (GHSA-j8xj-7jff-46mx / CVE-2025-30225).
 - Removed version string from OpenAPI spec responses (GHSA-rmjh-cf9q-pv7q / CVE-2025-53887).
-- Required read permission for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
+- Required authentication and target collection/item read for manual flow triggers (GHSA-7cvf-pxgp-42fc / CVE-2025-53889).
 - Cleaned the `fields` array on permissions for deleted fields (GHSA-9x5g-62gj-wqf2 / CVE-2025-64746).
 - Excluded concealed fields from the search query parameter (GHSA-8jpw-gpr4-8cmh / CVE-2025-64748).
 - Closed user-enumeration on the password reset request endpoint (GHSA-jr94-gj3h-c8rf / CVE-2026-26185).

--- a/api/src/flows.test.ts
+++ b/api/src/flows.test.ts
@@ -276,18 +276,6 @@ describe('FlowManager._runManualFlow (GHSA-7cvf-pxgp-42fc)', () => {
 			expect(executeFlowSpy).not.toHaveBeenCalled();
 		});
 
-		it('rejects when checkAccess on directus_flows fails', async () => {
-			checkAccessSpy.mockImplementation(async (_action: any, collection: any) => {
-				if (collection === 'directus_flows') throw new exceptions.ForbiddenException();
-			});
-
-			await expect(
-				manager._runManualFlow(buildFlow(), buildData(), buildContext(nonAdminWithItemRead))
-			).rejects.toBeInstanceOf(exceptions.ForbiddenException);
-
-			expect(executeFlowSpy).not.toHaveBeenCalled();
-		});
-
 		it('rejects when checkAccess on target items fails (keys path)', async () => {
 			checkAccessSpy.mockImplementation(async (_action: any, collection: any) => {
 				if (collection === TARGET_COLLECTION) throw new exceptions.ForbiddenException();
@@ -346,11 +334,12 @@ describe('FlowManager._runManualFlow (GHSA-7cvf-pxgp-42fc)', () => {
 			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
 		});
 
-		it('non-admin with item-read permissions and explicit keys executes the flow', async () => {
+		it('triggers without directus_flows.read when caller has target-item read (Decision #18)', async () => {
 			await manager._runManualFlow(buildFlow(), buildData(), buildContext(nonAdminWithItemRead));
+
 			expect(executeFlowSpy).toHaveBeenCalledTimes(1);
-			expect(checkAccessSpy).toHaveBeenCalledWith('read', 'directus_flows', FLOW_ID);
 			expect(checkAccessSpy).toHaveBeenCalledWith('read', TARGET_COLLECTION, TARGET_KEYS);
+			expect(checkAccessSpy).not.toHaveBeenCalledWith('read', 'directus_flows', expect.anything());
 		});
 
 		it('non-admin with collection-level read executes collection-mode flow (no keys + requireSelection: false)', async () => {

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -315,8 +315,6 @@ class FlowManager {
 
 		const authorizationService = new AuthorizationService({ accountability, knex: getDatabase(), schema });
 
-		await authorizationService.checkAccess('read', 'directus_flows', flow.id);
-
 		if (Array.isArray(keys) && keys.length > 0) {
 			await authorizationService.checkAccess('read', targetCollection, keys);
 		} else if (flow.options?.['requireSelection'] === false) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Narrows the manual flow trigger fix for GHSA-7cvf-pxgp-42fc to the intended authorization boundary (per policy, which we are still developing and documenting).

The previous fix correctly required authentication and target collection/item access for manual flow triggers, but it also required read access to `directus_flows`. That coupled flow execution to flow-definition inspection. This PR removes that extra requirement while preserving the security fix: callers still must be authenticated, the flow must be enabled for the target collection, and callers must have read access to the target collection or items.

### Testing / verification

- Updated tests covering:
	- authenticated callers with target-item read can trigger without `directus_flows` read permission
	- target-item read is still checked for keyed manual triggers
	- flow-definition read is not checked for manual trigger execution
	- anonymous callers remain rejected
	- target collection/item authorization remains enforced

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
