### PR TITLE
Fix OAuth2/OpenID refresh-token persistence for existing SSO users

### DIFF
--- a/api/src/auth/drivers/oauth2.test.ts
+++ b/api/src/auth/drivers/oauth2.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import emitter from '../../emitter.js';
+import { OAuth2AuthDriver } from './oauth2.js';
+
+vi.mock('../../emitter.js', () => ({
+	default: {
+		emitFilter: vi.fn(async (_event: string, payload: unknown) => payload),
+		emitAction: vi.fn(),
+	},
+}));
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(() => ({})),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../../env.js', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+		LOGIN_STALL_TIME: 0,
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+function createDriver(refreshToken: string | undefined) {
+	const updateOne = vi.fn(async () => 'user-1');
+	const driver = Object.create(OAuth2AuthDriver.prototype) as OAuth2AuthDriver;
+
+	driver.redirectUrl = 'http://localhost/auth/login/test/callback';
+	driver.config = { provider: 'test' };
+	(driver as any).schema = { collections: {}, relations: [] };
+
+	driver.client = {
+		oauthCallback: vi.fn(async () => ({ access_token: 'ACCESS', refresh_token: refreshToken })),
+		userinfo: vi.fn(async () => ({ sub: 'external-id', email: 'user@example.com' })),
+	} as any;
+
+	driver.usersService = { updateOne } as any;
+	(driver as any).fetchUserId = vi.fn(async () => 'user-1');
+
+	return { driver, updateOne };
+}
+
+const payload = { code: 'CODE', codeVerifier: 'VERIFIER', state: 'STATE' };
+
+describe('OAuth2 auth driver auth_data persistence', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes the computed refresh-token auth_data through the auth.update hook and persists the hook return', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+
+		await driver.getUserID(payload);
+
+		expect(emitter.emitFilter).toHaveBeenCalledTimes(1);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({
+			auth_data: JSON.stringify({ refreshToken: 'REFRESH' }),
+		});
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: JSON.stringify({ refreshToken: 'REFRESH' }) });
+	});
+
+	it('passes auth_data as null when the provider returns no refresh token', async () => {
+		const { driver, updateOne } = createDriver(undefined);
+
+		await driver.getUserID(payload);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({ auth_data: null });
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: null });
+	});
+
+	it('persists the auth_data value returned by the auth.update hook', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+		vi.mocked(emitter.emitFilter).mockResolvedValueOnce({ auth_data: 'hook-modified' });
+
+		await driver.getUserID(payload);
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: 'hook-modified' });
+	});
+});

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -160,7 +160,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],

--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import emitter from '../../emitter.js';
+import { OpenIDAuthDriver } from './openid.js';
+
+vi.mock('../../emitter.js', () => ({
+	default: {
+		emitFilter: vi.fn(async (_event: string, payload: unknown) => payload),
+		emitAction: vi.fn(),
+	},
+}));
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(() => ({})),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../../env.js', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+		LOGIN_STALL_TIME: 0,
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+function createDriver(refreshToken: string | undefined) {
+	const updateOne = vi.fn(async () => 'user-1');
+	const driver = Object.create(OpenIDAuthDriver.prototype) as OpenIDAuthDriver;
+
+	driver.redirectUrl = 'http://localhost/auth/login/test/callback';
+	driver.config = { provider: 'test' };
+	(driver as any).schema = { collections: {}, relations: [] };
+
+	driver.client = Promise.resolve({
+		callback: vi.fn(async () => ({
+			access_token: 'ACCESS',
+			refresh_token: refreshToken,
+			claims: () => ({ sub: 'external-id', email: 'user@example.com' }),
+		})),
+		issuer: { metadata: {} },
+	} as any);
+
+	driver.usersService = { updateOne } as any;
+	(driver as any).fetchUserId = vi.fn(async () => 'user-1');
+
+	return { driver, updateOne };
+}
+
+const payload = { code: 'CODE', codeVerifier: 'VERIFIER', state: 'STATE' };
+
+describe('OpenID auth driver auth_data persistence', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes the computed refresh-token auth_data through the auth.update hook and persists the hook return', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+
+		await driver.getUserID(payload);
+
+		expect(emitter.emitFilter).toHaveBeenCalledTimes(1);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({
+			auth_data: JSON.stringify({ refreshToken: 'REFRESH' }),
+		});
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: JSON.stringify({ refreshToken: 'REFRESH' }) });
+	});
+
+	it('passes auth_data as null when the provider returns no refresh token', async () => {
+		const { driver, updateOne } = createDriver(undefined);
+
+		await driver.getUserID(payload);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({ auth_data: null });
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: null });
+	});
+
+	it('persists the auth_data value returned by the auth.update hook', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+		vi.mocked(emitter.emitFilter).mockResolvedValueOnce({ auth_data: 'hook-modified' });
+
+		await driver.getUserID(payload);
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: 'hook-modified' });
+	});
+});

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -186,7 +186,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

OAuth2 and OpenID logins for existing users could fail to persist provider refresh-token state. The callback path computed `auth_data`, but seeded the `auth.update` hook with an empty object, so the computed provider refresh token was lost before the user row update.

This PR seeds the existing-user OAuth2/OpenID update hook with the computed `auth_data`, using `null` when the provider does not return a refresh token. The hook contract is preserved: if an `auth.update` hook changes `auth_data`, the hook-returned value is what gets persisted.

### Testing / verification

Added tests covering:
- OAuth2 existing-user callback passes computed refresh-token `auth_data` through `auth.update` and persists it
- OAuth2 existing-user callback passes `auth_data: null` when the provider returns no refresh token
- OAuth2 persists the `auth_data` value returned by an `auth.update` hook
- OpenID existing-user callback passes computed refresh-token `auth_data` through `auth.update` and persists it
- OpenID existing-user callback passes `auth_data: null` when the provider returns no refresh token
- OpenID persists the `auth_data` value returned by an `auth.update` hook

Blackbox was not run because the existing blackbox suite does not include an OAuth2/OpenID provider fixture that exercises this callback/update path at this time.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
