### PR TITLE
Reject value-derived aggregates on concealed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Rejected non-object filter query inputs before recursive parsing.
 - Set X-Content-Type-Options: nosniff on all responses.
 - Removed stale super_admin_token parameter from the /server/info spec.
+- Rejected value-deriving aggregate operations on concealed fields at the query layer.
 
 ### Acknowledgements
 

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -385,6 +385,7 @@ describe('applyAggregate — concealed operand rejection (GHSA-38hg-ww64-rrwc fo
 		it('throws on concealed-field aggregate even when caller is admin', () => {
 			const dbQuery = makeBuilder();
 			const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+
 			const adminAccountability: Accountability = {
 				user: 'user-uuid',
 				role: 'role-uuid',
@@ -395,14 +396,9 @@ describe('applyAggregate — concealed operand rejection (GHSA-38hg-ww64-rrwc fo
 			};
 
 			expect(() =>
-				applyQuery(
-					knexInstance,
-					'notes',
-					dbQuery,
-					{ aggregate: { min: ['secret_token'] } },
-					makeSchema(),
-					{ accountability: adminAccountability }
-				)
+				applyQuery(knexInstance, 'notes', dbQuery, { aggregate: { min: ['secret_token'] } }, makeSchema(), {
+					accountability: adminAccountability,
+				})
 			).toThrow(InvalidQueryException);
 		});
 	});

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -1,8 +1,8 @@
-import type { Accountability, Permission, SchemaOverview } from '@cairncms/types';
+import type { Accountability, Aggregate, Permission, SchemaOverview } from '@cairncms/types';
 import knex from 'knex';
 import { describe, expect, it } from 'vitest';
 import { InvalidQueryException } from '../exceptions/invalid-query.js';
-import { applySearch, applySort } from './apply-query.js';
+import applyQuery, { applySearch, applySort } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -311,6 +311,115 @@ describe('applySort — unknown column validation', () => {
 
 		it('accepts multiple known fields', () => {
 			expect(() => callApplySort(['title', '-rank'])).not.toThrow();
+		});
+	});
+});
+
+describe('applyAggregate — concealed operand rejection (GHSA-38hg-ww64-rrwc follow-up)', () => {
+	function callApplyQuery(aggregate: Aggregate) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applyQuery(knexInstance, 'notes', dbQuery, { aggregate }, makeSchema());
+	}
+
+	describe('bug-exposing — value-deriving aggregates on concealed operands raise InvalidQueryException', () => {
+		it('throws on min over a concealed field', () => {
+			expect(() => callApplyQuery({ min: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('throws on max over a concealed field', () => {
+			expect(() => callApplyQuery({ max: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('throws on sum over a concealed field', () => {
+			expect(() => callApplyQuery({ sum: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('throws on sumDistinct over a concealed field', () => {
+			expect(() => callApplyQuery({ sumDistinct: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('throws on avg over a concealed field', () => {
+			expect(() => callApplyQuery({ avg: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('throws on avgDistinct over a concealed field', () => {
+			expect(() => callApplyQuery({ avgDistinct: ['secret_token'] })).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the operation and the concealed field', () => {
+			expect(() => callApplyQuery({ min: ['secret_token'] })).toThrow(/min/);
+			expect(() => callApplyQuery({ min: ['secret_token'] })).toThrow(/secret_token/);
+		});
+	});
+
+	describe('regression — count-style aggregates on concealed operands continue to work', () => {
+		it('accepts count over a concealed field', () => {
+			expect(() => callApplyQuery({ count: ['secret_token'] })).not.toThrow();
+		});
+
+		it('accepts countDistinct over a concealed field', () => {
+			expect(() => callApplyQuery({ countDistinct: ['secret_token'] })).not.toThrow();
+		});
+
+		it('accepts countAll (handled by applyAggregate but not in the Aggregate type)', () => {
+			expect(() => callApplyQuery({ countAll: ['*'] } as unknown as Aggregate)).not.toThrow();
+		});
+	});
+
+	describe('regression — value-deriving aggregates on non-concealed operands continue to work', () => {
+		it('accepts min on title', () => {
+			expect(() => callApplyQuery({ min: ['title'] })).not.toThrow();
+		});
+
+		it('accepts max on body', () => {
+			expect(() => callApplyQuery({ max: ['body'] })).not.toThrow();
+		});
+
+		it('accepts sum on rank', () => {
+			expect(() => callApplyQuery({ sum: ['rank'] })).not.toThrow();
+		});
+	});
+
+	describe('regression — role-independence', () => {
+		it('throws on concealed-field aggregate even when caller is admin', () => {
+			const dbQuery = makeBuilder();
+			const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+			const adminAccountability: Accountability = {
+				user: 'user-uuid',
+				role: 'role-uuid',
+				admin: true,
+				app: true,
+				ip: '127.0.0.1',
+				permissions: [],
+			};
+
+			expect(() =>
+				applyQuery(
+					knexInstance,
+					'notes',
+					dbQuery,
+					{ aggregate: { min: ['secret_token'] } },
+					makeSchema(),
+					{ accountability: adminAccountability }
+				)
+			).toThrow(InvalidQueryException);
+		});
+	});
+
+	describe('regression — empty and absent aggregate queries', () => {
+		it('does not throw when no aggregate is present', () => {
+			const dbQuery = makeBuilder();
+			const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+			expect(() => applyQuery(knexInstance, 'notes', dbQuery, {}, makeSchema())).not.toThrow();
+		});
+
+		it('does not throw on an empty aggregate object', () => {
+			expect(() => callApplyQuery({})).not.toThrow();
+		});
+
+		it('does not throw on a value-deriving aggregate with an empty operand list', () => {
+			expect(() => callApplyQuery({ min: [] })).not.toThrow();
 		});
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -69,6 +69,7 @@ export default function applyQuery(
 	}
 
 	if (query.aggregate) {
+		validateAggregateOperands(schema, collection, query.aggregate);
 		applyAggregate(dbQuery, query.aggregate, collection);
 	}
 
@@ -817,6 +818,34 @@ export async function applySearch(
 			this.whereRaw('1 = 0');
 		}
 	});
+}
+
+const VALUE_DERIVING_AGGREGATE_OPS = new Set(['min', 'max', 'sum', 'sumDistinct', 'avg', 'avgDistinct']);
+
+export function validateAggregateOperands(
+	schema: SchemaOverview,
+	collection: string,
+	aggregate: Aggregate
+): void {
+	const fields = schema.collections[collection]?.fields ?? {};
+
+	for (const [operation, operands] of Object.entries(aggregate)) {
+		if (!operands) continue;
+		if (!VALUE_DERIVING_AGGREGATE_OPS.has(operation)) continue;
+
+		for (const operand of operands) {
+			if (operand === '*') continue;
+
+			const field = fields[operand];
+			if (!field) continue;
+
+			if ((field.special as string[] | undefined)?.includes('conceal')) {
+				throw new InvalidQueryException(
+					`Aggregate operation "${operation}" is not valid on concealed field "${operand}".`
+				);
+			}
+		}
+	}
 }
 
 export function applyAggregate(dbQuery: Knex.QueryBuilder, aggregate: Aggregate, collection: string): void {

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -822,11 +822,7 @@ export async function applySearch(
 
 const VALUE_DERIVING_AGGREGATE_OPS = new Set(['min', 'max', 'sum', 'sumDistinct', 'avg', 'avgDistinct']);
 
-export function validateAggregateOperands(
-	schema: SchemaOverview,
-	collection: string,
-	aggregate: Aggregate
-): void {
+export function validateAggregateOperands(schema: SchemaOverview, collection: string, aggregate: Aggregate): void {
 	const fields = schema.collections[collection]?.fields ?? {};
 
 	for (const [operation, operands] of Object.entries(aggregate)) {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Tightens the GHSA-38hg-ww64-rrwc aggregate fix by rejecting value-deriving aggregate operations on concealed fields before SQL generation.

The original fix masked concealed aggregate results after the database computed them. This PR keeps that masking as defense-in-depth, but adds a query-layer guard so `min`, `max`, `sum`, `sumDistinct`, `avg`, and `avgDistinct` are invalid on fields marked `special: ['conceal']`.

Count-style aggregates remain allowed because they return counts rather than cleartext-derived values.

### Testing / verification

- Added tests covering:
	- rejection of value-deriving aggregates on concealed fields
	- error messages naming the aggregate operation and concealed field
	- count-style aggregates on concealed fields remain allowed
	- value-deriving aggregates on non-concealed fields remain allowed
	- admin callers are subject to the same query-shape rule
	- absent and empty aggregate queries remain valid

Also verified against a live instance and confirmed:
- REST `aggregate[min]=tfa_secret` now returns HTTP 400
- REST `aggregate[count]=tfa_secret` still succeeds
- REST `aggregate[min]=email` still succeeds
- GraphQL value-derived string concealed fields remain schema-gated


## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
