### PR TITLE
Collapse suspended-user error on login/refresh into invalid credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Replaced vm2 with isolated-vm in the Run Script flow operation.
 - Redacted tokens in flow logs (GHSA-f24x-rm6g-3w5v / CVE-2025-53886).
 - Send password reset email to the stored address rather than the supplied input (GHSA-qw9g-7549-7wg5 / CVE-2024-27295).
-- Unified local-login error responses to prevent SSO user enumeration (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
+- Collapsed suspended-user login and refresh errors into invalid credentials (GHSA-jgf4-vwc3-r46v / CVE-2024-39896).
 - Excluded /auth responses from the response cache (GHSA-cff8-x7jv-4fm8 / CVE-2024-45596).
 - Sanitized condition operation validation errors in flow responses (GHSA-fm3h-p9wm-h74h / CVE-2025-30353).
 - Added Cross-Origin-Opener-Policy header to /auth routes (GHSA-8m32-p958-jg99 / CVE-2026-35408).

--- a/api/src/services/authentication.test.ts
+++ b/api/src/services/authentication.test.ts
@@ -143,6 +143,54 @@ describe('Integration Tests', () => {
 					service.login('default', { email: 'local@example.com', password: 'wrong' })
 				).rejects.toBeInstanceOf(InvalidCredentialsException);
 			});
+
+			it('throws InvalidCredentialsException when the user is suspended', async () => {
+				mockLocalDriver.getUserID.mockResolvedValueOnce('suspended-user-id');
+
+				tracker.on.select(/select.*from "directus_users"/).response({
+					id: 'suspended-user-id',
+					first_name: 'Suspended',
+					last_name: 'User',
+					email: 'suspended@example.com',
+					password: 'hashed',
+					status: 'suspended',
+					role: 'role-id',
+					admin_access: false,
+					app_access: true,
+					tfa_secret: null,
+					provider: 'default',
+					external_identifier: null,
+					auth_data: null,
+				});
+
+				const service = new AuthenticationService({
+					knex: db,
+					schema: testSchema,
+				});
+
+				await expect(
+					service.login('default', { email: 'suspended@example.com', password: 'whatever' })
+				).rejects.toBeInstanceOf(InvalidCredentialsException);
+			});
+		});
+
+		describe('refresh — invalid-token responses are uniform', () => {
+			it('throws InvalidCredentialsException when the refresh-token session references a suspended user', async () => {
+				vi.spyOn(AuthenticationService.prototype as any, 'lookupSession').mockResolvedValueOnce({
+					user_id: 'suspended-user-id',
+					user_status: 'suspended',
+					share_id: null,
+				});
+
+				tracker.on.delete('directus_sessions').response(1);
+
+				const service = new AuthenticationService({
+					knex: db,
+					schema: testSchema,
+				});
+
+				await expect(service.refresh('suspended-refresh-token')).rejects.toBeInstanceOf(InvalidCredentialsException);
+			});
 		});
 	});
 });

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -9,7 +9,7 @@ import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import getDatabase from '../database/index.js';
 import emitter from '../emitter.js';
 import env from '../env.js';
-import { InvalidCredentialsException, InvalidOTPException, UserSuspendedException } from '../exceptions/index.js';
+import { InvalidCredentialsException, InvalidOTPException } from '../exceptions/index.js';
 import { createRateLimiter } from '../rate-limiter.js';
 import type { AbstractServiceOptions, CairnTokenPayload, LoginResult, Session, User } from '../types/index.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
@@ -137,17 +137,8 @@ export class AuthenticationService {
 			);
 		};
 
-		if (user?.status !== 'active') {
+		if (user?.status !== 'active' || user.provider !== providerName) {
 			emitStatus('fail');
-
-			if (user?.status === 'suspended') {
-				await stall(STALL_TIME, timeStart);
-				throw new UserSuspendedException();
-			} else {
-				await stall(STALL_TIME, timeStart);
-				throw new InvalidCredentialsException();
-			}
-		} else if (user.provider !== providerName) {
 			await stall(STALL_TIME, timeStart);
 			throw new InvalidCredentialsException();
 		}
@@ -335,14 +326,8 @@ export class AuthenticationService {
 
 		if (record.user_id && record.user_status !== 'active') {
 			await this.knex('directus_sessions').where({ token: refreshToken }).del();
-
-			if (record.user_status === 'suspended') {
-				await stall(STALL_TIME, timeStart);
-				throw new UserSuspendedException();
-			} else {
-				await stall(STALL_TIME, timeStart);
-				throw new InvalidCredentialsException();
-			}
+			await stall(STALL_TIME, timeStart);
+			throw new InvalidCredentialsException();
 		}
 
 		if (record.user_id) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Follows up on GHSA-jgf4-vwc3-r46v / CVE-2024-39896 by removing the remaining suspended-user disclosure on auth surfaces.

Suspended users now receive the same invalid-credentials response as other failed login and refresh cases. This prevents unauthenticated callers, or callers holding an invalidated refresh token, from distinguishing suspended accounts from other invalid account states.

The existing wrong-provider login unification remains unchanged.

### Testing / verification

- Added tests covering:
	- suspended-user login returns `InvalidCredentialsException`
	- suspended-user refresh returns `InvalidCredentialsException`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
