### PR TITLE
Redact secrets from step outputs in flow revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Rejected value-deriving aggregate operations on concealed fields at the query layer.
 - Scoped metadata filter_count search to fields the caller is permitted to read.
 - Send user invites to the stored account email rather than the supplied input.
+- Redacted secrets from prior step outputs when persisting flow revisions.
 
 ### Acknowledgements
 

--- a/api/src/flows.test.ts
+++ b/api/src/flows.test.ts
@@ -148,6 +148,94 @@ describe('buildRevisionData', () => {
 		expect(step.key).toBe('send-notification');
 		expect(step.status).toBe('resolve');
 	});
+
+	test('redacts a token produced by a prior step output and interpolated into a later step option', () => {
+		const STEP_TOKEN = 'sk_live_step_output_token_value';
+		const keyedData = makeKeyedData({});
+		keyedData['fetch-token'] = { data: { access_token: STEP_TOKEN } };
+
+		const steps: Step[] = [
+			{
+				operation: 'op-1',
+				key: 'fetch-token',
+				status: 'resolve',
+				options: { url: 'https://internal/token' },
+			},
+			{
+				operation: 'op-2',
+				key: 'send-notification',
+				status: 'resolve',
+				options: {
+					url: `https://hook.example.com/?key=${STEP_TOKEN}`,
+					method: 'POST',
+				},
+			},
+		];
+
+		const result = buildRevisionData(steps, keyedData);
+		const stepB = result.steps[1] as Step;
+
+		expect(stepB.options).not.toBeNull();
+		expect((stepB.options as Record<string, unknown>)['url']).toBe(`https://hook.example.com/?key=${REDACT_TEXT}`);
+		expect((stepB.options as Record<string, unknown>)['method']).toBe('POST');
+	});
+
+	test('redacts a credential produced by a prior step output and interpolated into a later step message', () => {
+		const STEP_CRED = 'super-secret-credential-value-1234';
+		const keyedData = makeKeyedData({});
+		keyedData['authenticate'] = { credentials: { password: STEP_CRED } };
+
+		const steps: Step[] = [
+			{
+				operation: 'op-1',
+				key: 'authenticate',
+				status: 'resolve',
+				options: { username: 'service-account' },
+			},
+			{
+				operation: 'op-2',
+				key: 'log-message',
+				status: 'resolve',
+				options: {
+					message: `Authenticated with ${STEP_CRED}`,
+					target: 'audit@example.com',
+				},
+			},
+		];
+
+		const result = buildRevisionData(steps, keyedData);
+		const stepB = result.steps[1] as Step;
+
+		expect(stepB.options).not.toBeNull();
+		expect((stepB.options as Record<string, unknown>)['message']).toBe(`Authenticated with ${REDACT_TEXT}`);
+		expect((stepB.options as Record<string, unknown>)['target']).toBe('audit@example.com');
+	});
+
+	test('does not redact non-sensitive-keyed step output values (regression — no false positives)', () => {
+		const PROSE = 'an innocuous descriptive prose string';
+		const keyedData = makeKeyedData({});
+		keyedData['fetch-content'] = { data: { description: PROSE } };
+
+		const steps: Step[] = [
+			{
+				operation: 'op-1',
+				key: 'fetch-content',
+				status: 'resolve',
+				options: { url: 'https://internal/content' },
+			},
+			{
+				operation: 'op-2',
+				key: 'forward',
+				status: 'resolve',
+				options: { message: `Fetched: ${PROSE}` },
+			},
+		];
+
+		const result = buildRevisionData(steps, keyedData);
+		const stepB = result.steps[1] as Step;
+
+		expect((stepB.options as Record<string, unknown>)['message']).toContain(PROSE);
+	});
 });
 
 describe('executeFlow — webhook trigger with failing condition does not leak context into response', () => {

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -46,10 +46,12 @@ export function buildRevisionData(
 	steps: ReadonlyArray<Step>,
 	keyedData: Record<string, unknown>
 ): { steps: ReadonlyArray<Step>; data: Record<string, unknown> } {
-	const sensitiveValues = collectSensitiveValues(keyedData['$trigger']);
+	const revisionData = omit(keyedData, '$accountability.permissions');
+	const sensitiveValues = collectSensitiveValues(revisionData);
+
 	return {
 		steps: redactFlowLog(steps, sensitiveValues),
-		data: redactFlowLog(omit(keyedData, '$accountability.permissions'), sensitiveValues) as Record<string, unknown>,
+		data: redactFlowLog(revisionData, sensitiveValues) as Record<string, unknown>,
 	};
 }
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Follows up on GHSA-f24x-rm6g-3w5v / CVE-2025-53886 by extending flow-revision redaction to sensitive values produced by prior flow steps.

The original advisory surface is already closed for values originating in `$trigger`. Before this change, `buildRevisionData()` collected sensitive values only from `$trigger`, so a secret returned by one operation could still be persisted in cleartext if a later operation interpolated that value into a non-sensitive option such as `url` or `message`.

This PR widens the value-collection source to the same flow revision data that CairnCMS persists. Sensitive values under keys like `access_token`, `credentials`, or `password` are now collected from prior step outputs as well as the trigger payload, then scrubbed wherever they reappear in persisted `steps` or `data`.

This only changes persisted revision/log artifacts. It does not change flow execution behavior or what a configured operation sends to an external destination.

### Testing / verification

- Added tests covering:
	- a token returned by a prior step under `access_token` and interpolated into a later step URL;
	- a credential returned by a prior step under `credentials.password` and interpolated into a later step message;
	- a non-sensitive long prose value returned by a prior step and reused later without being redacted.

Also verified against a live SQLite instance and confirmed:

- a webhook flow with revision persistence still writes a well-formed revision row;
- non-sensitive trigger body content remains visible in persisted revision data;
- non-sensitive operation options remain visible in persisted step data.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
