### PR TITLE
Fix/UI bug fixes

### DIFF
--- a/app/src/components/v-card.vue
+++ b/app/src/components/v-card.vue
@@ -42,6 +42,7 @@ body {
 	height: var(--v-card-height);
 	min-height: var(--v-card-min-height);
 	max-height: var(--v-card-max-height);
+	overflow: auto;
 
 	/* Page Content Spacing */
 	font-size: 15px;

--- a/app/src/components/v-checkbox.test.ts
+++ b/app/src/components/v-checkbox.test.ts
@@ -90,3 +90,34 @@ test('disabled prop', async () => {
 
 	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
 });
+
+test('array modelValue without a value prop does not emit update:modelValue', async () => {
+	const wrapper = mount(VCheckbox, {
+		props: {
+			modelValue: ['test'],
+		},
+		global,
+	});
+
+	await wrapper.get('.checkbox').trigger('click');
+
+	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+});
+
+test('clicking the customValue input does not toggle the checkbox', async () => {
+	const wrapper = mount(VCheckbox, {
+		props: {
+			customValue: true,
+			modelValue: false,
+		},
+		global,
+	});
+
+	await wrapper.find('input').trigger('click');
+
+	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+
+	await wrapper.find('input').setValue('my custom value');
+
+	expect(wrapper.emitted()['update:value'][0]).toEqual(['my custom value']);
+});

--- a/app/src/components/v-checkbox.vue
+++ b/app/src/components/v-checkbox.vue
@@ -12,8 +12,8 @@
 		<div v-if="$slots.prepend" class="prepend"><slot name="prepend" /></div>
 		<v-icon class="checkbox" :name="icon" :disabled="disabled" />
 		<span class="label type-text">
-			<slot v-if="customValue === false">{{ label }}</slot>
-			<input v-else v-model="internalValue" class="custom-input" />
+			<slot v-if="!customValue">{{ label }}</slot>
+			<input v-else v-model="internalValue" class="custom-input" @click.stop="" />
 		</span>
 		<div v-if="$slots.append" class="append"><slot name="append" /></div>
 	</component>
@@ -92,16 +92,18 @@ function toggleInput(): void {
 		emit('update:indeterminate', false);
 	}
 
-	if (props.modelValue instanceof Array && props.value) {
-		const newValue = [...props.modelValue];
+	if (props.modelValue instanceof Array) {
+		if (props.value) {
+			const newValue = [...props.modelValue];
 
-		if (props.modelValue.includes(props.value) === false) {
-			newValue.push(props.value);
-		} else {
-			newValue.splice(newValue.indexOf(props.value), 1);
+			if (!props.modelValue.includes(props.value)) {
+				newValue.push(props.value);
+			} else {
+				newValue.splice(newValue.indexOf(props.value), 1);
+			}
+
+			emit('update:modelValue', newValue);
 		}
-
-		emit('update:modelValue', newValue);
 	} else {
 		emit('update:modelValue', !props.modelValue);
 	}

--- a/app/src/displays/boolean/boolean.test.ts
+++ b/app/src/displays/boolean/boolean.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { GlobalMountOptions } from '@vue/test-utils/dist/types';
+import { expect, test } from 'vitest';
+
+import BooleanDisplay from './boolean.vue';
+
+const global: GlobalMountOptions = {
+	stubs: ['v-icon', 'value-null'],
+};
+
+test('renders the default on icon when no icon is configured', () => {
+	const wrapper = mount(BooleanDisplay, {
+		props: { value: true, colorOn: 'var(--primary)', colorOff: 'var(--foreground-subdued)' },
+		global,
+	});
+
+	expect(wrapper.find('v-icon-stub').attributes('name')).toBe('check');
+});
+
+test('renders the default off icon when no icon is configured', () => {
+	const wrapper = mount(BooleanDisplay, {
+		props: { value: false, colorOn: 'var(--primary)', colorOff: 'var(--foreground-subdued)' },
+		global,
+	});
+
+	expect(wrapper.find('v-icon-stub').attributes('name')).toBe('close');
+});

--- a/app/src/displays/boolean/boolean.vue
+++ b/app/src/displays/boolean/boolean.vue
@@ -25,8 +25,8 @@ const props = withDefaults(
 		value: false,
 		labelOn: null,
 		labelOff: null,
-		iconOn: null,
-		iconOff: null,
+		iconOn: 'check',
+		iconOff: 'close',
 		colorOn: 'var(--primary)',
 		colorOff: 'var(--foreground-subdued)',
 	}

--- a/app/src/interfaces/_system/system-collection/system-collection.vue
+++ b/app/src/interfaces/_system/system-collection/system-collection.vue
@@ -52,10 +52,16 @@ export default defineComponent({
 		});
 
 		const items = computed(() => {
-			return collections.value.map((collection) => ({
-				text: collection.name,
-				value: collection.collection,
-			}));
+			return collections.value.reduce<{ text: string; value: string }[]>((acc, collection) => {
+				if (collection.type !== 'alias') {
+					acc.push({
+						text: collection.name,
+						value: collection.collection,
+					});
+				}
+
+				return acc;
+			}, []);
 		});
 
 		return { items, t };

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -19,7 +19,7 @@
 						<v-icon class="drag-handle" name="drag_handle" />
 						<v-icon class="icon" :name="element.icon" />
 						<div class="info">
-							<div class="name">{{ element.name }}</div>
+							<div class="name">{{ element.displayName }}</div>
 							<div class="to">{{ element.to }}</div>
 						</div>
 						<div class="spacer" />
@@ -69,10 +69,12 @@ import { nanoid } from 'nanoid';
 import { Field, DeepPartial } from '@cairncms/types';
 import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useExtensions } from '@/extensions';
+import { translate } from '@/utils/translate-object-values';
 
 type PreviewExtra = {
 	to: string;
 	name: string;
+	displayName: string;
 	icon: string;
 };
 
@@ -201,6 +203,7 @@ export default defineComponent({
 							to: part.url,
 							icon: part.icon,
 							name: part.name,
+							displayName: translate(part.name),
 						};
 					}
 
@@ -210,6 +213,7 @@ export default defineComponent({
 						...part,
 						to: `/${module.id}`,
 						name: module.name,
+						displayName: module.name,
 						icon: module.icon,
 					};
 				});

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -23,8 +23,8 @@
 			</span>
 		</template>
 		<v-dialog v-model="linkDrawerOpen">
-			<v-card class="card">
-				<v-card-title class="card-title">{{ t('wysiwyg_options.link') }}</v-card-title>
+			<v-card>
+				<v-card-title>{{ t('wysiwyg_options.link') }}</v-card-title>
 				<v-card-text>
 					<div class="grid">
 						<div class="field">
@@ -583,14 +583,5 @@ export default defineComponent({
 	padding: var(--content-padding);
 	padding-top: 0;
 	padding-bottom: var(--content-padding);
-}
-
-.card {
-	overflow: auto;
-
-	.card-title {
-		margin-bottom: 24px;
-		font-size: 24px;
-	}
 }
 </style>

--- a/app/src/modules/settings/components/navigation.test.ts
+++ b/app/src/modules/settings/components/navigation.test.ts
@@ -61,3 +61,28 @@ describe('Settings Navigation — version display', () => {
 		expect(wrapper.html()).not.toContain('github.com/CairnCMS/cairncms/releases');
 	});
 });
+
+describe('Settings Navigation - support links', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: true,
+			})
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('links to the generic issue and discussion pages without a preselected template or category', () => {
+		const wrapper = mountNavigation();
+		const hrefs = wrapper.findAll('a.v-list-item-stub').map((anchor) => anchor.attributes('href'));
+
+		expect(hrefs).toContain('https://github.com/CairnCMS/cairncms/issues/new');
+		expect(hrefs).toContain('https://github.com/CairnCMS/cairncms/discussions/new');
+		expect(hrefs.some((href) => href?.includes('?template='))).toBe(false);
+		expect(hrefs.some((href) => href?.includes('?category='))).toBe(false);
+	});
+});

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -75,12 +75,12 @@ export default defineComponent({
 				{
 					icon: 'bug_report',
 					name: t('report_bug'),
-					href: 'https://github.com/CairnCMS/cairncms/issues/new?template=bug_report.yml',
+					href: 'https://github.com/CairnCMS/cairncms/issues/new',
 				},
 				{
 					icon: 'new_releases',
 					name: t('request_feature'),
-					href: 'https://github.com/CairnCMS/cairncms/discussions/new?category=feature-requests',
+					href: 'https://github.com/CairnCMS/cairncms/discussions/new',
 				},
 			];
 		});

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -92,6 +92,14 @@
 							small
 						/>
 						<v-icon v-if="hidden" v-tooltip="t('hidden_field')" name="visibility_off" class="hidden-icon" small />
+
+						<router-link
+							v-if="showRelatedCollectionLink"
+							:to="`/settings/data-model/${relatedCollectionInfo!.relatedCollection}`"
+						>
+							<v-icon name="open_in_new" class="link-icon" small />
+						</router-link>
+
 						<field-select-menu
 							:field="field"
 							@toggle-visibility="toggleVisibility"
@@ -145,7 +153,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed } from 'vue';
+import { defineComponent, PropType, ref, computed, unref } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRouter } from 'vue-router';
@@ -160,6 +168,7 @@ import { hideDragImage } from '@/utils/hide-drag-image';
 import Draggable from 'vuedraggable';
 import formatTitle from '@cairncms/format-title';
 import { useExtension } from '@/composables/use-extension';
+import { getRelatedCollection } from '@/utils/get-related-collection';
 
 export default defineComponent({
 	name: 'FieldSelect',
@@ -205,6 +214,15 @@ export default defineComponent({
 
 		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
 
+		const relatedCollectionInfo = computed(() => getRelatedCollection(props.field.collection, props.field.field));
+
+		const showRelatedCollectionLink = computed(
+			() =>
+				unref(relatedCollectionInfo) !== null &&
+				props.field.collection !== unref(relatedCollectionInfo)?.relatedCollection &&
+				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
+		);
+
 		return {
 			t,
 			interfaceName,
@@ -224,6 +242,8 @@ export default defineComponent({
 			hidden,
 			toggleVisibility,
 			localType,
+			showRelatedCollectionLink,
+			relatedCollectionInfo,
 			hideDragImage,
 			onGroupSortChange,
 			nestedFields,
@@ -376,6 +396,10 @@ export default defineComponent({
 		--v-icon-color: var(--warning);
 		--v-icon-color-hover: var(--warning);
 	}
+
+	&.link-icon:hover {
+		--v-icon-color: var(--foreground-normal);
+	}
 }
 
 .drag-handle {
@@ -522,7 +546,7 @@ export default defineComponent({
 }
 
 .icons {
-	.v-icon + .v-icon:not(:last-child) {
+	* + *:not(:last-child) {
 		margin-left: 8px;
 	}
 }

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -10,7 +10,7 @@
 				</v-card-text>
 				<v-card-actions>
 					<v-button v-if="notification.type === 'error' && admin && notification.code === 'UNKNOWN'" secondary>
-						<a target="_blank" href="https://github.com/CairnCMS/cairncms/issues/new?template=bug_report.yml">
+						<a target="_blank" href="https://github.com/CairnCMS/cairncms/issues/new">
 							{{ t('report_error') }}
 						</a>
 					</v-button>

--- a/packages/composables/src/use-custom-selection.test.ts
+++ b/packages/composables/src/use-custom-selection.test.ts
@@ -1,0 +1,31 @@
+import { expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useCustomSelectionMultiple } from './use-custom-selection.js';
+
+test('editing a previously unselected custom value does not append it to the selection', () => {
+	const currentValues = ref(['a', 'b']);
+	const items = ref<any[]>([]);
+	const emit = vi.fn();
+
+	const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(currentValues, items, emit);
+
+	addOtherValue();
+
+	const newRow = otherValues.value[otherValues.value.length - 1];
+	setOtherValue(newRow!.key, 'c');
+
+	expect(emit).toHaveBeenLastCalledWith(['a', 'b']);
+});
+
+test('editing a selected custom value replaces it in the selection', () => {
+	const currentValues = ref(['a', 'b']);
+	const items = ref<any[]>([]);
+	const emit = vi.fn();
+
+	const { otherValues, setOtherValue } = useCustomSelectionMultiple(currentValues, items, emit);
+
+	const rowForA = otherValues.value.find((o) => o.value === 'a');
+	setOtherValue(rowForA!.key, 'x');
+
+	expect(emit).toHaveBeenLastCalledWith(['b', 'x']);
+});

--- a/packages/composables/src/use-custom-selection.ts
+++ b/packages/composables/src/use-custom-selection.ts
@@ -118,9 +118,11 @@ export function useCustomSelectionMultiple(
 				return otherValue;
 			});
 
-			const newEmitValue = [...valueWithoutPrevious, newValue];
-
-			emit(newEmitValue);
+			if (valueWithoutPrevious.length === currentValues.value?.length) {
+				emit(valueWithoutPrevious);
+			} else {
+				emit([...valueWithoutPrevious, newValue]);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Fixes a set of small admin UI correctness issues that could make common interfaces behave unexpectedly.

This PR keeps the changes limited to admin UI behavior and one shared UI composable. It does not change API behavior, permissions, auth, schema state, storage, redirects, token handling, logging, or platform security boundaries.

### Testing / verification

Added tests covering:
	- array-backed checkboxes without a value do not emit a spurious `modelValue` update
	- clicking a checkbox custom-value input updates the custom value without toggling the checkbox
	- boolean displays render the default `check` and `close` icons when no custom icons are configured
	- editing an unselected custom multiple-selection value does not append it to the selected set
	- editing a selected custom multiple-selection value still replaces the selected value
	- settings support links point to generic CairnCMS issue/discussion destinations without preselected template or category parameters

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
