### PR TITLE
Gate sort and group operands by field-read authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ These are the changes operators coming from Directus 10 will need to account for
 - Send user invites to the stored account email rather than the supplied input.
 - Redacted secrets from prior step outputs when persisting flow revisions.
 - Removed access tokens from admin export URLs.
+- Required field-read permission for sort and group query operands.
+- Rejected sort and group on concealed fields at the query layer.
 
 ### Acknowledgements
 

--- a/api/src/services/authorization.test.ts
+++ b/api/src/services/authorization.test.ts
@@ -1,4 +1,5 @@
 import { FailedValidationException } from '@cairncms/exceptions';
+import { ForbiddenException } from '../exceptions/index.js';
 import type { Accountability, SchemaOverview } from '@cairncms/types';
 import type { Knex } from 'knex';
 import knex from 'knex';
@@ -139,5 +140,258 @@ describe('AuthorizationService.validatePayload — _in filter with empty array (
 		});
 
 		expect(result).toStrictEqual({ role: 'some-allowed-role-uuid' });
+	});
+});
+
+describe('AuthorizationService.processAST — sort operand requires field-read authority', () => {
+	let db: MockedFunction<Knex>;
+
+	function makeField(name: string, type: 'string' | 'uuid' = 'string'): any {
+		return {
+			field: name,
+			defaultValue: null,
+			nullable: true,
+			generated: false,
+			type,
+			dbType: type === 'uuid' ? 'uuid' : 'varchar',
+			precision: null,
+			scale: null,
+			special: [],
+			note: null,
+			validation: null,
+			alias: false,
+		};
+	}
+
+	const employeesSchema = {
+		collections: {
+			employees: {
+				collection: 'employees',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					name: makeField('name'),
+					salary: makeField('salary'),
+					company: makeField('company', 'uuid'),
+				},
+			},
+			companies: {
+				collection: 'companies',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					name: makeField('name'),
+					secret_revenue: makeField('secret_revenue'),
+				},
+			},
+		},
+		relations: [
+			{
+				collection: 'employees',
+				field: 'company',
+				related_collection: 'companies',
+				schema: null,
+				meta: null,
+			},
+		],
+	} as unknown as SchemaOverview;
+
+	function makeService(fields: string[]): AuthorizationService {
+		const accountability: Accountability = {
+			user: 'user-uuid',
+			role: 'role-uuid',
+			admin: false,
+			app: true,
+			permissions: [
+				{
+					id: 1,
+					role: 'role-uuid',
+					collection: 'employees',
+					action: 'read',
+					permissions: {},
+					validation: null,
+					presets: null,
+					fields,
+				},
+			],
+		};
+
+		return new AuthorizationService({ knex: db, schema: employeesSchema, accountability });
+	}
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		createTracker(db);
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('bug-exposing — sort by unread field is rejected', () => {
+		it('throws ForbiddenException for sort on a field not in permission.fields', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'], sort: ['salary'] }, employeesSchema, {
+				accountability: service.accountability,
+			});
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('throws ForbiddenException for descending sort on unread field', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'], sort: ['-salary'] }, employeesSchema, {
+				accountability: service.accountability,
+			});
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('regression — sort by readable field is accepted', () => {
+		it('accepts sort on a permitted field', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'], sort: ['name'] }, employeesSchema, {
+				accountability: service.accountability,
+			});
+
+			await expect(service.processAST(ast)).resolves.toBeDefined();
+		});
+
+		it('wildcard permission accepts sort on any field', async () => {
+			const service = makeService(['*']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery('employees', { fields: ['*'], sort: ['salary'] }, employeesSchema, {
+				accountability: service.accountability,
+			});
+
+			await expect(service.processAST(ast)).resolves.toBeDefined();
+		});
+	});
+
+	describe('bug-exposing — function-wrapped sort on unread field is rejected', () => {
+		it('throws ForbiddenException for year(salary) when salary is unread', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], sort: ['year(salary)'] },
+				employeesSchema,
+				{ accountability: service.accountability }
+			);
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('bug-exposing — alias sort mapped to an unread real field is rejected', () => {
+		it('throws ForbiddenException when alias resolves to an unread field', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], sort: ['display'], alias: { display: 'salary' } },
+				employeesSchema,
+				{ accountability: service.accountability }
+			);
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('bug-exposing — group operand on unread field is rejected via AST fields rewrite', () => {
+		it('throws ForbiddenException when grouping by an unread field', async () => {
+			const service = makeService(['id', 'name']);
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], group: ['salary'], aggregate: { count: ['*'] } },
+				employeesSchema,
+				{ accountability: service.accountability }
+			);
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+
+	describe('bug-exposing — relational sort by an unread field on the related collection is rejected', () => {
+		function makeServiceWithRelatedRead(): AuthorizationService {
+			const accountability: Accountability = {
+				user: 'user-uuid',
+				role: 'role-uuid',
+				admin: false,
+				app: true,
+				permissions: [
+					{
+						id: 1,
+						role: 'role-uuid',
+						collection: 'employees',
+						action: 'read',
+						permissions: {},
+						validation: null,
+						presets: null,
+						fields: ['id', 'name', 'company'],
+					},
+					{
+						id: 2,
+						role: 'role-uuid',
+						collection: 'companies',
+						action: 'read',
+						permissions: {},
+						validation: null,
+						presets: null,
+						fields: ['id', 'name'],
+					},
+				],
+			};
+
+			return new AuthorizationService({ knex: db, schema: employeesSchema, accountability });
+		}
+
+		it('throws ForbiddenException when sort references a field unread on the related collection', async () => {
+			const service = makeServiceWithRelatedRead();
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], sort: ['company.secret_revenue'] },
+				employeesSchema,
+				{ accountability: service.accountability }
+			);
+
+			await expect(service.processAST(ast)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('accepts sort on a readable field on the related collection (regression)', async () => {
+			const service = makeServiceWithRelatedRead();
+			const { default: getASTFromQuery } = await import('../utils/get-ast-from-query.js');
+
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], sort: ['company.name'] },
+				employeesSchema,
+				{ accountability: service.accountability }
+			);
+
+			await expect(service.processAST(ast)).resolves.toBeDefined();
+		});
 	});
 });

--- a/api/src/services/authorization.ts
+++ b/api/src/services/authorization.ts
@@ -173,6 +173,11 @@ export class AuthorizationService {
 							extractRequiredFieldPermissions(collection, ast.query?.[collection]?.filter ?? {})
 						);
 
+						requiredFieldPermissions = mergeRequiredFieldPermissions(
+							requiredFieldPermissions,
+							extractRequiredFieldPermissionsFromSort(collection, ast.query?.[collection]?.sort ?? [])
+						);
+
 						for (const child of ast.children[collection]!) {
 							const childPermissions = validateFilterPermissions(child, schema, action, accountability);
 
@@ -192,6 +197,11 @@ export class AuthorizationService {
 					requiredFieldPermissions = mergeRequiredFieldPermissions(
 						requiredFieldPermissions,
 						extractRequiredFieldPermissions(ast.name, ast.query?.filter ?? {})
+					);
+
+					requiredFieldPermissions = mergeRequiredFieldPermissions(
+						requiredFieldPermissions,
+						extractRequiredFieldPermissionsFromSort(ast.name, ast.query?.sort ?? [])
 					);
 
 					for (const child of ast.children) {
@@ -350,6 +360,64 @@ export class AuthorizationService {
 					},
 					{}
 				);
+			}
+
+			function extractRequiredFieldPermissionsFromSort(
+				collection: string,
+				sort: string[]
+			): Record<string, Set<string>> {
+				const result: Record<string, Set<string>> = {};
+
+				for (const rawOperand of sort) {
+					const operand = rawOperand.startsWith('-') ? rawOperand.substring(1) : rawOperand;
+					const segments = operand.split('.');
+
+					let currentCollection = collection;
+					let invalidPath = false;
+
+					for (let i = 0; i < segments.length; i++) {
+						const segment = segments[i]!;
+						const baseName = segment.split(':')[0]!;
+
+						if (i === segments.length - 1) {
+							const fieldName = stripFunction(baseName);
+
+							if (fieldName === schema.collections[currentCollection]?.primary) {
+								continue;
+							}
+
+							(result[currentCollection] || (result[currentCollection] = new Set())).add(fieldName);
+						} else {
+							(result[currentCollection] || (result[currentCollection] = new Set())).add(baseName);
+
+							const { relation, relationType } = getRelationInfo(schema.relations, currentCollection, baseName);
+
+							if (!relation) {
+								invalidPath = true;
+								break;
+							}
+
+							if (relationType === 'm2o') {
+								currentCollection = relation.related_collection!;
+							} else if (relationType === 'a2o') {
+								const pathScope = segment.split(':')[1];
+
+								if (!pathScope) {
+									invalidPath = true;
+									break;
+								}
+
+								currentCollection = pathScope;
+							} else {
+								currentCollection = relation.collection;
+							}
+						}
+					}
+
+					if (invalidPath) continue;
+				}
+
+				return result;
 			}
 
 			function mergeRequiredFieldPermissions(current: Record<string, Set<string>>, child: Record<string, Set<string>>) {

--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -2,7 +2,7 @@ import type { Accountability, Aggregate, Permission, SchemaOverview } from '@cai
 import knex from 'knex';
 import { describe, expect, it } from 'vitest';
 import { InvalidQueryException } from '../exceptions/invalid-query.js';
-import applyQuery, { applySearch, applySort } from './apply-query.js';
+import applyQuery, { applySearch, applySort, validateGroupOperands } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -44,6 +44,48 @@ function makeSchema(): SchemaOverview {
 			},
 		},
 		relations: [],
+	} as unknown as SchemaOverview;
+}
+
+function makeRelationalSchema(): SchemaOverview {
+	return {
+		collections: {
+			notes: {
+				collection: 'notes',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					title: makeField('title'),
+					author: makeField('author', 'uuid'),
+				},
+			},
+			users: {
+				collection: 'users',
+				primary: 'id',
+				singleton: false,
+				sortField: null,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					name: makeField('name'),
+					tfa_secret: makeField('tfa_secret', 'string', ['conceal']),
+				},
+			},
+		},
+		relations: [
+			{
+				collection: 'notes',
+				field: 'author',
+				related_collection: 'users',
+				schema: null,
+				meta: null,
+			},
+		],
 	} as unknown as SchemaOverview;
 }
 
@@ -449,6 +491,97 @@ describe('applyAggregate — concealed operand rejection (GHSA-38hg-ww64-rrwc fo
 
 		it('does not throw on a value-deriving aggregate with an empty operand list', () => {
 			expect(() => callApplyQuery({ min: [] })).not.toThrow();
+		});
+	});
+});
+
+describe('applySort — concealed operand rejection', () => {
+	function callApplySort(sort: string[]) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applySort(knexInstance, makeSchema(), dbQuery, sort, 'notes', {});
+	}
+
+	describe('bug-exposing — concealed sort operand raises InvalidQueryException', () => {
+		it('throws on plain concealed field', () => {
+			expect(() => callApplySort(['secret_token'])).toThrow(InvalidQueryException);
+		});
+
+		it('throws on descending concealed field', () => {
+			expect(() => callApplySort(['-secret_token'])).toThrow(InvalidQueryException);
+		});
+
+		it('throws on function-wrapped concealed field', () => {
+			expect(() => callApplySort(['year(secret_token)'])).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the concealed field', () => {
+			expect(() => callApplySort(['secret_token'])).toThrow(/secret_token/);
+		});
+	});
+
+	describe('regression — non-concealed sort continues to work', () => {
+		it('accepts a non-concealed field', () => {
+			expect(() => callApplySort(['title'])).not.toThrow();
+		});
+
+		it('accepts descending non-concealed field', () => {
+			expect(() => callApplySort(['-title'])).not.toThrow();
+		});
+
+		it('does not raise the conceal error for function-wrapped non-concealed fields', () => {
+			expect(() => callApplySort(['year(title)'])).not.toThrow(/concealed/);
+		});
+	});
+
+	describe('bug-exposing — relational sort by a concealed field on the related collection is rejected', () => {
+		function callRelationalSort(sort: string[]) {
+			const dbQuery = knex.default({ client: 'sqlite3', useNullAsDefault: true }).from('notes').select('*');
+
+			const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+			return applySort(knexInstance, makeRelationalSchema(), dbQuery, sort, 'notes', {});
+		}
+
+		it('throws InvalidQueryException for sort on a concealed field on the related collection', () => {
+			expect(() => callRelationalSort(['author.tfa_secret'])).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the concealed field', () => {
+			expect(() => callRelationalSort(['author.tfa_secret'])).toThrow(/tfa_secret/);
+		});
+
+		it('accepts sort on a non-concealed field on the related collection (regression)', () => {
+			expect(() => callRelationalSort(['author.name'])).not.toThrow(/concealed/);
+		});
+	});
+});
+
+describe('validateGroupOperands — concealed operand rejection', () => {
+	describe('bug-exposing — concealed group operand raises InvalidQueryException', () => {
+		it('throws on direct concealed field', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', ['secret_token'])).toThrow(InvalidQueryException);
+		});
+
+		it('throws on function-wrapped concealed field', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', ['year(secret_token)'])).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the concealed field', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', ['secret_token'])).toThrow(/secret_token/);
+		});
+	});
+
+	describe('regression — non-concealed group continues to work', () => {
+		it('accepts a non-concealed field', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', ['title'])).not.toThrow();
+		});
+
+		it('accepts multiple non-concealed fields', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', ['title', 'body'])).not.toThrow();
+		});
+
+		it('does not throw on empty group array', () => {
+			expect(() => validateGroupOperands(makeSchema(), 'notes', [])).not.toThrow();
 		});
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -71,6 +71,7 @@ export default function applyQuery(
 	}
 
 	if (query.group) {
+		validateGroupOperands(schema, collection, query.group);
 		dbQuery.groupBy(query.group.map((column) => getColumn(knex, collection, column, false, schema)));
 	}
 
@@ -295,6 +296,17 @@ export function applySort(
 					throw new InvalidQueryException(`Invalid sort column "${pathRoot}"`);
 				}
 
+				if (!relation) {
+					const fieldName = stripFunction(pathRoot);
+					const fieldMeta = schema.collections[collection]?.fields?.[fieldName];
+
+					if ((fieldMeta?.special as string[] | undefined)?.includes('conceal')) {
+						throw new InvalidQueryException(
+							`Sort operand "${fieldName}" is concealed and cannot be used as a sort field.`
+						);
+					}
+				}
+
 				return {
 					order,
 					column: returnRecords ? column[0] : (getColumn(knex, collection, column[0]!, false, schema) as any),
@@ -312,7 +324,7 @@ export function applySort(
 			knex,
 		});
 
-		const { columnPath } = getColumnPath({
+		const { columnPath, targetCollection } = getColumnPath({
 			path: column,
 			collection,
 			aliasMap,
@@ -321,6 +333,15 @@ export function applySort(
 		});
 
 		const [alias, field] = columnPath.split('.');
+
+		const targetFieldName = stripFunction(field!);
+		const targetFieldMeta = schema.collections[targetCollection]?.fields?.[targetFieldName];
+
+		if ((targetFieldMeta?.special as string[] | undefined)?.includes('conceal')) {
+			throw new InvalidQueryException(
+				`Sort operand "${targetFieldName}" is concealed and cannot be used as a sort field.`
+			);
+		}
 
 		if (!hasMultiRelationalSort) {
 			hasMultiRelationalSort = hasMultiRelational;
@@ -827,6 +848,20 @@ export async function applySearch(
 }
 
 const VALUE_DERIVING_AGGREGATE_OPS = new Set(['min', 'max', 'sum', 'sumDistinct', 'avg', 'avgDistinct']);
+
+export function validateGroupOperands(schema: SchemaOverview, collection: string, group: string[]): void {
+	const fields = schema.collections[collection]?.fields ?? {};
+
+	for (const operand of group) {
+		const fieldName = stripFunction(operand);
+		const field = fields[fieldName];
+		if (!field) continue;
+
+		if ((field.special as string[] | undefined)?.includes('conceal')) {
+			throw new InvalidQueryException(`Group operand "${fieldName}" is concealed and cannot be used as a group field.`);
+		}
+	}
+}
 
 export function validateAggregateOperands(schema: SchemaOverview, collection: string, aggregate: Aggregate): void {
 	const fields = schema.collections[collection]?.fields ?? {};

--- a/api/src/utils/get-ast-from-query.test.ts
+++ b/api/src/utils/get-ast-from-query.test.ts
@@ -1,0 +1,140 @@
+import type { Accountability, Permission, SchemaOverview } from '@cairncms/types';
+import { describe, expect, it, vi } from 'vitest';
+import getASTFromQuery from './get-ast-from-query.js';
+
+vi.mock('../database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('sqlite'),
+}));
+
+function makeField(name: string, type: 'string' | 'uuid' = 'string'): any {
+	return {
+		field: name,
+		defaultValue: null,
+		nullable: true,
+		generated: false,
+		type,
+		dbType: type === 'uuid' ? 'uuid' : 'varchar',
+		precision: null,
+		scale: null,
+		special: [],
+		note: null,
+		validation: null,
+		alias: false,
+	};
+}
+
+function makeSchema(sortField: string | null = null): SchemaOverview {
+	return {
+		collections: {
+			employees: {
+				collection: 'employees',
+				primary: 'id',
+				singleton: false,
+				sortField,
+				note: null,
+				accountability: null,
+				fields: {
+					id: makeField('id', 'uuid'),
+					name: makeField('name'),
+					salary: makeField('salary'),
+				},
+			},
+		},
+		relations: [],
+	} as unknown as SchemaOverview;
+}
+
+function makePermission(fields: string[] | null): Permission {
+	return {
+		id: 1,
+		role: 'role-uuid',
+		collection: 'employees',
+		action: 'read',
+		permissions: null,
+		validation: null,
+		presets: null,
+		fields,
+	};
+}
+
+function makeAccountability(overrides: Partial<Accountability> = {}): Accountability {
+	return {
+		user: 'user-uuid',
+		role: 'role-uuid',
+		admin: false,
+		app: true,
+		ip: '127.0.0.1',
+		permissions: [makePermission(['id', 'name'])],
+		...overrides,
+	};
+}
+
+describe('getASTFromQuery — default sort normalization for unread schema sortField', () => {
+	describe('bug-exposing — implicit default sort silently falls back when sort field is unread', () => {
+		it('falls back to primary key when caller cannot read the schema sortField', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'] }, makeSchema('salary'), {
+				accountability: makeAccountability({ permissions: [makePermission(['id', 'name'])] }),
+			});
+
+			expect(ast.query.sort).toEqual(['id']);
+		});
+	});
+
+	describe('regression — admin and wildcard preserve the schema sortField default', () => {
+		it('admin caller uses the schema sortField default', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'] }, makeSchema('salary'), {
+				accountability: makeAccountability({ admin: true }),
+			});
+
+			expect(ast.query.sort).toEqual(['salary']);
+		});
+
+		it('wildcard fields permission uses the schema sortField default', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'] }, makeSchema('salary'), {
+				accountability: makeAccountability({ permissions: [makePermission(['*'])] }),
+			});
+
+			expect(ast.query.sort).toEqual(['salary']);
+		});
+
+		it('caller with read on the sortField uses it as default', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'] }, makeSchema('name'), {
+				accountability: makeAccountability({ permissions: [makePermission(['id', 'name'])] }),
+			});
+
+			expect(ast.query.sort).toEqual(['name']);
+		});
+
+		it('no schema sortField configured: defaults to primary key', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'] }, makeSchema(null), {
+				accountability: makeAccountability(),
+			});
+
+			expect(ast.query.sort).toEqual(['id']);
+		});
+	});
+
+	describe('regression — explicit sort is preserved as-is', () => {
+		it('explicit user sort is kept regardless of permissions', async () => {
+			const ast = await getASTFromQuery(
+				'employees',
+				{ fields: ['id', 'name'], sort: ['salary'] },
+				makeSchema('salary'),
+				{ accountability: makeAccountability({ permissions: [makePermission(['id', 'name'])] }) }
+			);
+
+			expect(ast.query.sort).toEqual(['salary']);
+		});
+	});
+
+	describe('regression — group-derived default sort is not normalized here', () => {
+		it('first group column becomes the default sort even when caller cannot read it', async () => {
+			const ast = await getASTFromQuery('employees', { fields: ['id', 'name'], group: ['salary'] }, makeSchema(null), {
+				accountability: makeAccountability({ permissions: [makePermission(['id', 'name'])] }),
+			});
+
+			expect(ast.query.sort).toEqual(['salary']);
+		});
+	});
+});

--- a/api/src/utils/get-ast-from-query.ts
+++ b/api/src/utils/get-ast-from-query.ts
@@ -75,15 +75,27 @@ export default async function getASTFromQuery(
 	delete query.deep;
 
 	if (!query.sort) {
-		// We'll default to the primary key for the standard sort output
-		let sortField = schema.collections[collection]!.primary;
+		const primary = schema.collections[collection]!.primary;
+		let sortField = primary;
 
-		// If a custom manual sort field is configured, use that
 		if (schema.collections[collection]?.sortField) {
-			sortField = schema.collections[collection]!.sortField as string;
+			const configured = schema.collections[collection]!.sortField as string;
+
+			if (accountability && accountability.admin !== true) {
+				const readPermission = accountability.permissions?.find(
+					(perm) => perm.collection === collection && perm.action === 'read'
+				);
+
+				const allowed = readPermission?.fields ?? [];
+
+				if (allowed.includes('*') || allowed.includes(configured)) {
+					sortField = configured;
+				}
+			} else {
+				sortField = configured;
+			}
 		}
 
-		// When group by is used, default to the first column provided in the group by clause
 		if (query.group?.[0]) {
 			sortField = query.group[0];
 		}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents sort and group queries from using fields the caller cannot read. Before this change, a caller could infer restricted values through row order or grouped counts, for example by sorting or grouping on an unread field. Concealed fields were also blocked only at output time in some paths, not before query construction.

This PR adds field-read checks for sort operands, rejects sort and group operands that reference concealed fields, and falls back to primary-key sort when an implicit default sort field is unread.

This is a follow-up hardening change for sibling read-derived query surfaces.

### Testing / verification

- Added tests covering:
	- direct, descending, alias, function-wrapped, and relational sort operands
	- group by unread field through the AST authorization path
	- direct, function-wrapped, and relational concealed sort/group operands
	- implicit unread default sort falling back to primary key
	- readable, wildcard, and admin regression paths

Also verified against a live SQLite instance and confirmed:
- non-admin `?sort=salary` returns `403`
- non-admin `?sort=name` returns `200` and orders by name
- non-admin `?groupBy[]=salary&aggregate[count]=*` returns `403`
- non-admin no-sort request with collection `sort_field=salary` returns `200` in primary-key order
- admin `/users?sort=tfa_secret` returns `400`
- admin `/users?groupBy[]=tfa_secret&aggregate[count]=*` returns `400`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
