### PR TITLE
Meta search explicit context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Set X-Content-Type-Options: nosniff on all responses.
 - Removed stale super_admin_token parameter from the /server/info spec.
 - Rejected value-deriving aggregate operations on concealed fields at the query layer.
+- Scoped metadata filter_count search to fields the caller is permitted to read.
 
 ### Acknowledgements
 

--- a/api/src/services/meta.test.ts
+++ b/api/src/services/meta.test.ts
@@ -1,0 +1,159 @@
+import type { Accountability, Permission, SchemaOverview } from '@cairncms/types';
+import knex, { type Knex } from 'knex';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetaService } from './meta.js';
+
+vi.mock('../database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('sqlite'),
+}));
+
+function makeField(name: string, type: 'string' | 'uuid' = 'string'): any {
+	return {
+		field: name,
+		defaultValue: null,
+		nullable: true,
+		generated: false,
+		type,
+		dbType: type === 'uuid' ? 'uuid' : 'varchar',
+		precision: null,
+		scale: null,
+		special: [],
+		note: null,
+		validation: null,
+		alias: false,
+	};
+}
+
+function makeSchema(): SchemaOverview {
+	return {
+		collections: {
+			notes: {
+				collection: 'notes',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					title: makeField('title'),
+					body: makeField('body'),
+					secret_note: makeField('secret_note'),
+				},
+			},
+		},
+		relations: [],
+	} as unknown as SchemaOverview;
+}
+
+function makePermission(fields: string[] | null): Permission {
+	return {
+		id: 1,
+		role: 'role-uuid',
+		collection: 'notes',
+		action: 'read',
+		permissions: null,
+		validation: null,
+		presets: null,
+		fields,
+	};
+}
+
+function makeAccountability(overrides: Partial<Accountability> = {}): Accountability {
+	return {
+		user: 'user-uuid',
+		role: 'role-uuid',
+		admin: false,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [makePermission(['id', 'title'])],
+		...overrides,
+	};
+}
+
+const ROW_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('MetaService.filterCount — search scoped by read permissions (GHSA-7wq3-jr35-275c follow-up)', () => {
+	let db: Knex;
+
+	beforeEach(async () => {
+		db = knex.default({
+			client: 'sqlite3',
+			useNullAsDefault: true,
+			connection: ':memory:',
+			pool: { min: 1, max: 1 },
+		});
+
+		await db.schema.createTable('notes', (table) => {
+			table.uuid('id').primary();
+			table.string('title');
+			table.string('body');
+			table.string('secret_note');
+		});
+
+		await db('notes').insert({
+			id: ROW_ID,
+			title: 'public-row',
+			body: 'plain-body',
+			secret_note: 'hidden-value-xyz',
+		});
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	function makeService(accountability: Accountability | null): MetaService {
+		return new MetaService({ knex: db, schema: makeSchema(), accountability });
+	}
+
+	describe('bug-exposing — non-admin filter_count search scopes to permitted fields', () => {
+		it('non-admin with read permission on [id, title] does not find a row whose match is in secret_note', async () => {
+			const accountability = makeAccountability({ permissions: [makePermission(['id', 'title'])] });
+			const count = await makeService(accountability).filterCount('notes', { search: 'hidden-value-xyz' });
+			expect(count).toBe(0);
+		});
+
+		it('non-admin with empty read fields emits a forced-false predicate', async () => {
+			const accountability = makeAccountability({ permissions: [makePermission([])] });
+			const count = await makeService(accountability).filterCount('notes', { search: 'hidden-value-xyz' });
+			expect(count).toBe(0);
+		});
+	});
+
+	describe('regression — permitted-field search and admin path continue to work', () => {
+		it('non-admin with read permission on [id, title, secret_note] finds the row via secret_note', async () => {
+			const accountability = makeAccountability({
+				permissions: [makePermission(['id', 'title', 'secret_note'])],
+			});
+
+			const count = await makeService(accountability).filterCount('notes', { search: 'hidden-value-xyz' });
+			expect(count).toBe(1);
+		});
+
+		it('non-admin with wildcard read permission finds the row', async () => {
+			const accountability = makeAccountability({ permissions: [makePermission(['*'])] });
+			const count = await makeService(accountability).filterCount('notes', { search: 'hidden-value-xyz' });
+			expect(count).toBe(1);
+		});
+
+		it('admin caller searches all non-concealed fields', async () => {
+			const accountability = makeAccountability({ admin: true, permissions: [] });
+			const count = await makeService(accountability).filterCount('notes', { search: 'hidden-value-xyz' });
+			expect(count).toBe(1);
+		});
+
+		it('non-admin filter_count without a search returns the inserted row count', async () => {
+			const accountability = makeAccountability({ permissions: [makePermission(['id', 'title'])] });
+			const count = await makeService(accountability).filterCount('notes', {});
+			expect(count).toBe(1);
+		});
+
+		it('admin filter_count without a filter and without a search returns the total row count', async () => {
+			const accountability = makeAccountability({ admin: true, permissions: [] });
+			const count = await makeService(accountability).filterCount('notes', {});
+			expect(count).toBe(1);
+		});
+	});
+});

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -82,7 +82,7 @@ export class MetaService {
 		}
 
 		if (query.search) {
-			applySearch(this.schema, dbQuery, query.search, collection);
+			applySearch(this.schema, dbQuery, query.search, collection, this.accountability);
 		}
 
 		const records = await dbQuery;

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -2,7 +2,7 @@ import type { Accountability, Permission, SchemaOverview } from '@cairncms/types
 import knex from 'knex';
 import { describe, expect, it } from 'vitest';
 import { InvalidQueryException } from '../exceptions/invalid-query.js';
-import { applySearch, applySort } from './apply-query.js';
+import applyQuery, { applySearch, applySort } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -146,17 +146,6 @@ describe('applySearch — field-permission scoping (GHSA-7wq3-jr35-275c)', () =>
 			const dbQuery = makeBuilder();
 
 			await applySearch(makeSchema(), dbQuery, 'foo', 'notes', null);
-
-			const { sql } = dbQuery.toSQL();
-
-			expect(sql).toContain('title');
-			expect(sql).toContain('secret_note');
-		});
-
-		it('undefined accountability bypasses the filter (no accountability argument)', async () => {
-			const dbQuery = makeBuilder();
-
-			await applySearch(makeSchema(), dbQuery, 'foo', 'notes');
 
 			const { sql } = dbQuery.toSQL();
 
@@ -311,6 +300,47 @@ describe('applySort — unknown column validation', () => {
 
 		it('accepts multiple known fields', () => {
 			expect(() => callApplySort(['title', '-rank'])).not.toThrow();
+		});
+	});
+});
+
+describe('applyQuery — explicit accountability required when search is present (GHSA-7wq3-jr35-275c follow-up)', () => {
+	function callApplyQuery(query: Parameters<typeof applyQuery>[3], options?: Parameters<typeof applyQuery>[5]) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applyQuery(knexInstance, 'notes', dbQuery, query, makeSchema(), options);
+	}
+
+	describe('bug-exposing — missing accountability with a search throws', () => {
+		it('throws when options is undefined and query.search is present', () => {
+			expect(() => callApplyQuery({ search: 'foo' })).toThrow(InvalidQueryException);
+		});
+
+		it('throws when options is provided without an accountability key and query.search is present', () => {
+			expect(() => callApplyQuery({ search: 'foo' }, {})).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the accountability requirement', () => {
+			expect(() => callApplyQuery({ search: 'foo' })).toThrow(/accountability/);
+		});
+	});
+
+	describe('regression — explicit context and non-search paths continue to work', () => {
+		it('does not throw when accountability is explicit null (trusted/system caller)', () => {
+			expect(() => callApplyQuery({ search: 'foo' }, { accountability: null })).not.toThrow();
+		});
+
+		it('does not throw when accountability is a real Accountability', () => {
+			const accountability = makeAccountability({ permissions: [makePermission(['title'])] });
+			expect(() => callApplyQuery({ search: 'foo' }, { accountability })).not.toThrow();
+		});
+
+		it('does not throw when there is no search and no options', () => {
+			expect(() => callApplyQuery({})).not.toThrow();
+		});
+
+		it('does not throw on filter-only queries without accountability', () => {
+			expect(() => callApplyQuery({ filter: { title: { _eq: 'x' } } })).not.toThrow();
 		});
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -61,7 +61,13 @@ export default function applyQuery(
 	}
 
 	if (query.search) {
-		applySearch(schema, dbQuery, query.search, collection, options?.accountability);
+		if (options?.accountability === undefined) {
+			throw new InvalidQueryException(
+				'applyQuery: query.search requires explicit accountability; pass null for trusted/system callers'
+			);
+		}
+
+		applySearch(schema, dbQuery, query.search, collection, options.accountability);
 	}
 
 	if (query.group) {
@@ -768,7 +774,7 @@ export async function applySearch(
 	dbQuery: Knex.QueryBuilder,
 	searchQuery: string,
 	collection: string,
-	accountability?: Accountability | null
+	accountability: Accountability | null
 ): Promise<void> {
 	const allFields = Object.entries(schema.collections[collection]!.fields);
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Extends field-permission scoping for search to the metadata `filter_count` path and makes search helpers require explicit security context.

The GHSA-7wq3-jr35-275c item-read surface was already fixed. This follow-up addresses the same search-oracle bug class on a sibling metadata path: `filter_count` still called the search helper without accountability, so a caller could use `?meta=filter_count&search=<hidden-value>` to learn whether unread fields contained a value through the returned count.

This PR passes request accountability into `MetaService.filterCount`, requires direct `applySearch` callers to provide explicit accountability, and makes `applyQuery` throw when `query.search` is present without explicit context. Explicit `null` remains the trusted/system migration path.

### Testing / verification

- Added tests covering:
	- non-admin `filterCount` search does not match values only present in unread fields
	- empty readable-field sets return `0` instead of searching all fields
	- permitted-field, wildcard, and admin `filterCount` search still work
	- `filterCount` without `search` still returns the normal count
	- `applyQuery` throws when `search` is used without an options bag or without `accountability`
	- explicit `null`, real accountability, no-search, and filter-only `applyQuery` paths still work

Also verified against a live instance and confirmed:
- non-admin `?meta=filter_count&search=admin@example.com` returns `filter_count: 0` when the role can only read `id`
- admin `?meta=filter_count&search=admin@example.com` still returns the matching row count
- non-admin item-read `?search=admin@example.com` remains scoped to readable fields

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
