### PR TITLE
Fix/form field render guard

### DIFF
--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -1,0 +1,51 @@
+import { i18n } from '@/lang';
+import { createTestingPinia } from '@pinia/testing';
+import { shallowMount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FormField from './form-field.vue';
+import VForm from './v-form.vue';
+
+const field = {
+	collection: 'test',
+	field: 'title',
+	type: 'string',
+	name: 'Title',
+	meta: {
+		collection: 'test',
+		field: 'title',
+		type: 'string',
+		interface: 'input',
+		special: null,
+		hidden: false,
+		group: null,
+		sort: 1,
+		width: 'full',
+	},
+	schema: { name: 'title', table: 'test', data_type: 'varchar' },
+};
+
+function mountForm(loading: boolean) {
+	return shallowMount(VForm, {
+		props: { fields: [field] as any, loading },
+		global: { plugins: [i18n] },
+	});
+}
+
+describe('VForm renders a field only when it is present in fieldsMap', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+	});
+
+	it('does not render a form field while loading, when fieldsMap is empty', () => {
+		const wrapper = mountForm(true);
+
+		expect(wrapper.findComponent(FormField).exists()).toBe(false);
+	});
+
+	it('renders the form field once loading is complete and the field is in fieldsMap', () => {
+		const wrapper = mountForm(false);
+
+		expect(wrapper.findComponent(FormField).exists()).toBe(true);
+	});
+});

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -15,70 +15,72 @@
 			{{ t('no_visible_fields_copy') }}
 		</v-info>
 		<template v-for="(fieldName, index) in fieldNames" :key="fieldName">
-			<component
-				:is="`interface-${fieldsMap[fieldName]?.meta?.interface || 'group-standard'}`"
-				v-if="fieldsMap[fieldName]?.meta?.special?.includes('group')"
-				v-show="!fieldsMap[fieldName]?.meta?.hidden"
-				:ref="
+			<template v-if="fieldsMap[fieldName]">
+				<component
+					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
+					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group')"
+					v-show="!fieldsMap[fieldName]!.meta?.hidden"
+					:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
 					}
 				"
-				:class="[
-					fieldsMap[fieldName]?.meta?.width || 'full',
-					index === firstVisibleFieldIndex ? 'first-visible-field' : '',
-				]"
-				:field="fieldsMap[fieldName]"
-				:fields="fieldsForGroup[index] || []"
-				:values="modelValue || {}"
-				:initial-values="initialValues || {}"
-				:disabled="disabled"
-				:batch-mode="batchMode"
-				:batch-active-fields="batchActiveFields"
-				:primary-key="primaryKey"
-				:loading="loading"
-				:validation-errors="validationErrors"
-				:badge="badge"
-				:raw-editor-enabled="rawEditorEnabled"
-				:direction="direction"
-				v-bind="fieldsMap[fieldName]?.meta?.options || {}"
-				@apply="apply"
-			/>
+					:class="[
+						fieldsMap[fieldName]!.meta?.width || 'full',
+						index === firstVisibleFieldIndex ? 'first-visible-field' : '',
+					]"
+					:field="fieldsMap[fieldName]"
+					:fields="fieldsForGroup[index] || []"
+					:values="modelValue || {}"
+					:initial-values="initialValues || {}"
+					:disabled="disabled"
+					:batch-mode="batchMode"
+					:batch-active-fields="batchActiveFields"
+					:primary-key="primaryKey"
+					:loading="loading"
+					:validation-errors="validationErrors"
+					:badge="badge"
+					:raw-editor-enabled="rawEditorEnabled"
+					:direction="direction"
+					v-bind="fieldsMap[fieldName]!.meta?.options || {}"
+					@apply="apply"
+				/>
 
-			<form-field
-				v-else-if="!fieldsMap[fieldName]?.meta?.hidden"
-				:ref="
-					(el) => {
-						formFieldEls[fieldName] = el;
-					}
-				"
-				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="fieldsMap[fieldName]!"
-				:autofocus="index === firstEditableFieldIndex && autofocus"
-				:model-value="(values || {})[fieldName]"
-				:initial-value="(initialValues || {})[fieldName]"
-				:disabled="isDisabled(fieldsMap[fieldName]!)"
-				:batch-mode="batchMode"
-				:batch-active="batchActiveFields.includes(fieldName)"
-				:primary-key="primaryKey"
-				:loading="loading"
-				:validation-error="
-					validationErrors.find(
-						(err) =>
-							err.collection === fieldsMap[fieldName]?.collection &&
-							(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
-					)
-				"
-				:badge="badge"
-				:raw-editor-enabled="rawEditorEnabled"
-				:raw-editor-active="rawActiveFields.has(fieldName)"
-				:direction="direction"
-				@update:model-value="setValue(fieldName, $event)"
-				@set-field-value="setValue($event.field, $event.value, { force: true })"
-				@unset="unsetValue(fieldsMap[fieldName]!)"
-				@toggle-batch="toggleBatchField(fieldsMap[fieldName]!)"
-				@toggle-raw="toggleRawField(fieldsMap[fieldName]!)"
-			/>
+				<form-field
+					v-else-if="!fieldsMap[fieldName]!.meta?.hidden"
+					:ref="
+						(el) => {
+							formFieldEls[fieldName] = el;
+						}
+					"
+					:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
+					:field="fieldsMap[fieldName]!"
+					:autofocus="index === firstEditableFieldIndex && autofocus"
+					:model-value="(values || {})[fieldName]"
+					:initial-value="(initialValues || {})[fieldName]"
+					:disabled="isDisabled(fieldsMap[fieldName]!)"
+					:batch-mode="batchMode"
+					:batch-active="batchActiveFields.includes(fieldName)"
+					:primary-key="primaryKey"
+					:loading="loading"
+					:validation-error="
+						validationErrors.find(
+							(err) =>
+								err.collection === fieldsMap[fieldName]!.collection &&
+								(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
+						)
+					"
+					:badge="badge"
+					:raw-editor-enabled="rawEditorEnabled"
+					:raw-editor-active="rawActiveFields.has(fieldName)"
+					:direction="direction"
+					@update:model-value="setValue(fieldName, $event)"
+					@set-field-value="setValue($event.field, $event.value, { force: true })"
+					@unset="unsetValue(fieldsMap[fieldName]!)"
+					@toggle-batch="toggleBatchField(fieldsMap[fieldName]!)"
+					@toggle-raw="toggleRawField(fieldsMap[fieldName]!)"
+				/>
+			</template>
 		</template>
 		<v-divider v-if="showDivider && !noVisibleFields" />
 	</div>


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

`v-form` could try to render a field whose definition was not present in `fieldsMap`. In that state, `form-field` received `field: undefined` and crashed while reading `field.meta`, which showed up while editing roles.

This PR guards the per-field render block so missing field definitions render nothing instead of mounting `form-field`. Fields that are present still render normally.

### Testing / verification

Added tests covering:
- `v-form` does not render `form-field` while loading, when `fieldsMap` is empty
- `v-form` does render `form-field` after loading when the field is present

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
