### PR TITLE
Validate effective post-update grant on share writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Restricted _in/_nin filter operators with empty arrays (GHSA-hxgm-ghmv-xjjm).
 - Masked concealed fields routed through query aliases (GHSA-p8v3-m643-4xqx / CVE-2024-34708).
 - Deduplicated GraphQL aggregate field selections (GHSA-7hmh-pfrp-vcx4 / CVE-2024-39895).
-- Validated share role on create and update (GHSA-pmf4-v838-29hg / CVE-2025-24353).
+- Validated share role and target share authority on create and update (GHSA-pmf4-v838-29hg / CVE-2025-24353).
 - Extended outbound IP deny-list to the full loopback range (GHSA-68g8-c275-xf2m / CVE-2024-46990).
 - Validated preset ownership on create and update (GHSA-3fff-gqw3-vj86 / CVE-2024-6534).
 - Redacted access_token query parameter from request logs (GHSA-vw58-ph65-6rxp / CVE-2024-47822).

--- a/api/src/services/shares.test.ts
+++ b/api/src/services/shares.test.ts
@@ -1,7 +1,7 @@
 import type { Accountability, SchemaOverview } from '@cairncms/types';
 import type { Knex } from 'knex';
 import knex from 'knex';
-import { MockClient, createTracker } from 'knex-mock-client';
+import { MockClient, Tracker, createTracker } from 'knex-mock-client';
 import type { MockedFunction } from 'vitest';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
@@ -106,14 +106,22 @@ const SHARE_ID = '33333333-3333-3333-3333-333333333333';
 
 describe('SharesService — role validation (GHSA-pmf4-v838-29hg)', () => {
 	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
 
 	beforeAll(() => {
 		db = vi.mocked(knex.default({ client: MockClient }));
-		createTracker(db);
+		tracker = createTracker(db);
 	});
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		tracker.reset();
+
+		tracker.on.select(/select.*from "directus_shares"/).response({
+			role: CALLER_ROLE,
+			collection: 'directus_users',
+			item: 'item-uuid',
+		});
 
 		vi.spyOn(AuthorizationService.prototype, 'checkAccess').mockResolvedValue(undefined as any);
 		vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue(SHARE_ID);
@@ -312,6 +320,109 @@ describe('SharesService — role validation (GHSA-pmf4-v838-29hg)', () => {
 			const service = makeService({ role: null });
 
 			await expect(service.createOne(validCreatePayload(OTHER_ROLE))).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('bug-exposing — non-admin update-path effective-state validation', () => {
+		it('updateOne — rejects when role is omitted and stored role differs from caller role', async () => {
+			tracker.reset();
+
+			tracker.on.select(/select.*from "directus_shares"/).response({
+				role: OTHER_ROLE,
+				collection: 'directus_users',
+				item: 'item-uuid',
+			});
+
+			const service = makeService();
+
+			await expect(service.updateOne(SHARE_ID, { name: 'just-renaming' })).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('updateOne — rejects when patch redirects item to a target the caller cannot share', async () => {
+			vi.spyOn(AuthorizationService.prototype, 'checkAccess').mockImplementation(async (_action, _collection, item) => {
+				if (item === 'forbidden-item') throw new ForbiddenException();
+			});
+
+			const service = makeService();
+
+			await expect(service.updateOne(SHARE_ID, { item: 'forbidden-item' })).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('updateOne — rejects when patch redirects collection to a target the caller cannot share', async () => {
+			vi.spyOn(AuthorizationService.prototype, 'checkAccess').mockImplementation(async (_action, collection) => {
+				if (collection === 'forbidden-collection') throw new ForbiddenException();
+			});
+
+			const service = makeService();
+
+			await expect(service.updateOne(SHARE_ID, { collection: 'forbidden-collection' })).rejects.toBeInstanceOf(
+				ForbiddenException
+			);
+		});
+
+		it('updateMany — runs effective-state validation per key', async () => {
+			tracker.reset();
+
+			tracker.on.select(/select.*from "directus_shares"/).response({
+				role: OTHER_ROLE,
+				collection: 'directus_users',
+				item: 'item-uuid',
+			});
+
+			const service = makeService();
+
+			await expect(service.updateMany([SHARE_ID], { name: 'just-renaming' })).rejects.toBeInstanceOf(
+				ForbiddenException
+			);
+		});
+
+		it('updateBatch — runs effective-state validation before super.updateBatch', async () => {
+			tracker.reset();
+
+			tracker.on.select(/select.*from "directus_shares"/).response({
+				role: OTHER_ROLE,
+				collection: 'directus_users',
+				item: 'item-uuid',
+			});
+
+			const updateBatchSpy = vi.spyOn(ItemsService.prototype, 'updateBatch');
+
+			const service = makeService();
+
+			await expect(service.updateBatch([{ id: SHARE_ID, name: 'rename' }])).rejects.toBeInstanceOf(ForbiddenException);
+			expect(updateBatchSpy).not.toHaveBeenCalled();
+		});
+
+		it('updateByQuery — receives effective-state validation via the updateMany dispatch chain', async () => {
+			tracker.reset();
+
+			tracker.on.select(/select.*from "directus_shares"/).response({
+				role: OTHER_ROLE,
+				collection: 'directus_users',
+				item: 'item-uuid',
+			});
+
+			vi.spyOn(ItemsService.prototype as any, 'getKeysByQuery').mockResolvedValueOnce([SHARE_ID]);
+
+			const service = makeService();
+
+			await expect(service.updateByQuery({}, { name: 'rename' })).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('regression — admin update-path bypass', () => {
+		it('updateOne — admin bypasses effective-state validation even when stored role mismatches caller', async () => {
+			tracker.reset();
+
+			tracker.on.select(/select.*from "directus_shares"/).response({
+				role: OTHER_ROLE,
+				collection: 'directus_users',
+				item: 'item-uuid',
+			});
+
+			const service = makeService({ admin: true });
+
+			await expect(service.updateOne(SHARE_ID, { name: 'rename' })).resolves.toBe(SHARE_ID);
 		});
 	});
 });

--- a/api/src/services/shares.ts
+++ b/api/src/services/shares.ts
@@ -56,6 +56,44 @@ export class SharesService extends ItemsService {
 		}
 	}
 
+	private async validateEffectiveShareGrant(key: PrimaryKey, patch: Partial<Item>): Promise<void> {
+		if (this.accountability?.admin === true) return;
+
+		const existing = await this.knex
+			.select('role', 'collection', 'item')
+			.from('directus_shares')
+			.where('id', key)
+			.first();
+
+		if (!existing) {
+			throw new ForbiddenException();
+		}
+
+		const effectiveRole = 'role' in patch ? patch['role'] : existing.role;
+		const effectiveCollection = 'collection' in patch ? patch['collection'] : existing.collection;
+		const effectiveItem = 'item' in patch ? patch['item'] : existing.item;
+
+		const callerRole = this.accountability?.role ?? null;
+
+		if (callerRole === null) {
+			throw new ForbiddenException();
+		}
+
+		if (effectiveRole !== callerRole) {
+			throw new ForbiddenException();
+		}
+
+		if (typeof effectiveCollection !== 'string' || effectiveCollection.length === 0) {
+			throw new ForbiddenException();
+		}
+
+		if ((typeof effectiveItem !== 'string' && typeof effectiveItem !== 'number') || effectiveItem === '') {
+			throw new ForbiddenException();
+		}
+
+		await this.authorizationService.checkAccess('share', effectiveCollection, effectiveItem);
+	}
+
 	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
 		this.validateShareRole(data, { requireRole: true });
 		await this.authorizationService.checkAccess('share', data['collection'], data['item']);
@@ -72,18 +110,30 @@ export class SharesService extends ItemsService {
 	}
 
 	override async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		this.validateShareRole(data);
-		return super.updateOne(key, data, opts);
+		await this.validateEffectiveShareGrant(key, data);
+		await super.updateMany([key], data, opts);
+		return key;
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		this.validateShareRole(data);
+		for (const key of keys) {
+			await this.validateEffectiveShareGrant(key, data);
+		}
+
 		return super.updateMany(keys, data, opts);
 	}
 
 	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+
 		for (const item of data) {
-			this.validateShareRole(item);
+			const key = item[primaryKeyField];
+
+			if (!key) {
+				throw new InvalidPayloadException(`Item in update misses primary key.`);
+			}
+
+			await this.validateEffectiveShareGrant(key, item);
 		}
 
 		return super.updateBatch(data, opts);


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Follows up on GHSA-pmf4-v838-29hg.

The original fix blocked direct role escalation by validating the submitted `role` field. Update requests still needed one more boundary check: validate the resulting share grant, not only the submitted patch.

This PR updates `SharesService.updateOne`, `updateMany`, and `updateBatch` so they read the existing share row, compute the effective `{ role, collection, item }`, and validate that resulting grant before saving.

Create paths are unchanged.

### Testing / verification

- Added tests covering:
	- rejecting updates where `role` is omitted but the stored role differs from the caller's role;
	- rejecting updates that redirect the share to a collection or item the caller cannot share;
	- applying effective-state validation through `updateMany`, `updateBatch`, and `updateByQuery`;
	- preserving the admin bypass for share updates.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
