### PR TITLE
Clear cached item responses after permission changes

### DIFF
--- a/api/src/services/permissions.test.ts
+++ b/api/src/services/permissions.test.ts
@@ -1,0 +1,73 @@
+import type { SchemaOverview } from '@cairncms/types';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { systemSchema } from '../__utils__/schemas.js';
+import { ItemsService } from './items.js';
+import { PermissionsService } from './permissions.js';
+
+vi.mock('../env', async () => {
+	const actual = (await vi.importActual('../env')) as { default: Record<string, any> };
+
+	const MOCK_ENV = {
+		...actual.default,
+		CACHE_AUTO_PURGE: false,
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../cache', () => ({
+	getCache: vi.fn().mockReturnValue({
+		cache: { clear: vi.fn() },
+		systemCache: { clear: vi.fn() },
+	}),
+	clearSystemCache: vi.fn(),
+}));
+
+const mutations = [
+	{ name: 'createOne', run: (service: PermissionsService, opts: any) => service.createOne({}, opts) },
+	{ name: 'createMany', run: (service: PermissionsService, opts: any) => service.createMany([{}], opts) },
+	{ name: 'updateBatch', run: (service: PermissionsService, opts: any) => service.updateBatch([{}], opts) },
+	{ name: 'updateMany', run: (service: PermissionsService, opts: any) => service.updateMany(['1'], {}, opts) },
+	{ name: 'upsertMany', run: (service: PermissionsService, opts: any) => service.upsertMany([{}], opts) },
+	{ name: 'deleteMany', run: (service: PermissionsService, opts: any) => service.deleteMany(['1'], opts) },
+];
+
+function createService() {
+	return new PermissionsService({ knex: {} as any, schema: systemSchema as SchemaOverview });
+}
+
+describe('PermissionsService response cache invalidation', () => {
+	beforeAll(() => {
+		for (const { name } of mutations) {
+			vi.spyOn(ItemsService.prototype, name as any).mockResolvedValue(undefined as any);
+		}
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each(mutations)('$name clears the response cache when autoPurgeCache is not disabled', async ({ run }) => {
+		const service = createService();
+
+		await run(service, undefined);
+
+		expect(service.cache!.clear).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(mutations)('$name does not clear the response cache when autoPurgeCache is false', async ({ run }) => {
+		const service = createService();
+
+		await run(service, { autoPurgeCache: false });
+
+		expect(service.cache!.clear).not.toHaveBeenCalled();
+	});
+});

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -82,36 +82,66 @@ export class PermissionsService extends ItemsService {
 	override async createOne(data: Partial<Item>, opts?: MutationOptions) {
 		const res = await super.createOne(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.createMany(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.updateBatch(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions) {
 		const res = await super.updateMany(keys, data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.upsertMany(payloads, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async deleteMany(keys: PrimaryKey[], opts?: MutationOptions) {
 		const res = await super.deleteMany(keys, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 }

--- a/tests/blackbox/routes/permissions/cache-purge.test.ts
+++ b/tests/blackbox/routes/permissions/cache-purge.test.ts
@@ -1,0 +1,143 @@
+import config, { Env, getUrl, paths } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import { awaitDirectusConnection } from '@utils/await-connection';
+import { ChildProcess, spawn } from 'child_process';
+import { cloneDeep } from 'lodash';
+import request from 'supertest';
+
+// SQLite cannot safely share a single file across multiple instances, and this
+// test spawns a dedicated cache-configured instance alongside the default one.
+const supportedVendors = vendors.filter((vendor) => vendor !== 'sqlite3');
+const describeFn = supportedVendors.length > 0 ? describe : describe.skip;
+
+const collection = 'test_perms_cache_purge';
+const cacheStatusHeader = 'x-cache-status';
+const adminToken = common.USER.ADMIN.TOKEN;
+const roleId = common.ROLE.TESTS_FLOW.ID;
+
+describeFn('Permissions cache purging', () => {
+	const instances = {} as { [vendor: string]: ChildProcess };
+	const envs = {} as { [vendor: string]: Env };
+
+	beforeAll(async () => {
+		const promises = [];
+
+		for (const vendor of supportedVendors) {
+			const env = cloneDeep(config.envs);
+			env[vendor].CACHE_ENABLED = 'true';
+			env[vendor].CACHE_AUTO_PURGE = 'false';
+			env[vendor].CACHE_STORE = 'memory';
+			env[vendor].CACHE_STATUS_HEADER = cacheStatusHeader;
+			env[vendor].CACHE_NAMESPACE = 'cairncms-perms-cache-purge';
+
+			const port = Number(env[vendor]!.PORT) + 150;
+			env[vendor]!.PORT = String(port);
+
+			instances[vendor] = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], {
+				cwd: paths.cwd,
+				env: env[vendor],
+			});
+
+			envs[vendor] = env;
+			promises.push(awaitDirectusConnection(port));
+		}
+
+		await Promise.all(promises);
+
+		for (const vendor of supportedVendors) {
+			await common.CreateCollection(vendor, { collection, env: envs[vendor] });
+		}
+	}, 300000);
+
+	afterAll(() => {
+		for (const vendor of supportedVendors) {
+			instances[vendor]!.kill();
+		}
+	});
+
+	async function primeCache(vendor: string, env: Env) {
+		await request(getUrl(vendor, env)).post('/utils/cache/clear').set('Authorization', `Bearer ${adminToken}`);
+		await request(getUrl(vendor, env)).get(`/items/${collection}`).set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	function readItems(vendor: string, env: Env) {
+		return request(getUrl(vendor, env)).get(`/items/${collection}`).set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	function createPermission(vendor: string, env: Env, action: string) {
+		return request(getUrl(vendor, env))
+			.post('/permissions')
+			.send({ role: roleId, collection, action })
+			.set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	describe('GET /items response cache', () => {
+		it.each(supportedVendors)('%s serves a cached item response as a HIT when nothing changes', async (vendor) => {
+			const env = envs[vendor]!;
+
+			await primeCache(vendor, env);
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('HIT');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is created', async (vendor) => {
+			const env = envs[vendor]!;
+
+			await primeCache(vendor, env);
+
+			const created = await createPermission(vendor, env, 'read');
+			expect(created.statusCode).toBe(200);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is updated', async (vendor) => {
+			const env = envs[vendor]!;
+
+			const created = await createPermission(vendor, env, 'create');
+			expect(created.statusCode).toBe(200);
+			const permissionId = created.body.data.id;
+
+			await primeCache(vendor, env);
+
+			const updated = await request(getUrl(vendor, env))
+				.patch(`/permissions/${permissionId}`)
+				.send({ action: 'update' })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			expect(updated.statusCode).toBe(200);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is deleted', async (vendor) => {
+			const env = envs[vendor]!;
+
+			const created = await createPermission(vendor, env, 'delete');
+			expect(created.statusCode).toBe(200);
+			const permissionId = created.body.data.id;
+
+			await primeCache(vendor, env);
+
+			const deleted = await request(getUrl(vendor, env))
+				.delete(`/permissions/${permissionId}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			expect(deleted.statusCode).toBeLessThan(300);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -15,6 +15,7 @@ exports.list = {
 		{ testFilePath: '/schema/timezone/timezone-changed-node-tz-asia.test.ts' },
 		{ testFilePath: '/logger/redact.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
+		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/assets/format.test.ts' },
 		{ testFilePath: '/routes/assets/read.test.ts' },
 		{ testFilePath: '/routes/assets/limit.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Permission changes alter the effective authorization boundary, but cached item responses could survive those changes when response caching was enabled and global content auto-purge was disabled. This PR clears cached item responses after permission creates, updates, upserts, and deletes. The existing system-cache invalidation stays in place, and the internal `autoPurgeCache: false` still suppresses the response-cache clear when a caller intentionally batches cache work.

### Testing / verification

Added tests covering:
- each `PermissionsService` mutation path clears the response cache when `autoPurgeCache` is not disabled
- each `PermissionsService` mutation path preserves the `autoPurgeCache: false` suppression behavior
- cached item responses become `MISS` after a permission is created
- cached item responses become `MISS` after a permission is updated
- cached item responses become `MISS` after a permission is deleted
- cached item responses remain `HIT` when no permission change occurs

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
