### PR TITLE
Send user invites to stored account email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Removed stale super_admin_token parameter from the /server/info spec.
 - Rejected value-deriving aggregate operations on concealed fields at the query layer.
 - Scoped metadata filter_count search to fields the caller is permitted to read.
+- Send user invites to the stored account email rather than the supplied input.
 
 ### Acknowledgements
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -9,6 +9,8 @@ import { ForbiddenException, InvalidPayloadException } from '../exceptions/index
 import jwt from 'jsonwebtoken';
 import { ItemsService, MailService, UsersService } from './index.js';
 
+const originalInviteUrl = (UsersService.prototype as any).inviteUrl;
+
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
@@ -705,6 +707,7 @@ describe('Integration Tests', () => {
 				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
 					status: 'invited',
 					role: 'invite-role',
+					email: 'user@example.com',
 				});
 
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
@@ -725,6 +728,7 @@ describe('Integration Tests', () => {
 				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
 					status: 'active',
 					role: 'invite-role',
+					email: 'user@example.com',
 				});
 
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
@@ -748,6 +752,7 @@ describe('Integration Tests', () => {
 					id: 1,
 					status: 'invited',
 					role: 'existing-role',
+					email: 'user@example.com',
 				});
 
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
@@ -755,6 +760,56 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([1]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+
+			it('sends the invite to the stored address even when supplied a confusable variant', async () => {
+				vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(originalInviteUrl);
+
+				const storedEmail = 'julian@cure53.de';
+				const suppliedEmail = 'julian@cüre53.de';
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id',
+					role: 'invite-role',
+					status: 'invited',
+					email: storedEmail,
+				});
+
+				const promise = service.inviteUser(suppliedEmail, 'invite-role', null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(mailService.send).toBeCalledTimes(1);
+				const sendArgs = (mailService.send as any).mock.calls[0][0];
+
+				expect(sendArgs.to).toBe(storedEmail);
+				expect(sendArgs.template.data.email).toBe(storedEmail);
+
+				const tokenMatch = sendArgs.template.data.url.match(/token=([^&]+)/);
+				expect(tokenMatch).not.toBeNull();
+				const decoded = jwt.decode(tokenMatch[1]) as { email: string };
+				expect(decoded.email).toBe(storedEmail);
+			});
+
+			it('sends the invite to the supplied address when the user is new (no existing account)', async () => {
+				vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(originalInviteUrl);
+
+				const suppliedEmail = 'new-user@example.com';
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(null);
+
+				const promise = service.inviteUser(suppliedEmail, 'invite-role', null);
+				await expect(promise).resolves.not.toThrow();
+
+				expect(mailService.send).toBeCalledTimes(1);
+				const sendArgs = (mailService.send as any).mock.calls[0][0];
+
+				expect(sendArgs.to).toBe(suppliedEmail);
+				expect(sendArgs.template.data.email).toBe(suppliedEmail);
+
+				const tokenMatch = sendArgs.template.data.url.match(/token=([^&]+)/);
+				expect(tokenMatch).not.toBeNull();
+				const decoded = jwt.decode(tokenMatch[1]) as { email: string };
+				expect(decoded.email).toBe(suppliedEmail);
 			});
 		});
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -399,16 +399,17 @@ export class UsersService extends ItemsService {
 
 			// Send invite for new and already invited users
 			if (isEmpty(user) || user.status === 'invited') {
+				const targetEmail = user?.email ?? email;
 				const subjectLine = subject ?? "You've been invited";
 
 				await mailService.send({
-					to: email,
+					to: targetEmail,
 					subject: subjectLine,
 					template: {
 						name: 'user-invitation',
 						data: {
-							url: this.inviteUrl(email, url),
-							email,
+							url: this.inviteUrl(targetEmail, url),
+							email: targetEmail,
 						},
 					},
 				});


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Extends the stored-email behavior from the password-reset fix to user invitations.

The original GHSA-qw9g-7549-7wg5 password-reset advisory surface was already closed. This is a follow-up for the same stored-vs-supplied email bug class on the invite path.

Before this change, `inviteUser()` could look up an existing invited account through a supplied email variant, then send the invite and sign the invite token using that supplied input. On MySQL/MariaDB accent-insensitive collations, that could let a confusable address resolve to a different stored invited user.

This PR uses the stored account email whenever an existing user resolves, and falls back to the supplied email only for genuinely new users.

### Testing / verification

- Added tests covering:
	- an existing invited user resolved from a confusable supplied email receives the invite at the stored email
	- the invitation template email uses the stored email for existing invited users
	- the invitation JWT email claim uses the stored email for existing invited users
	- new-user invites still use the supplied email for mail target, template data, and JWT claim
	- existing invite role-update and active-user no-resend behavior remain unchanged

Also verified against a live instance and confirmed:
- re-inviting an existing canonical user calls the mail path with the stored email
- inviting a new user calls the mail path with the supplied email
- re-invite does not corrupt the existing invited user row

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
