### PR TITLE
Apply relational field presets to nested items on create

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -206,7 +206,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			}
 
 			const { revisions: revisionsO2M, nestedActionEvents: nestedActionEventsO2M } = await payloadService.processO2M(
-				payload,
+				payloadWithPresets,
 				primaryKey,
 				opts
 			);

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -182,6 +182,7 @@ permissions_for_role: 'Items the {role} Role can {action}.'
 fields_for_role: 'Fields the {role} Role can {action}.'
 validation_for_role: 'Field {action} rules the {role} Role must obey.'
 presets_for_role: 'Field value defaults for the {role} Role.'
+presets_field_warning: 'Relational presets for field "{field}" should be configured with the "detailed" syntax.'
 presentation_and_aliases: Presentation & Aliases
 revision_post_create: Here is what this item looked like when it was created.
 revision_post_update: Here is what this item looked like after the update.

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/presets.test.ts
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/presets.test.ts
@@ -1,0 +1,74 @@
+import { i18n } from '@/lang';
+import { useRelationsStore } from '@/stores/relations';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Presets from './presets.vue';
+
+const stubs = {
+	'v-notice': { props: ['type'], template: '<div class="v-notice" :data-type="type"><slot /></div>' },
+	'interface-input-code': true,
+};
+
+function mountPresets(presets: Record<string, any> | null) {
+	return mount(Presets, {
+		props: {
+			permission: { collection: 'articles', action: 'create', presets } as any,
+		},
+		global: {
+			plugins: [i18n],
+			stubs,
+		},
+	});
+}
+
+describe('Role preset editor relational-field warnings', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }));
+
+		// articles has two relational O2M fields, comments and tags
+		useRelationsStore().getRelationsForCollection = vi.fn(
+			() => [{ meta: { one_field: 'comments' } }, { meta: { one_field: 'tags' } }] as any
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function warnings(wrapper: ReturnType<typeof mountPresets>) {
+		return wrapper.findAll('.v-notice[data-type="warning"]');
+	}
+
+	it('warns for a relational field whose preset uses non-empty array syntax', () => {
+		const wrapper = mountPresets({ comments: [1, 2] });
+
+		expect(warnings(wrapper)).toHaveLength(1);
+		expect(warnings(wrapper)[0]!.text()).toContain('comments');
+	});
+
+	it('does not warn for a relational field configured with detailed object syntax', () => {
+		const wrapper = mountPresets({ tags: { create: [], update: [], delete: [] } });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('does not warn for a relational field whose preset is an empty array', () => {
+		const wrapper = mountPresets({ comments: [] });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('does not warn for a non-relational field', () => {
+		const wrapper = mountPresets({ title: 'Hello' });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('warns only for the relational fields among a mix of preset fields', () => {
+		const wrapper = mountPresets({ comments: [1], tags: [2], title: 'Hello' });
+
+		expect(warnings(wrapper)).toHaveLength(2);
+	});
+});

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
@@ -8,18 +8,26 @@
 				})
 			}}
 		</v-notice>
+		<v-notice v-for="field in fieldWarnings" :key="field" type="warning">
+			{{
+				t('presets_field_warning', {
+					field,
+				})
+			}}
+		</v-notice>
 		<interface-input-code :value="presets" language="json" type="json" @input="presets = $event" />
 	</div>
 </template>
 
 <script setup lang="ts">
+import { useRelationsStore } from '@/stores/relations';
 import { useSync } from '@cairncms/composables';
 import { Permission, Role } from '@cairncms/types';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	permission?: Permission;
+	permission: Permission;
 	role?: Role;
 }>();
 
@@ -39,6 +47,36 @@ const presets = computed({
 			presets: newPresets,
 		};
 	},
+});
+
+const relationsStore = useRelationsStore();
+const relations = relationsStore.getRelationsForCollection(props.permission.collection);
+/**
+ * Display a warning for all relational fields if an array is used as the preset value.
+ * Interfaces in the app that use the useRelationMultiple composable expect the detailed syntax and not the array syntax.
+ *
+ * The useRelationMultiple composable treats arrays as an empty value and the preset would therefore not be shown in the app interface.
+ * If the app interface is used, presets for relational fields have to be entered with the detailed syntax.
+ * The api works correctly in both cases, so if the relational interface is not used in the app, the array syntax can be used as preset as well.
+ */
+// one_field is the field name that is used in the update syntax for a relational field
+const relationFields = relations.map((relation) => relation.meta?.one_field).filter((field) => field);
+
+const fieldWarnings = computed(() => {
+	const warnings: string[] = [];
+
+	if (!presets.value) {
+		return warnings;
+	}
+
+	for (const key of Object.keys(presets.value)) {
+		if (relationFields.includes(key) && Array.isArray(presets.value[key]) && presets.value[key].length > 0) {
+			// Show the warning if the relational field uses a non-empty array as preset
+			warnings.push(key);
+		}
+	}
+
+	return warnings;
 });
 </script>
 

--- a/tests/blackbox/routes/items/relational-presets.test.ts
+++ b/tests/blackbox/routes/items/relational-presets.test.ts
@@ -1,0 +1,124 @@
+import { getUrl } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import request from 'supertest';
+
+// The preset path is only exercised under a non-admin accountability (admin bypasses
+// the permission system), so this test creates its own non-admin role rather than
+// reusing the admin-capable TESTS_FLOW role.
+
+const parentCollection = 'test_items_relational_presets_parent';
+const childCollection = 'test_items_relational_presets_child';
+const adminToken = common.USER.ADMIN.TOKEN;
+const presetUserToken = 'RelationalPresetTestToken';
+
+describe('Relational field presets on item create', () => {
+	const roleId = {} as Record<string, string>;
+	const userId = {} as Record<string, string>;
+
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			await common.CreateCollection(vendor, { collection: parentCollection });
+			await common.CreateCollection(vendor, { collection: childCollection });
+			await common.CreateField(vendor, { collection: parentCollection, field: 'name', type: 'string' });
+			await common.CreateField(vendor, { collection: childCollection, field: 'name', type: 'string' });
+
+			await common.CreateFieldO2M(vendor, {
+				collection: parentCollection,
+				field: 'children',
+				otherCollection: childCollection,
+				otherField: 'parent_id',
+				primaryKeyType: 'integer',
+			});
+
+			const role = await request(getUrl(vendor))
+				.post('/roles')
+				.send({ name: 'Relational Preset Test Role', admin_access: false, app_access: true })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			roleId[vendor] = role.body.data.id;
+
+			const user = await request(getUrl(vendor))
+				.post('/users')
+				.send({
+					email: `relational-preset-${vendor}@tests.com`,
+					password: 'RelationalPresetPassword',
+					token: presetUserToken,
+					role: roleId[vendor],
+					status: 'active',
+				})
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			userId[vendor] = user.body.data.id;
+
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({
+					role: roleId[vendor],
+					collection: parentCollection,
+					action: 'create',
+					fields: ['*'],
+					presets: { children: { create: [{ name: 'Preset child' }] } },
+				})
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// Read permission so the create response carries the new primary key.
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({ role: roleId[vendor], collection: parentCollection, action: 'read', fields: ['*'] })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// `fields: ['*']` so the nested create can write the parent foreign key on the child.
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({ role: roleId[vendor], collection: childCollection, action: 'create', fields: ['*'] })
+				.set('Authorization', `Bearer ${adminToken}`);
+		}
+	}, 300000);
+
+	afterAll(async () => {
+		for (const vendor of vendors) {
+			await request(getUrl(vendor))
+				.delete(`/collections/${childCollection}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			await request(getUrl(vendor))
+				.delete(`/collections/${parentCollection}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// Delete the user before the role so it is never left orphaned with role = null.
+			if (userId[vendor]) {
+				await request(getUrl(vendor))
+					.delete(`/users/${userId[vendor]}`)
+					.set('Authorization', `Bearer ${adminToken}`);
+			}
+
+			if (roleId[vendor]) {
+				await request(getUrl(vendor))
+					.delete(`/roles/${roleId[vendor]}`)
+					.set('Authorization', `Bearer ${adminToken}`);
+			}
+		}
+	});
+
+	it.each(vendors)('%s applies a relational O2M preset to nested children on create', async (vendor) => {
+		const created = await request(getUrl(vendor))
+			.post(`/items/${parentCollection}`)
+			.send({ name: 'Parent created without children in the payload' })
+			.set('Authorization', `Bearer ${presetUserToken}`);
+
+		expect(created.statusCode).toBe(200);
+
+		const parentId = created.body.data.id;
+
+		const readBack = await request(getUrl(vendor))
+			.get(`/items/${parentCollection}/${parentId}`)
+			.query({ fields: '*,children.*' })
+			.set('Authorization', `Bearer ${adminToken}`);
+
+		expect(readBack.statusCode).toBe(200);
+		expect(readBack.body.data.children).toHaveLength(1);
+		expect(readBack.body.data.children[0].name).toBe('Preset child');
+		expect(readBack.body.data.children[0].parent_id).toBe(parentId);
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -16,6 +16,7 @@ exports.list = {
 		{ testFilePath: '/logger/redact.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
+		{ testFilePath: '/routes/items/relational-presets.test.ts' },
 		{ testFilePath: '/routes/assets/format.test.ts' },
 		{ testFilePath: '/routes/assets/read.test.ts' },
 		{ testFilePath: '/routes/assets/limit.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Relational field presets on create were merged into the payload, then lost before O2M processing because the create path still used the raw request payload. This PR passes the preset-merged payload into O2M processing, so role-configured relational presets can create nested children as intended.

The PR also adds a warning in the role preset editor for non-empty array syntax on relational fields. The API accepts that syntax, but the admin app's relational interfaces expect the detailed preset syntax.

### Testing / verification

Added tests covering:
- a new blackbox where a non-admin role creates a parent item and a relational O2M preset creates the nested child record
- the nested child record is linked back to the created parent
- the role preset editor warns for non-empty array syntax on relational fields
- the role preset editor does not warn for detailed object syntax on relational fields
- the role preset editor does not warn for empty arrays or non-relational fields
- mixed preset objects warn only for the relational fields that need the warning

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
