### PR TITLE
Restrict validation merge composition and harden preset create baseline

### DIFF
--- a/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
+++ b/api/src/database/system-data/app-access-permissions/app-access-permissions.yaml
@@ -32,6 +32,8 @@
 
 - collection: directus_presets
   action: create
+  presets:
+    user: $CURRENT_USER
   validation:
     user:
       _eq: $CURRENT_USER

--- a/api/src/utils/merge-permissions.test.ts
+++ b/api/src/utils/merge-permissions.test.ts
@@ -1,6 +1,6 @@
 import type { Filter, Permission } from '@cairncms/types';
 import { describe, expect, test } from 'vitest';
-import { mergePermission } from './merge-permissions.js';
+import { mergePermission, mergePermissions } from './merge-permissions.js';
 
 const fullFilter = {} as Filter;
 const conditionalFilter = { user: { id: { _eq: '$CURRENT_USER' } } } as Filter;
@@ -31,7 +31,7 @@ describe('merging permissions', () => {
 		});
 	});
 
-	test('processes _or validations', () => {
+	test('composes non-empty validations with _and under _or strategy', () => {
 		const mergedPermission = mergePermission(
 			'or',
 			{ ...permissionTemplate, validation: conditionalFilter },
@@ -41,7 +41,7 @@ describe('merging permissions', () => {
 		expect(mergedPermission).toStrictEqual({
 			...permissionTemplate,
 			validation: {
-				_or: [conditionalFilter, conditionalFilter2],
+				_and: [conditionalFilter, conditionalFilter2],
 			},
 		});
 	});
@@ -86,16 +86,6 @@ describe('merging permissions', () => {
 		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, permissions: fullFilter });
 	});
 
-	test('{} supersedes conditional validations in _or', () => {
-		const mergedPermission = mergePermission(
-			'or',
-			{ ...permissionTemplate, validation: fullFilter },
-			{ ...permissionTemplate, validation: conditionalFilter }
-		);
-
-		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: fullFilter });
-	});
-
 	test('{} does not supersede conditional permissions in _and', () => {
 		const mergedPermission = mergePermission(
 			'and',
@@ -113,20 +103,60 @@ describe('merging permissions', () => {
 		expect(mergedPermission).toStrictEqual(expectedPermission);
 	});
 
-	test('{} does not supersede conditional validations in _and', () => {
+	test('{} validation contributes nothing under _and strategy', () => {
 		const mergedPermission = mergePermission(
 			'and',
 			{ ...permissionTemplate, validation: fullFilter },
 			{ ...permissionTemplate, validation: conditionalFilter }
 		);
 
-		const expectedPermission = {
-			...permissionTemplate,
-			validation: {
-				_and: [fullFilter, conditionalFilter],
-			},
-		};
+		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: conditionalFilter });
+	});
 
-		expect(mergedPermission).toStrictEqual(expectedPermission);
+	test('null validation contributes nothing under _or strategy', () => {
+		const mergedPermission = mergePermission(
+			'or',
+			{ ...permissionTemplate, validation: conditionalFilter },
+			{ ...permissionTemplate, validation: null }
+		);
+
+		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: conditionalFilter });
+	});
+
+	test('{} validation contributes nothing under _or strategy', () => {
+		const mergedPermission = mergePermission(
+			'or',
+			{ ...permissionTemplate, validation: conditionalFilter },
+			{ ...permissionTemplate, validation: fullFilter }
+		);
+
+		expect(mergedPermission).toStrictEqual({ ...permissionTemplate, validation: conditionalFilter });
+	});
+
+	test('three-row merge flattens validation _and (no nesting)', () => {
+		const a = { user: { _eq: 'a' } } as Filter;
+		const b = { status: { _eq: 'published' } } as Filter;
+		const c = { tenant_id: { _eq: 't1' } } as Filter;
+
+		const merged = mergePermissions(
+			'or',
+			[{ ...permissionTemplate, validation: a }],
+			[{ ...permissionTemplate, validation: b }],
+			[{ ...permissionTemplate, validation: c }]
+		);
+
+		expect(merged[0]!.validation).toStrictEqual({ _and: [a, b, c] });
+	});
+
+	test('GHSA-3fff regression: baseline validation survives operator row with empty validation under _or', () => {
+		const baselineValidation = { user: { _eq: '$CURRENT_USER' } } as Filter;
+
+		const merged = mergePermissions(
+			'or',
+			[{ ...permissionTemplate, collection: 'directus_presets', action: 'update', validation: fullFilter }],
+			[{ ...permissionTemplate, collection: 'directus_presets', action: 'update', validation: baselineValidation }]
+		);
+
+		expect(merged[0]!.validation).toStrictEqual(baselineValidation);
 	});
 });

--- a/api/src/utils/merge-permissions.ts
+++ b/api/src/utils/merge-permissions.ts
@@ -16,6 +16,17 @@ export function mergePermissions(strategy: 'and' | 'or', ...permissions: Permiss
 	return Array.from(mergedPermissions);
 }
 
+function validationParts(validation: Permission['validation']): unknown[] {
+	if (!validation || typeof validation !== 'object') return [];
+	const keys = Object.keys(validation);
+
+	if (keys[0] === '_and' && Array.isArray((validation as LogicalFilterAND)['_and'])) {
+		return (validation as LogicalFilterAND)['_and'];
+	}
+
+	return [validation];
+}
+
 export function mergePermission(
 	strategy: 'and' | 'or',
 	currentPerm: Permission,
@@ -52,27 +63,15 @@ export function mergePermission(
 		}
 	}
 
-	if (newPerm.validation) {
-		if (currentPerm.validation && Object.keys(currentPerm.validation)[0] === logicalKey) {
-			validation = {
-				[logicalKey]: [
-					...(currentPerm.validation as LogicalFilterOR & LogicalFilterAND)[logicalKey],
-					newPerm.validation,
-				],
-			} as LogicalFilterAND | LogicalFilterOR;
-		} else if (currentPerm.validation) {
-			// Empty {} supersedes other validations in _OR merge
-			if (strategy === 'or' && (isEqual(currentPerm.validation, {}) || isEqual(newPerm.validation, {}))) {
-				validation = {};
-			} else {
-				validation = {
-					[logicalKey]: [currentPerm.validation, newPerm.validation],
-				} as LogicalFilterAND | LogicalFilterOR;
-			}
+	const newValidationEmpty = !newPerm.validation || isEqual(newPerm.validation, {});
+	const currentValidationEmpty = !currentPerm.validation || isEqual(currentPerm.validation, {});
+
+	if (!newValidationEmpty) {
+		if (currentValidationEmpty) {
+			validation = newPerm.validation;
 		} else {
-			validation = {
-				[logicalKey]: [newPerm.validation],
-			} as LogicalFilterAND | LogicalFilterOR;
+			const parts = [...validationParts(currentPerm.validation), ...validationParts(newPerm.validation)];
+			validation = { _and: parts } as LogicalFilterAND;
 		}
 	}
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Follows up on GHSA-3fff-gqw3-vj86 / CVE-2024-6534 by fixing validation merge behavior.

Permission filters still merge with OR semantics. Validation rules now merge restrictively: empty validation contributes nothing, and non-empty validations compose with `_and`. This prevents an operator permission row with empty validation from erasing default validation constraints.

Also adds `presets.user: $CURRENT_USER` to the `directus_presets.create` app-access baseline so the YAML matches the intended preset + validation pattern. Runtime preset ownership enforcement remains handled by `PresetsService`.

### Testing / verification

- Added tests covering:
	- restrictive validation merging
	- empty/null validation as no contribution
	- flattened multi-row validation merges
	- GHSA-3fff regression case
	- unchanged permission-filter OR behavior

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
