### PR TITLE
Use authenticated fetch + Blob for local exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ These are the changes operators coming from Directus 10 will need to account for
 - Scoped metadata filter_count search to fields the caller is permitted to read.
 - Send user invites to the stored account email rather than the supplied input.
 - Redacted secrets from prior step outputs when persisting flow revisions.
+- Removed access tokens from admin export URLs.
 
 ### Acknowledgements
 

--- a/app/src/utils/download-local-export.test.ts
+++ b/app/src/utils/download-local-export.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildExportParams, downloadLocalExport, getFilenameFromContentDisposition } from './download-local-export';
+
+vi.mock('@/api', () => ({
+	default: { get: vi.fn() },
+}));
+
+vi.mock('file-saver', () => ({
+	saveAs: vi.fn(),
+}));
+
+import api from '@/api';
+import { saveAs } from 'file-saver';
+
+describe('buildExportParams', () => {
+	it('never includes access_token', () => {
+		const params = buildExportParams('csv', {});
+		expect(params).not.toHaveProperty('access_token');
+	});
+
+	it('carries the export format', () => {
+		const params = buildExportParams('csv', {});
+		expect(params['export']).toBe('csv');
+	});
+
+	it('defaults limit to -1 when unset', () => {
+		const params = buildExportParams('csv', {});
+		expect(params['limit']).toBe(-1);
+	});
+
+	it('preserves an explicit limit', () => {
+		const params = buildExportParams('csv', { limit: 50 });
+		expect(params['limit']).toBe(50);
+	});
+
+	it('includes sort when set and non-empty', () => {
+		const params = buildExportParams('csv', { sort: '-id' });
+		expect(params['sort']).toBe('-id');
+	});
+
+	it('omits sort when empty string', () => {
+		const params = buildExportParams('csv', { sort: '' });
+		expect(params).not.toHaveProperty('sort');
+	});
+
+	it('includes fields when set', () => {
+		const params = buildExportParams('csv', { fields: ['id', 'title'] });
+		expect(params['fields']).toEqual(['id', 'title']);
+	});
+
+	it('includes search and filter when set', () => {
+		const params = buildExportParams('csv', { search: 'foo', filter: { x: { _eq: 1 } } });
+		expect(params['search']).toBe('foo');
+		expect(params['filter']).toEqual({ x: { _eq: 1 } });
+	});
+});
+
+describe('getFilenameFromContentDisposition', () => {
+	it('parses quoted filename', () => {
+		expect(getFilenameFromContentDisposition('attachment; filename="Collection 2026-05-18.csv"')).toBe(
+			'Collection 2026-05-18.csv'
+		);
+	});
+
+	it('parses unquoted filename', () => {
+		expect(getFilenameFromContentDisposition('attachment; filename=Collection.csv')).toBe('Collection.csv');
+	});
+
+	it("parses RFC 5987 encoded filename (filename*=UTF-8'')", () => {
+		expect(getFilenameFromContentDisposition("attachment; filename*=UTF-8''Collection%202026-05-18.csv")).toBe(
+			'Collection 2026-05-18.csv'
+		);
+	});
+
+	it('returns null for missing header', () => {
+		expect(getFilenameFromContentDisposition(undefined)).toBeNull();
+		expect(getFilenameFromContentDisposition(null)).toBeNull();
+		expect(getFilenameFromContentDisposition('')).toBeNull();
+	});
+
+	it('returns null for header without a filename directive', () => {
+		expect(getFilenameFromContentDisposition('attachment')).toBeNull();
+	});
+});
+
+describe('downloadLocalExport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('calls api.get with responseType blob and no access_token in params', async () => {
+		(api.get as any).mockResolvedValue({ data: new Blob(['x']), headers: {} });
+
+		await downloadLocalExport('notes', 'csv', {});
+
+		const call = (api.get as any).mock.calls[0];
+		expect(call[1].responseType).toBe('blob');
+		expect(call[1].params).not.toHaveProperty('access_token');
+		expect(call[1].params.export).toBe('csv');
+	});
+
+	it('invokes saveAs with the response blob', async () => {
+		const blob = new Blob(['x']);
+		(api.get as any).mockResolvedValue({ data: blob, headers: {} });
+
+		await downloadLocalExport('notes', 'csv', {});
+
+		expect(saveAs).toHaveBeenCalledTimes(1);
+		const [arg0, arg1] = (saveAs as any).mock.calls[0];
+		expect(arg0).toBe(blob);
+		expect(typeof arg1).toBe('string');
+	});
+
+	it('uses Content-Disposition filename when present', async () => {
+		(api.get as any).mockResolvedValue({
+			data: new Blob(['x']),
+			headers: { 'content-disposition': 'attachment; filename="Collection 2026-05-18.csv"' },
+		});
+
+		await downloadLocalExport('notes', 'csv', {});
+
+		expect((saveAs as any).mock.calls[0][1]).toBe('Collection 2026-05-18.csv');
+	});
+
+	it('falls back to collection.format when Content-Disposition is missing', async () => {
+		(api.get as any).mockResolvedValue({ data: new Blob(['x']), headers: {} });
+
+		await downloadLocalExport('notes', 'csv', {});
+
+		expect((saveAs as any).mock.calls[0][1]).toBe('notes.csv');
+	});
+
+	it('passes sort/fields/search/filter/limit through', async () => {
+		(api.get as any).mockResolvedValue({ data: new Blob(['x']), headers: {} });
+
+		await downloadLocalExport('notes', 'json', {
+			sort: '-id',
+			fields: ['id', 'title'],
+			search: 'foo',
+			filter: { x: { _eq: 1 } },
+			limit: 50,
+		});
+
+		const params = (api.get as any).mock.calls[0][1].params;
+
+		expect(params).toEqual({
+			export: 'json',
+			sort: '-id',
+			fields: ['id', 'title'],
+			search: 'foo',
+			filter: { x: { _eq: 1 } },
+			limit: 50,
+		});
+	});
+});

--- a/app/src/utils/download-local-export.ts
+++ b/app/src/utils/download-local-export.ts
@@ -1,0 +1,58 @@
+import api from '@/api';
+import { getEndpoint } from '@cairncms/utils';
+import { saveAs } from 'file-saver';
+
+export type ExportSettings = {
+	sort?: string;
+	fields?: string[];
+	search?: string;
+	filter?: Record<string, any>;
+	limit?: number;
+};
+
+export function buildExportParams(format: string, settings: ExportSettings): Record<string, unknown> {
+	const params: Record<string, unknown> = { export: format };
+
+	if (settings.sort && settings.sort !== '') params['sort'] = settings.sort;
+	if (settings.fields) params['fields'] = settings.fields;
+	if (settings.search) params['search'] = settings.search;
+	if (settings.filter) params['filter'] = settings.filter;
+
+	params['limit'] = settings.limit ?? -1;
+
+	return params;
+}
+
+const FILENAME_STAR = /filename\*\s*=\s*([^']*)'[^']*'([^;]+)/i;
+const FILENAME = /filename\s*=\s*"?([^";]+)"?/i;
+
+export function getFilenameFromContentDisposition(header: string | undefined | null): string | null {
+	if (!header) return null;
+
+	const starMatch = header.match(FILENAME_STAR);
+
+	if (starMatch && starMatch[2]) {
+		try {
+			return decodeURIComponent(starMatch[2].trim());
+		} catch {
+			return starMatch[2].trim();
+		}
+	}
+
+	const match = header.match(FILENAME);
+	if (!match || !match[1]) return null;
+
+	return match[1].trim();
+}
+
+export async function downloadLocalExport(collection: string, format: string, settings: ExportSettings): Promise<void> {
+	const response = await api.get(getEndpoint(collection), {
+		params: buildExportParams(format, settings),
+		responseType: 'blob',
+	});
+
+	const filename =
+		getFilenameFromContentDisposition(response.headers?.['content-disposition']) ?? `${collection}.${format}`;
+
+	saveAs(response.data, filename);
+}

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -234,7 +234,7 @@
 <script lang="ts" setup>
 import api from '@/api';
 import { usePermissionsStore } from '@/stores/permissions';
-import { getPublicURL } from '@/utils/get-root-path';
+import { downloadLocalExport } from '@/utils/download-local-export';
 import { notify } from '@/utils/notify';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -501,31 +501,16 @@ function startExport() {
 	}
 }
 
-function exportDataLocal() {
-	const endpoint = getEndpoint(collection.value);
+async function exportDataLocal() {
+	exporting.value = true;
 
-	// usually getEndpoint contains leading slash, but here we need to remove it
-	const url = getPublicURL() + endpoint.substring(1);
-
-	let params: Record<string, unknown> = {
-		access_token: api.defaults.headers.common['Authorization'].substring(7),
-		export: format.value,
-	};
-
-	if (exportSettings.sort && exportSettings.sort !== '') params.sort = exportSettings.sort;
-	if (exportSettings.fields) params.fields = exportSettings.fields;
-	if (exportSettings.search) params.search = exportSettings.search;
-	if (exportSettings.filter) params.filter = exportSettings.filter;
-	if (exportSettings.search) params.search = exportSettings.search;
-
-	params.limit = exportSettings.limit ?? -1;
-
-	const exportUrl = api.getUri({
-		url,
-		params,
-	});
-
-	window.open(exportUrl);
+	try {
+		await downloadLocalExport(collection.value, format.value, exportSettings);
+	} catch (err) {
+		unexpectedError(err);
+	} finally {
+		exporting.value = false;
+	}
 }
 
 async function exportDataFiles() {


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Local collection exports in the admin sidebar generated URLs with the active session token as `?access_token=...`. This is a follow-up on the same token-in-URL class as GHSA-2ccr-g2rv-h677, but on a different first-party surface from the original asset URL fix.

This PR replaces the export-sidebar tokenized URL path with an authenticated API fetch and Blob download. The "export to Files" path is unchanged.

### Testing / verification

- Added a test covering:
	- export request params never include `access_token`
	- local export requests use `responseType: 'blob'`
	- the returned Blob is passed to `saveAs()`
	- `Content-Disposition` filenames are preserved when present
	- fallback filenames are used when `Content-Disposition` is missing or invalid
	- sort, fields, search, filter, limit, and format params are preserved

Also verified against a live instance and confirmed:
- `GET /users?export=csv` with `Authorization: Bearer ...` returns `200` with a CSV attachment
- `GET /users?export=csv` without authorization returns `403`

Also verified manually in the admin UI:
- local export request URL has no `access_token` query parameter
- file download completes successfully

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
