### PR TITLE
Fix/alias fields display template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
 			rules: {
 				...defaultRules,
 				'vue/multi-word-component-names': 'off',
+				'vue/require-default-prop': 'off',
 				// It's recommended to turn off this rule on TypeScript projects
 				'no-undef': 'off',
 				// Allow ts-directive comments (used to suppress TypeScript compiler errors)

--- a/api/src/auth/drivers/oauth2.test.ts
+++ b/api/src/auth/drivers/oauth2.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import emitter from '../../emitter.js';
+import { OAuth2AuthDriver } from './oauth2.js';
+
+vi.mock('../../emitter.js', () => ({
+	default: {
+		emitFilter: vi.fn(async (_event: string, payload: unknown) => payload),
+		emitAction: vi.fn(),
+	},
+}));
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(() => ({})),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../../env.js', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+		LOGIN_STALL_TIME: 0,
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+function createDriver(refreshToken: string | undefined) {
+	const updateOne = vi.fn(async () => 'user-1');
+	const driver = Object.create(OAuth2AuthDriver.prototype) as OAuth2AuthDriver;
+
+	driver.redirectUrl = 'http://localhost/auth/login/test/callback';
+	driver.config = { provider: 'test' };
+	(driver as any).schema = { collections: {}, relations: [] };
+
+	driver.client = {
+		oauthCallback: vi.fn(async () => ({ access_token: 'ACCESS', refresh_token: refreshToken })),
+		userinfo: vi.fn(async () => ({ sub: 'external-id', email: 'user@example.com' })),
+	} as any;
+
+	driver.usersService = { updateOne } as any;
+	(driver as any).fetchUserId = vi.fn(async () => 'user-1');
+
+	return { driver, updateOne };
+}
+
+const payload = { code: 'CODE', codeVerifier: 'VERIFIER', state: 'STATE' };
+
+describe('OAuth2 auth driver auth_data persistence', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes the computed refresh-token auth_data through the auth.update hook and persists the hook return', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+
+		await driver.getUserID(payload);
+
+		expect(emitter.emitFilter).toHaveBeenCalledTimes(1);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({
+			auth_data: JSON.stringify({ refreshToken: 'REFRESH' }),
+		});
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: JSON.stringify({ refreshToken: 'REFRESH' }) });
+	});
+
+	it('passes auth_data as null when the provider returns no refresh token', async () => {
+		const { driver, updateOne } = createDriver(undefined);
+
+		await driver.getUserID(payload);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({ auth_data: null });
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: null });
+	});
+
+	it('persists the auth_data value returned by the auth.update hook', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+		vi.mocked(emitter.emitFilter).mockResolvedValueOnce({ auth_data: 'hook-modified' });
+
+		await driver.getUserID(payload);
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: 'hook-modified' });
+	});
+});

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -160,7 +160,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],

--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import emitter from '../../emitter.js';
+import { OpenIDAuthDriver } from './openid.js';
+
+vi.mock('../../emitter.js', () => ({
+	default: {
+		emitFilter: vi.fn(async (_event: string, payload: unknown) => payload),
+		emitAction: vi.fn(),
+	},
+}));
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(() => ({})),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../../env.js', () => {
+	const MOCK_ENV = {
+		SECRET: 'test-secret-for-jwt',
+		PUBLIC_URL: 'http://localhost:8055',
+		LOGIN_STALL_TIME: 0,
+		EXTENSIONS_PATH: './extensions',
+		EMAIL_TRANSPORT: 'sendmail',
+	};
+
+	return { default: MOCK_ENV, getEnv: () => MOCK_ENV };
+});
+
+function createDriver(refreshToken: string | undefined) {
+	const updateOne = vi.fn(async () => 'user-1');
+	const driver = Object.create(OpenIDAuthDriver.prototype) as OpenIDAuthDriver;
+
+	driver.redirectUrl = 'http://localhost/auth/login/test/callback';
+	driver.config = { provider: 'test' };
+	(driver as any).schema = { collections: {}, relations: [] };
+
+	driver.client = Promise.resolve({
+		callback: vi.fn(async () => ({
+			access_token: 'ACCESS',
+			refresh_token: refreshToken,
+			claims: () => ({ sub: 'external-id', email: 'user@example.com' }),
+		})),
+		issuer: { metadata: {} },
+	} as any);
+
+	driver.usersService = { updateOne } as any;
+	(driver as any).fetchUserId = vi.fn(async () => 'user-1');
+
+	return { driver, updateOne };
+}
+
+const payload = { code: 'CODE', codeVerifier: 'VERIFIER', state: 'STATE' };
+
+describe('OpenID auth driver auth_data persistence', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes the computed refresh-token auth_data through the auth.update hook and persists the hook return', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+
+		await driver.getUserID(payload);
+
+		expect(emitter.emitFilter).toHaveBeenCalledTimes(1);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({
+			auth_data: JSON.stringify({ refreshToken: 'REFRESH' }),
+		});
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: JSON.stringify({ refreshToken: 'REFRESH' }) });
+	});
+
+	it('passes auth_data as null when the provider returns no refresh token', async () => {
+		const { driver, updateOne } = createDriver(undefined);
+
+		await driver.getUserID(payload);
+
+		expect(vi.mocked(emitter.emitFilter).mock.calls[0]![1]).toEqual({ auth_data: null });
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: null });
+	});
+
+	it('persists the auth_data value returned by the auth.update hook', async () => {
+		const { driver, updateOne } = createDriver('REFRESH');
+		vi.mocked(emitter.emitFilter).mockResolvedValueOnce({ auth_data: 'hook-modified' });
+
+		await driver.getUserID(payload);
+
+		expect(updateOne).toHaveBeenCalledWith('user-1', { auth_data: 'hook-modified' });
+	});
+});

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -186,7 +186,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{},
+				{ auth_data: userPayload.auth_data ?? null },
 				{
 					identifier,
 					provider: this.config['provider'],

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -206,7 +206,7 @@ export class ItemsService<Item extends AnyItem = AnyItem> implements AbstractSer
 			}
 
 			const { revisions: revisionsO2M, nestedActionEvents: nestedActionEventsO2M } = await payloadService.processO2M(
-				payload,
+				payloadWithPresets,
 				primaryKey,
 				opts
 			);

--- a/api/src/services/permissions.test.ts
+++ b/api/src/services/permissions.test.ts
@@ -1,0 +1,73 @@
+import type { SchemaOverview } from '@cairncms/types';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { systemSchema } from '../__utils__/schemas.js';
+import { ItemsService } from './items.js';
+import { PermissionsService } from './permissions.js';
+
+vi.mock('../env', async () => {
+	const actual = (await vi.importActual('../env')) as { default: Record<string, any> };
+
+	const MOCK_ENV = {
+		...actual.default,
+		CACHE_AUTO_PURGE: false,
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: () => MOCK_ENV,
+	};
+});
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn(),
+}));
+
+vi.mock('../cache', () => ({
+	getCache: vi.fn().mockReturnValue({
+		cache: { clear: vi.fn() },
+		systemCache: { clear: vi.fn() },
+	}),
+	clearSystemCache: vi.fn(),
+}));
+
+const mutations = [
+	{ name: 'createOne', run: (service: PermissionsService, opts: any) => service.createOne({}, opts) },
+	{ name: 'createMany', run: (service: PermissionsService, opts: any) => service.createMany([{}], opts) },
+	{ name: 'updateBatch', run: (service: PermissionsService, opts: any) => service.updateBatch([{}], opts) },
+	{ name: 'updateMany', run: (service: PermissionsService, opts: any) => service.updateMany(['1'], {}, opts) },
+	{ name: 'upsertMany', run: (service: PermissionsService, opts: any) => service.upsertMany([{}], opts) },
+	{ name: 'deleteMany', run: (service: PermissionsService, opts: any) => service.deleteMany(['1'], opts) },
+];
+
+function createService() {
+	return new PermissionsService({ knex: {} as any, schema: systemSchema as SchemaOverview });
+}
+
+describe('PermissionsService response cache invalidation', () => {
+	beforeAll(() => {
+		for (const { name } of mutations) {
+			vi.spyOn(ItemsService.prototype, name as any).mockResolvedValue(undefined as any);
+		}
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each(mutations)('$name clears the response cache when autoPurgeCache is not disabled', async ({ run }) => {
+		const service = createService();
+
+		await run(service, undefined);
+
+		expect(service.cache!.clear).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(mutations)('$name does not clear the response cache when autoPurgeCache is false', async ({ run }) => {
+		const service = createService();
+
+		await run(service, { autoPurgeCache: false });
+
+		expect(service.cache!.clear).not.toHaveBeenCalled();
+	});
+});

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -82,36 +82,66 @@ export class PermissionsService extends ItemsService {
 	override async createOne(data: Partial<Item>, opts?: MutationOptions) {
 		const res = await super.createOne(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.createMany(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async updateBatch(data: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.updateBatch(data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions) {
 		const res = await super.updateMany(keys, data, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async upsertMany(payloads: Partial<Item>[], opts?: MutationOptions) {
 		const res = await super.upsertMany(payloads, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 
 	override async deleteMany(keys: PrimaryKey[], opts?: MutationOptions) {
 		const res = await super.deleteMany(keys, opts);
 		await clearSystemCache({ autoPurgeCache: opts?.autoPurgeCache });
+
+		if (this.cache && opts?.autoPurgeCache !== false) {
+			await this.cache.clear();
+		}
+
 		return res;
 	}
 }

--- a/app/src/components/v-card.vue
+++ b/app/src/components/v-card.vue
@@ -42,6 +42,7 @@ body {
 	height: var(--v-card-height);
 	min-height: var(--v-card-min-height);
 	max-height: var(--v-card-max-height);
+	overflow: auto;
 
 	/* Page Content Spacing */
 	font-size: 15px;

--- a/app/src/components/v-checkbox.test.ts
+++ b/app/src/components/v-checkbox.test.ts
@@ -90,3 +90,34 @@ test('disabled prop', async () => {
 
 	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
 });
+
+test('array modelValue without a value prop does not emit update:modelValue', async () => {
+	const wrapper = mount(VCheckbox, {
+		props: {
+			modelValue: ['test'],
+		},
+		global,
+	});
+
+	await wrapper.get('.checkbox').trigger('click');
+
+	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+});
+
+test('clicking the customValue input does not toggle the checkbox', async () => {
+	const wrapper = mount(VCheckbox, {
+		props: {
+			customValue: true,
+			modelValue: false,
+		},
+		global,
+	});
+
+	await wrapper.find('input').trigger('click');
+
+	expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+
+	await wrapper.find('input').setValue('my custom value');
+
+	expect(wrapper.emitted()['update:value'][0]).toEqual(['my custom value']);
+});

--- a/app/src/components/v-checkbox.vue
+++ b/app/src/components/v-checkbox.vue
@@ -12,8 +12,8 @@
 		<div v-if="$slots.prepend" class="prepend"><slot name="prepend" /></div>
 		<v-icon class="checkbox" :name="icon" :disabled="disabled" />
 		<span class="label type-text">
-			<slot v-if="customValue === false">{{ label }}</slot>
-			<input v-else v-model="internalValue" class="custom-input" />
+			<slot v-if="!customValue">{{ label }}</slot>
+			<input v-else v-model="internalValue" class="custom-input" @click.stop="" />
 		</span>
 		<div v-if="$slots.append" class="append"><slot name="append" /></div>
 	</component>
@@ -92,16 +92,18 @@ function toggleInput(): void {
 		emit('update:indeterminate', false);
 	}
 
-	if (props.modelValue instanceof Array && props.value) {
-		const newValue = [...props.modelValue];
+	if (props.modelValue instanceof Array) {
+		if (props.value) {
+			const newValue = [...props.modelValue];
 
-		if (props.modelValue.includes(props.value) === false) {
-			newValue.push(props.value);
-		} else {
-			newValue.splice(newValue.indexOf(props.value), 1);
+			if (!props.modelValue.includes(props.value)) {
+				newValue.push(props.value);
+			} else {
+				newValue.splice(newValue.indexOf(props.value), 1);
+			}
+
+			emit('update:modelValue', newValue);
 		}
-
-		emit('update:modelValue', newValue);
 	} else {
 		emit('update:modelValue', !props.modelValue);
 	}

--- a/app/src/components/v-date-picker.vue
+++ b/app/src/components/v-date-picker.vue
@@ -5,11 +5,11 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue';
-import Flatpickr from 'flatpickr';
-import { format, formatISO } from 'date-fns';
 import { getFlatpickrLocale } from '@/utils/get-flatpickr-locale';
+import { format, formatISO } from 'date-fns';
+import Flatpickr from 'flatpickr';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 interface Props {
 	type: 'date' | 'time' | 'dateTime' | 'timestamp';
@@ -36,7 +36,7 @@ let flatpickr: Flatpickr.Instance | null;
 onMounted(async () => {
 	if (wrapper.value) {
 		const flatpickrLocale = await getFlatpickrLocale();
-		flatpickr = Flatpickr(wrapper.value, { ...flatpickrOptions.value, locale: flatpickrLocale } as any);
+		flatpickr = Flatpickr(wrapper.value as Node, { ...flatpickrOptions.value, locale: flatpickrLocale } as any);
 	}
 
 	watch(

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -29,12 +29,12 @@
 </template>
 
 <script setup lang="ts">
-import { toRefs, ref, watch, onMounted, onUnmounted, computed } from 'vue';
-import FieldListItem from './field-list-item.vue';
-import { FieldTree } from './types';
-import { Field, Relation } from '@cairncms/types';
 import { useFieldTree } from '@/composables/use-field-tree';
 import { flattenFieldGroups } from '@/utils/flatten-field-groups';
+import { Field, Relation } from '@cairncms/types';
+import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue';
+import FieldListItem from './field-list-item.vue';
+import { FieldTree } from './types';
 
 interface Props {
 	disabled?: boolean;
@@ -158,7 +158,7 @@ function onSelect() {
 			contentEl.value.appendChild(textSpan);
 		}
 
-		range.setStart(textSpan, 0);
+		range.setStart(textSpan as Node, 0);
 		selection.addRange(range);
 	}
 }
@@ -173,7 +173,7 @@ function addField(field: FieldTree) {
 
 	if (window.getSelection()?.rangeCount == 0) {
 		const range = document.createRange();
-		range.selectNodeContents(contentEl.value.children[0]);
+		range.selectNodeContents(contentEl.value.children[0] as Node);
 		window.getSelection()?.addRange(range);
 	}
 

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -46,14 +46,14 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed } from 'vue';
-import { Field } from '@cairncms/types';
-import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
 import { useExtension } from '@/composables/use-extension';
+import { getDefaultInterfaceForType } from '@/utils/get-default-interface-for-type';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { FormField } from './types';
 
 interface Props {
-	field: Field;
+	field: FormField;
 	batchMode?: boolean;
 	batchActive?: boolean;
 	primaryKey?: string | number | null;
@@ -93,7 +93,7 @@ const interfaceExists = computed(() => !!inter.value);
 const componentName = computed(() => {
 	return props.field?.meta?.interface
 		? `interface-${props.field.meta.interface}`
-		: `interface-${getDefaultInterfaceForType(props.field.type)}`;
+		: `interface-${getDefaultInterfaceForType(props.field.type!)}`;
 });
 </script>
 

--- a/app/src/components/v-form/form-field-label.vue
+++ b/app/src/components/v-form/form-field-label.vue
@@ -35,10 +35,10 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { Field } from '@cairncms/types';
+import type { FormField } from './types';
 
 interface Props {
-	field: Field;
+	field: FormField;
 	toggle: (event: Event) => any;
 	batchMode?: boolean;
 	batchActive?: boolean;
@@ -155,7 +155,7 @@ const { t } = useI18n();
 			width: 4px;
 			height: 4px;
 			background-color: var(--foreground-subdued);
-			border-radius: 2px;
+			border-radius: 4px;
 			content: '';
 		}
 

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -48,13 +48,13 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed } from 'vue';
-import { Field } from '@cairncms/types';
 import { useClipboard } from '@/composables/use-clipboard';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { FormField } from './types';
 
 interface Props {
-	field: Field;
+	field: FormField;
 	modelValue?: string | number | boolean | Record<string, any> | Array<any> | null;
 	initialValue?: string | number | boolean | Record<string, any> | Array<any> | null;
 	restricted?: boolean;

--- a/app/src/components/v-form/form-field-raw-editor.vue
+++ b/app/src/components/v-form/form-field-raw-editor.vue
@@ -33,13 +33,13 @@
 
 <script setup lang="ts">
 import { getJSType } from '@/utils/get-js-type';
-import { Field } from '@cairncms/types';
 import { isNil } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import type { FormField } from './types';
 
 interface Props {
-	field: Field;
+	field: FormField;
 	showModal: boolean;
 	disabled: boolean;
 	currentValue: unknown;

--- a/app/src/components/v-form/form-field.vue
+++ b/app/src/components/v-form/form-field.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :key="field.field" class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
+	<div class="field" :class="[field.meta?.width || 'full', { invalid: validationError }]">
 		<v-menu v-if="field.hideLabel !== true" placement="bottom-start" show-arrow>
 			<template #activator="{ toggle, active }">
 				<form-field-label
@@ -31,7 +31,7 @@
 				@paste-raw="pasteRaw"
 			/>
 		</v-menu>
-		<div v-else-if="['full', 'fill'].includes(field.meta?.width) === false" class="label-spacer" />
+		<div v-else-if="['full', 'fill'].includes(field.meta?.width ?? '') === false" class="label-spacer" />
 
 		<form-field-interface
 			:autofocus="autofocus"
@@ -71,20 +71,21 @@
 </template>
 
 <script setup lang="ts">
-import { Field, ValidationError } from '@cairncms/types';
+import { useClipboard } from '@/composables/use-clipboard';
+import { formatFieldFunction } from '@/utils/format-field-function';
+import { ValidationError } from '@cairncms/types';
+import { parseJSON } from '@cairncms/utils';
 import { isEqual } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import FormFieldInterface from './form-field-interface.vue';
 import FormFieldLabel from './form-field-label.vue';
 import FormFieldMenu from './form-field-menu.vue';
-import { formatFieldFunction } from '@/utils/format-field-function';
-import { useClipboard } from '@/composables/use-clipboard';
 import FormFieldRawEditor from './form-field-raw-editor.vue';
-import { parseJSON } from '@cairncms/utils';
+import type { FormField } from './types';
 
 interface Props {
-	field: Field;
+	field: FormField;
 	batchMode?: boolean;
 	batchActive?: boolean;
 	disabled?: boolean;
@@ -145,7 +146,7 @@ const validationPrefix = computed(() => {
 	if (!props.validationError) return null;
 
 	if (props.validationError.field.includes('(') && props.validationError.field.includes(')')) {
-		return formatFieldFunction(props.field.collection, props.validationError.field) + ': ';
+		return formatFieldFunction(props.field.collection!, props.validationError.field) + ': ';
 	}
 
 	return null;

--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -1,0 +1,51 @@
+import { i18n } from '@/lang';
+import { createTestingPinia } from '@pinia/testing';
+import { shallowMount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FormField from './form-field.vue';
+import VForm from './v-form.vue';
+
+const field = {
+	collection: 'test',
+	field: 'title',
+	type: 'string',
+	name: 'Title',
+	meta: {
+		collection: 'test',
+		field: 'title',
+		type: 'string',
+		interface: 'input',
+		special: null,
+		hidden: false,
+		group: null,
+		sort: 1,
+		width: 'full',
+	},
+	schema: { name: 'title', table: 'test', data_type: 'varchar' },
+};
+
+function mountForm(loading: boolean) {
+	return shallowMount(VForm, {
+		props: { fields: [field] as any, loading },
+		global: { plugins: [i18n] },
+	});
+}
+
+describe('VForm renders a field only when it is present in fieldsMap', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+	});
+
+	it('does not render a form field while loading, when fieldsMap is empty', () => {
+		const wrapper = mountForm(true);
+
+		expect(wrapper.findComponent(FormField).exists()).toBe(false);
+	});
+
+	it('renders the form field once loading is complete and the field is in fieldsMap', () => {
+		const wrapper = mountForm(false);
+
+		expect(wrapper.findComponent(FormField).exists()).toBe(true);
+	});
+});

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -15,70 +15,72 @@
 			{{ t('no_visible_fields_copy') }}
 		</v-info>
 		<template v-for="(fieldName, index) in fieldNames" :key="fieldName">
-			<component
-				:is="`interface-${fieldsMap[fieldName]?.meta?.interface || 'group-standard'}`"
-				v-if="fieldsMap[fieldName]?.meta?.special?.includes('group')"
-				v-show="!fieldsMap[fieldName]?.meta?.hidden"
-				:ref="
+			<template v-if="fieldsMap[fieldName]">
+				<component
+					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
+					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group')"
+					v-show="!fieldsMap[fieldName]!.meta?.hidden"
+					:ref="
 					(el: Element) => {
 						formFieldEls[fieldName] = el;
 					}
 				"
-				:class="[
-					fieldsMap[fieldName]?.meta?.width || 'full',
-					index === firstVisibleFieldIndex ? 'first-visible-field' : '',
-				]"
-				:field="fieldsMap[fieldName]"
-				:fields="fieldsForGroup[index] || []"
-				:values="modelValue || {}"
-				:initial-values="initialValues || {}"
-				:disabled="disabled"
-				:batch-mode="batchMode"
-				:batch-active-fields="batchActiveFields"
-				:primary-key="primaryKey"
-				:loading="loading"
-				:validation-errors="validationErrors"
-				:badge="badge"
-				:raw-editor-enabled="rawEditorEnabled"
-				:direction="direction"
-				v-bind="fieldsMap[fieldName]?.meta?.options || {}"
-				@apply="apply"
-			/>
+					:class="[
+						fieldsMap[fieldName]!.meta?.width || 'full',
+						index === firstVisibleFieldIndex ? 'first-visible-field' : '',
+					]"
+					:field="fieldsMap[fieldName]"
+					:fields="fieldsForGroup[index] || []"
+					:values="modelValue || {}"
+					:initial-values="initialValues || {}"
+					:disabled="disabled"
+					:batch-mode="batchMode"
+					:batch-active-fields="batchActiveFields"
+					:primary-key="primaryKey"
+					:loading="loading"
+					:validation-errors="validationErrors"
+					:badge="badge"
+					:raw-editor-enabled="rawEditorEnabled"
+					:direction="direction"
+					v-bind="fieldsMap[fieldName]!.meta?.options || {}"
+					@apply="apply"
+				/>
 
-			<form-field
-				v-else-if="!fieldsMap[fieldName]?.meta?.hidden"
-				:ref="
-					(el) => {
-						formFieldEls[fieldName] = el;
-					}
-				"
-				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="fieldsMap[fieldName]!"
-				:autofocus="index === firstEditableFieldIndex && autofocus"
-				:model-value="(values || {})[fieldName]"
-				:initial-value="(initialValues || {})[fieldName]"
-				:disabled="isDisabled(fieldsMap[fieldName]!)"
-				:batch-mode="batchMode"
-				:batch-active="batchActiveFields.includes(fieldName)"
-				:primary-key="primaryKey"
-				:loading="loading"
-				:validation-error="
-					validationErrors.find(
-						(err) =>
-							err.collection === fieldsMap[fieldName]?.collection &&
-							(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
-					)
-				"
-				:badge="badge"
-				:raw-editor-enabled="rawEditorEnabled"
-				:raw-editor-active="rawActiveFields.has(fieldName)"
-				:direction="direction"
-				@update:model-value="setValue(fieldName, $event)"
-				@set-field-value="setValue($event.field, $event.value, { force: true })"
-				@unset="unsetValue(fieldsMap[fieldName]!)"
-				@toggle-batch="toggleBatchField(fieldsMap[fieldName]!)"
-				@toggle-raw="toggleRawField(fieldsMap[fieldName]!)"
-			/>
+				<form-field
+					v-else-if="!fieldsMap[fieldName]!.meta?.hidden"
+					:ref="
+						(el) => {
+							formFieldEls[fieldName] = el;
+						}
+					"
+					:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
+					:field="fieldsMap[fieldName]!"
+					:autofocus="index === firstEditableFieldIndex && autofocus"
+					:model-value="(values || {})[fieldName]"
+					:initial-value="(initialValues || {})[fieldName]"
+					:disabled="isDisabled(fieldsMap[fieldName]!)"
+					:batch-mode="batchMode"
+					:batch-active="batchActiveFields.includes(fieldName)"
+					:primary-key="primaryKey"
+					:loading="loading"
+					:validation-error="
+						validationErrors.find(
+							(err) =>
+								err.collection === fieldsMap[fieldName]!.collection &&
+								(err.field === fieldName || err.field.endsWith(`(${fieldName})`))
+						)
+					"
+					:badge="badge"
+					:raw-editor-enabled="rawEditorEnabled"
+					:raw-editor-active="rawActiveFields.has(fieldName)"
+					:direction="direction"
+					@update:model-value="setValue(fieldName, $event)"
+					@set-field-value="setValue($event.field, $event.value, { force: true })"
+					@unset="unsetValue(fieldsMap[fieldName]!)"
+					@toggle-batch="toggleBatchField(fieldsMap[fieldName]!)"
+					@toggle-raw="toggleRawField(fieldsMap[fieldName]!)"
+				/>
+			</template>
 		</template>
 		<v-divider v-if="showDivider && !noVisibleFields" />
 	</div>

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -53,11 +53,11 @@
 					}
 				"
 				:class="index === firstVisibleFieldIndex ? 'first-visible-field' : ''"
-				:field="fieldsMap[fieldName] || {}"
+				:field="fieldsMap[fieldName]!"
 				:autofocus="index === firstEditableFieldIndex && autofocus"
 				:model-value="(values || {})[fieldName]"
 				:initial-value="(initialValues || {})[fieldName]"
-				:disabled="isDisabled(fieldsMap[fieldName])"
+				:disabled="isDisabled(fieldsMap[fieldName]!)"
 				:batch-mode="batchMode"
 				:batch-active="batchActiveFields.includes(fieldName)"
 				:primary-key="primaryKey"
@@ -75,9 +75,9 @@
 				:direction="direction"
 				@update:model-value="setValue(fieldName, $event)"
 				@set-field-value="setValue($event.field, $event.value, { force: true })"
-				@unset="unsetValue(fieldsMap[fieldName])"
-				@toggle-batch="toggleBatchField(fieldsMap[fieldName])"
-				@toggle-raw="toggleRawField(fieldsMap[fieldName])"
+				@unset="unsetValue(fieldsMap[fieldName]!)"
+				@toggle-batch="toggleBatchField(fieldsMap[fieldName]!)"
+				@toggle-raw="toggleRawField(fieldsMap[fieldName]!)"
 			/>
 		</template>
 		<v-divider v-if="showDivider && !noVisibleFields" />
@@ -93,9 +93,10 @@ import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fiel
 import { useElementSize } from '@cairncms/composables';
 import { Field, ValidationError } from '@cairncms/types';
 import { assign, cloneDeep, isEqual, isNil, omit, pick } from 'lodash';
-import { computed, ComputedRef, onBeforeUpdate, provide, ref, watch } from 'vue';
+import { ComputedRef, computed, onBeforeUpdate, provide, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import FormField from './form-field.vue';
+import type { FormField as TFormField } from './types';
 import ValidationErrors from './validation-errors.vue';
 
 type FieldValues = {
@@ -236,7 +237,7 @@ function useForm() {
 
 	const { formFields } = useFormFields(fields);
 
-	const fieldsMap: ComputedRef<Record<string, Field | undefined>> = computed(() => {
+	const fieldsMap: ComputedRef<Record<string, TFormField | undefined>> = computed(() => {
 		if (props.loading) return {} as Record<string, undefined>;
 		const valuesWithDefaults = Object.assign({}, defaultValues.value, values.value);
 		return formFields.value.reduce((result: Record<string, Field>, field: Field) => {
@@ -262,7 +263,7 @@ function useForm() {
 
 	return { fieldNames, fieldsMap, isDisabled, getFieldsForGroup, fieldsForGroup };
 
-	function isDisabled(field: Field | undefined) {
+	function isDisabled(field: TFormField | undefined) {
 		if (!field) return true;
 		const meta = fieldsMap.value?.[field.field]?.meta;
 		return (
@@ -283,9 +284,9 @@ function useForm() {
 		for (const field of fieldsInGroup) {
 			const meta = fieldsMap.value?.[field.field]?.meta;
 
-			if (meta?.special?.includes('group') && !passed.includes(meta!.field)) {
-				passed.push(meta!.field);
-				fieldsInGroup.push(...getFieldsForGroup(meta!.field, passed));
+			if (meta?.special?.includes('group') && !passed.includes(meta!.field!)) {
+				passed.push(meta!.field!);
+				fieldsInGroup.push(...getFieldsForGroup(meta!.field!, passed));
 			}
 		}
 
@@ -350,7 +351,7 @@ function apply(updates: { [field: string]: any }) {
 	}
 }
 
-function unsetValue(field: Field | undefined) {
+function unsetValue(field: TFormField | undefined) {
 	if (!field) return;
 	if (!props.batchMode && isDisabled(field)) return;
 
@@ -366,7 +367,7 @@ function useBatch() {
 
 	return { batchActiveFields, toggleBatchField };
 
-	function toggleBatchField(field: Field | undefined) {
+	function toggleBatchField(field: TFormField | undefined) {
 		if (!field) return;
 
 		if (batchActiveFields.value.includes(field.field)) {
@@ -391,7 +392,7 @@ function useRawEditor() {
 
 	return { rawActiveFields, toggleRawField };
 
-	function toggleRawField(field: Field | undefined) {
+	function toggleRawField(field: TFormField | undefined) {
 		if (!field) return;
 
 		if (rawActiveFields.value.has(field.field)) {

--- a/app/src/components/v-table/v-table.vue
+++ b/app/src/components/v-table/v-table.vue
@@ -91,15 +91,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, useSlots } from 'vue';
+import { i18n } from '@/lang/';
+import { hideDragImage } from '@/utils/hide-drag-image';
 import { ShowSelect } from '@cairncms/types';
-import { Header, HeaderRaw, Item, ItemSelectEvent, Sort } from './types';
+import { clone, forEach, pick } from 'lodash';
+import { computed, ref, useSlots } from 'vue';
+import Draggable from 'vuedraggable';
 import TableHeader from './table-header.vue';
 import TableRow from './table-row.vue';
-import { clone, forEach, pick } from 'lodash';
-import { i18n } from '@/lang/';
-import Draggable from 'vuedraggable';
-import { hideDragImage } from '@/utils/hide-drag-image';
+import { Header, HeaderRaw, Item, ItemSelectEvent, Sort } from './types';
 
 const HeaderDefaults: Header = {
 	text: '',
@@ -107,6 +107,7 @@ const HeaderDefaults: Header = {
 	align: 'left',
 	sortable: true,
 	width: null,
+	description: null,
 };
 
 interface Props {
@@ -203,7 +204,7 @@ const internalHeaders = computed({
 });
 
 // In case the sort prop isn't used, we'll use this local sort state as a fallback.
-// This allows the table to allow inline sorting on column ootb without the need for
+// This allows the table to allow inline sorting on column out of the box without the need for
 const internalSort = computed<Sort>(
 	() =>
 		props.sort ?? {
@@ -244,7 +245,7 @@ const someItemsSelected = computed<boolean>(() => {
 	return props.modelValue.length > 0 && allItemsSelected.value === false;
 });
 
-const columnStyle = computed<string>(() => {
+const columnStyle = computed<{ header: string; rows: string }>(() => {
 	return {
 		header: generate('auto'),
 		rows: generate(),

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -92,15 +92,15 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { ref, computed } from 'vue';
-import { uploadFiles } from '@/utils/upload-files';
-import { uploadFile } from '@/utils/upload-file';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import api from '@/api';
 import emitter, { Events } from '@/events';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { uploadFile } from '@/utils/upload-file';
+import { uploadFiles } from '@/utils/upload-files';
+import DrawerCollection from '@/views/private/components/drawer-collection.vue';
 import { Filter } from '@cairncms/types';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 interface Props {
 	multiple?: boolean;
@@ -258,7 +258,9 @@ function useDragging() {
 function useSelection() {
 	return { setSelection };
 
-	async function setSelection(selection: string[]) {
+	async function setSelection(selection: (string | number)[] | null) {
+		if (!selection) return;
+
 		if (props.multiple) {
 			const filesResponse = await api.get(`/files`, {
 				params: {

--- a/app/src/composables/use-alias-fields.test.ts
+++ b/app/src/composables/use-alias-fields.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { useAliasFields } from './use-alias-fields';
+
+vi.mock('@/utils/adjust-fields-for-displays', () => {
+	return {
+		adjustFieldsForDisplays: (fields: string[], _collection: string) => {
+			if (fields.includes('image')) {
+				return ['image.url.file', 'image.alt'];
+			}
+
+			return fields;
+		},
+	};
+});
+
+const TestComponent = defineComponent({
+	props: ['fields', 'collection'], // eslint-disable-line  vue/require-prop-types
+	setup(props) {
+		return useAliasFields(props.fields, props.collection);
+	},
+	render: () => '',
+});
+
+describe('useAliasFields', () => {
+	test('aliasing no collisions', () => {
+		const fields = ['id', 'image.url'];
+
+		const wrapper = mount(TestComponent, {
+			props: {
+				fields,
+				collection: 'articles',
+			},
+		});
+
+		expect(wrapper.vm.aliasedFields).toEqual({
+			id: {
+				aliased: false,
+				fieldName: 'id',
+				fields: ['id'],
+				key: 'id',
+			},
+			'image.url': {
+				aliased: false,
+				fieldName: 'image',
+				fields: ['image.url'],
+				key: 'image.url',
+			},
+		});
+
+		expect(wrapper.vm.aliasQuery).toEqual({});
+
+		expect(wrapper.vm.aliasedKeys).toEqual([]);
+
+		expect(
+			wrapper.vm.getFromAliasedItem(
+				{
+					id: 1,
+					image: {
+						url: 'https://example.com',
+					},
+				},
+				'image.url'
+			)
+		).toEqual('https://example.com');
+	});
+
+	test('aliasing with collisions', () => {
+		const fields = ['id', 'image', 'image.url'];
+
+		const wrapper = mount(TestComponent, {
+			props: {
+				fields,
+				collection: 'articles',
+			},
+		});
+
+		expect(wrapper.vm.aliasedFields).toEqual({
+			id: {
+				key: 'id',
+				fieldName: 'id',
+				fields: ['id'],
+				aliased: false,
+			},
+			'5faa95b': {
+				key: 'image',
+				fieldName: 'image',
+				fieldAlias: '5faa95b',
+				fields: ['5faa95b.url.file', '5faa95b.alt'],
+				aliased: true,
+			},
+			'3468cda4': {
+				key: 'image.url',
+				fieldName: 'image',
+				fieldAlias: '3468cda4',
+				fields: ['3468cda4.url'],
+				aliased: true,
+			},
+		});
+
+		expect(wrapper.vm.aliasQuery).toEqual({
+			'5faa95b': 'image',
+			'3468cda4': 'image',
+		});
+
+		expect(wrapper.vm.aliasedKeys).toEqual(['5faa95b', '3468cda4']);
+
+		const item = {
+			id: 1,
+			'5faa95b': {
+				url: {
+					file: 'https://example.com',
+				},
+				alt: 'Example',
+			},
+			'3468cda4': {
+				url: 'https://example.com',
+			},
+		};
+
+		expect(wrapper.vm.getFromAliasedItem(item, 'image.url')).toEqual('https://example.com');
+
+		expect(wrapper.vm.getFromAliasedItem(item, 'image')).toEqual({
+			url: {
+				file: 'https://example.com',
+			},
+			alt: 'Example',
+		});
+	});
+});

--- a/app/src/composables/use-alias-fields.ts
+++ b/app/src/composables/use-alias-fields.ts
@@ -1,63 +1,122 @@
-import { getSimpleHash } from '@cairncms/utils';
-import { Query } from '@cairncms/types';
-import { computed, ComputedRef, Ref } from 'vue';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { Query } from '@cairncms/types';
+import { get, getSimpleHash } from '@cairncms/utils';
+import { ComputedRef, Ref, computed, unref } from 'vue';
 
-export type AliasFields = {
-	fieldName: string;
-	fieldAlias: string;
-	fields: string[];
-	key: string;
-};
+export type AliasFields =
+	| {
+			fieldName: string;
+			fieldAlias: string;
+			fields: string[];
+			key: string;
+			aliased: true;
+	  }
+	| {
+			fieldName: string;
+			fields: string[];
+			key: string;
+			aliased: false;
+	  };
 
 type UsableAliasFields = {
 	aliasedFields: ComputedRef<Record<string, AliasFields>>;
 	aliasQuery: ComputedRef<Query['alias']>;
 	aliasedKeys: ComputedRef<string[]>;
+	getFromAliasedItem: <K, T extends Record<string, K>>(item: T, key: string) => K | undefined;
 };
 
-export function useAliasFields(fields: Ref<string[]>, collection: Ref<string | null>): UsableAliasFields {
+/**
+ * Generates aliases for field collisions when fetching the data for each display.
+ * @param fields This list of fields to be aliased
+ * @param collection The collection the fields belong to
+ * @returns Info about the display fields and if the original fields were aliased
+ */
+export function useAliasFields(
+	fields: Ref<string[]> | string[],
+	collection: Ref<string | null> | string | null
+): UsableAliasFields {
 	const aliasedFields = computed(() => {
 		const aliasedFields: Record<string, AliasFields> = {};
 
-		if (!fields.value || fields.value.length === 0 || !collection.value) return aliasedFields;
+		const _fields = unref(fields);
+		const _collection = unref(collection);
 
-		for (const field of fields.value) {
-			const alias = getSimpleHash(field);
+		if (!_fields || _fields.length === 0 || !_collection) return aliasedFields;
 
-			const fullFields = adjustFieldsForDisplays([field], collection.value).map((field) => {
-				if (field.includes('.')) {
-					return `${alias}.${field.split('.').slice(1).join('.')}`;
-				} else {
-					return field;
-				}
-			});
+		const fieldNameCount = _fields.reduce<Record<string, number>>((acc, field) => {
+			const fieldName = field.split('.')[0];
+			acc[fieldName] = (acc[fieldName] || 0) + 1;
+			return acc;
+		}, {});
 
-			aliasedFields[alias] = {
-				key: field,
-				fieldName: field.split('.')[0],
-				fieldAlias: alias,
-				fields: fullFields,
-			};
+		for (const field of _fields) {
+			const fieldName = field.split('.')[0];
+
+			if (fieldNameCount[fieldName] > 1 === false) {
+				aliasedFields[field] = {
+					key: field,
+					fieldName,
+					fields: adjustFieldsForDisplays([field], _collection),
+					aliased: false,
+				};
+			} else {
+				const alias = getSimpleHash(field);
+
+				aliasedFields[alias] = {
+					key: field,
+					fieldName,
+					fieldAlias: alias,
+					fields: adjustFieldsForDisplays([field], _collection).map((displayField) => {
+						if (displayField.includes('.')) {
+							return `${alias}.${displayField.split('.').slice(1).join('.')}`;
+						} else {
+							return alias;
+						}
+					}),
+					aliased: true,
+				};
+			}
 		}
 
 		return aliasedFields;
 	});
 
 	const aliasedKeys = computed(() => {
-		return Object.values(aliasedFields.value).map((field) => field.fieldAlias);
+		return Object.values(aliasedFields.value).reduce<string[]>((acc, field) => {
+			if (field.aliased) {
+				acc.push(field.fieldAlias);
+			}
+
+			return acc;
+		}, []);
 	});
 
 	const aliasQuery = computed(() => {
 		if (!aliasedFields.value) return null;
-		return Object.values(aliasedFields.value).reduce(
-			(acc, value) => ({
-				...acc,
-				[value.fieldAlias]: value.fieldName,
-			}),
-			{} as Query['alias']
-		);
+		return Object.values(aliasedFields.value).reduce<Record<string, string>>((acc, value) => {
+			if (value.aliased) {
+				acc[value.fieldAlias] = value.fieldName;
+			}
+
+			return acc;
+		}, {});
 	});
 
-	return { aliasedFields, aliasQuery, aliasedKeys };
+	/**
+	 * Returns the value of the given key from the given item, taking into account aliased fields
+	 * @param item The item to get the value from
+	 * @param key The key to get the value for without any alias
+	 * @returns The value of the given key from the given item
+	 */
+	function getFromAliasedItem<K, T extends Record<string, K>>(item: T, key: string): K | undefined {
+		const aliasInfo = Object.values(aliasedFields.value).find((field) => field.key === key);
+
+		if (!aliasInfo || !aliasInfo.aliased) return get(item, key);
+
+		if (key.includes('.') === false) return get(item, aliasInfo.fieldAlias);
+
+		return get(item, `${aliasInfo.fieldAlias}.${key.split('.').slice(1).join('.')}`);
+	}
+
+	return { aliasedFields, aliasQuery, aliasedKeys, getFromAliasedItem };
 }

--- a/app/src/displays/boolean/boolean.test.ts
+++ b/app/src/displays/boolean/boolean.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { GlobalMountOptions } from '@vue/test-utils/dist/types';
+import { expect, test } from 'vitest';
+
+import BooleanDisplay from './boolean.vue';
+
+const global: GlobalMountOptions = {
+	stubs: ['v-icon', 'value-null'],
+};
+
+test('renders the default on icon when no icon is configured', () => {
+	const wrapper = mount(BooleanDisplay, {
+		props: { value: true, colorOn: 'var(--primary)', colorOff: 'var(--foreground-subdued)' },
+		global,
+	});
+
+	expect(wrapper.find('v-icon-stub').attributes('name')).toBe('check');
+});
+
+test('renders the default off icon when no icon is configured', () => {
+	const wrapper = mount(BooleanDisplay, {
+		props: { value: false, colorOn: 'var(--primary)', colorOff: 'var(--foreground-subdued)' },
+		global,
+	});
+
+	expect(wrapper.find('v-icon-stub').attributes('name')).toBe('close');
+});

--- a/app/src/displays/boolean/boolean.vue
+++ b/app/src/displays/boolean/boolean.vue
@@ -25,8 +25,8 @@ const props = withDefaults(
 		value: false,
 		labelOn: null,
 		labelOff: null,
-		iconOn: null,
-		iconOff: null,
+		iconOn: 'check',
+		iconOff: 'close',
 		colorOn: 'var(--primary)',
 		colorOff: 'var(--foreground-subdued)',
 	}

--- a/app/src/displays/formatted-value/formatted-value.vue
+++ b/app/src/displays/formatted-value/formatted-value.vue
@@ -19,196 +19,155 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, PropType } from 'vue';
+<script setup lang="ts">
 import formatTitle from '@cairncms/format-title';
-import { decode } from 'html-entities';
-import { useI18n } from 'vue-i18n';
-import { isNil } from 'lodash';
 import dompurify from 'dompurify';
+import { decode } from 'html-entities';
+import { isNil } from 'lodash';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		type: {
-			type: String,
-			required: true,
-		},
-		value: {
-			type: [String, Number, Array],
-			default: null,
-		},
-		format: {
-			type: Boolean,
-			default: false,
-		},
-		font: {
-			type: String,
-			default: 'sans-serif',
-			validator: (value: string) => ['sans-serif', 'serif', 'monospace'].includes(value),
-		},
-		bold: {
-			type: Boolean,
-			default: false,
-		},
-		italic: {
-			type: Boolean,
-			default: false,
-		},
-		prefix: {
-			type: String,
-			default: null,
-		},
-		suffix: {
-			type: String,
-			default: null,
-		},
-		color: {
-			type: String,
-			default: null,
-		},
-		background: {
-			type: String,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: null,
-		},
-		border: {
-			type: Boolean,
-			default: false,
-		},
-		conditionalFormatting: {
-			type: Array as PropType<
-				{
-					operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains' | 'starts_with' | 'ends_with';
-					value: string;
-					color: string;
-					background: string;
-					text: string;
-					icon: string;
-				}[]
-			>,
-			default: () => [],
-		},
-	},
-	setup(props) {
-		const { t, n } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		type: string;
+		value?: string | number | (string | number)[];
+		format?: boolean;
+		font?: 'sans-serif' | 'serif' | 'monospace';
+		bold?: boolean;
+		italic?: boolean;
+		prefix?: string;
+		suffix?: string;
+		color?: string;
+		background?: string;
+		icon?: string;
+		border?: boolean;
+		conditionalFormatting?: {
+			operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains' | 'starts_with' | 'ends_with';
+			value: string;
+			color: string;
+			background: string;
+			text: string;
+			icon: string;
+		}[];
+	}>(),
+	{
+		font: 'sans-serif',
+		conditionalFormatting: () => [],
+	}
+);
 
-		const matchedConditions = computed(() => {
-			return (props.conditionalFormatting || []).filter(({ operator, value }) => {
-				if (['string', 'text'].includes(props.type)) {
-					const left = String(props.value);
-					const right = String(value);
-					return matchString(left, right, operator);
-				} else if (['float', 'decimal'].includes(props.type)) {
-					const left = parseFloat(String(props.value));
-					const right = parseFloat(String(value));
-					return matchNumber(left, right, operator);
-				} else {
-					const left = parseInt(String(props.value));
-					const right = parseInt(String(value));
-					return matchNumber(left, right, operator);
-				}
-			});
-		});
+const { t, n } = useI18n();
 
-		const computedFormat = computed(() => {
-			const { color, background, icon } = props;
-
-			return matchedConditions.value.reduce(
-				({ color, background, icon, text }, format) => ({
-					color: format.color || color,
-					background: format.background || background,
-					icon: format.icon || icon,
-					text: format.text || text,
-				}),
-				{
-					color,
-					background,
-					icon,
-					text: '',
-				}
-			);
-		});
-
-		const computedStyle = computed(() => {
-			return {
-				color: computedFormat.value.color,
-				borderStyle: 'solid',
-				borderWidth: props.border ? '2px' : 0,
-				borderColor: computedFormat.value.color,
-				backgroundColor: computedFormat.value.background ?? 'transparent',
-			};
-		});
-
-		const displayValue = computed(() => {
-			if (computedFormat.value.text) {
-				const { text } = computedFormat.value;
-				return text.startsWith('$t:') ? t(text.slice(3)) : text;
-			}
-
-			if (isNil(props.value) || props.value === '') return null;
-
-			let value = String(props.value);
-
-			// Strip out all HTML tags
-			value = dompurify.sanitize(value, { ALLOWED_TAGS: [] });
-
-			// Decode any HTML encoded characters (like &copy;)
-			value = decode(value);
-
-			if (props.format) {
-				if (['string', 'text'].includes(props.type)) {
-					value = formatTitle(value);
-				} else if (['float', 'decimal'].includes(props.type)) {
-					value = n(parseFloat(value));
-				} else {
-					value = n(parseInt(value));
-				}
-			}
-
-			const prefix = props.prefix ?? '';
-			const suffix = props.suffix ?? '';
-
-			return `${prefix}${value}${suffix}`;
-		});
-
-		return { t, computedFormat, displayValue, computedStyle };
-
-		function matchString(left: string, right: string, operator: string) {
-			switch (operator) {
-				case 'eq':
-					return left === right;
-				case 'neq':
-					return left !== right;
-				case 'contains':
-					return left.includes(right);
-				case 'starts_with':
-					return left.startsWith(right);
-				case 'ends_with':
-					return left.endsWith(right);
-			}
+const matchedConditions = computed(() => {
+	return (props.conditionalFormatting || []).filter(({ operator, value }) => {
+		if (['string', 'text'].includes(props.type)) {
+			const left = String(props.value);
+			const right = String(value);
+			return matchString(left, right, operator);
+		} else if (['float', 'decimal'].includes(props.type)) {
+			const left = parseFloat(String(props.value));
+			const right = parseFloat(String(value));
+			return matchNumber(left, right, operator);
+		} else {
+			const left = parseInt(String(props.value));
+			const right = parseInt(String(value));
+			return matchNumber(left, right, operator);
 		}
-
-		function matchNumber(left: number, right: number, operator: string) {
-			switch (operator) {
-				case 'eq':
-					return left === right;
-				case 'neq':
-					return left !== right;
-				case 'gt':
-					return left > right;
-				case 'gte':
-					return left >= right;
-				case 'lt':
-					return left < right;
-				case 'lte':
-					return left <= right;
-			}
-		}
-	},
+	});
 });
+
+const computedFormat = computed(() => {
+	const { color, background, icon } = props;
+
+	return matchedConditions.value.reduce(
+		({ color, background, icon, text }, format) => ({
+			color: format.color || color,
+			background: format.background || background,
+			icon: format.icon || icon,
+			text: format.text || text,
+		}),
+		{
+			color,
+			background,
+			icon,
+			text: '',
+		}
+	);
+});
+
+const computedStyle = computed(() => {
+	return {
+		color: computedFormat.value.color,
+		borderStyle: 'solid',
+		borderWidth: props.border ? '2px' : 0,
+		borderColor: computedFormat.value.color,
+		backgroundColor: computedFormat.value.background ?? 'transparent',
+	};
+});
+
+const displayValue = computed(() => {
+	if (computedFormat.value.text) {
+		const { text } = computedFormat.value;
+		return text.startsWith('$t:') ? t(text.slice(3)) : text;
+	}
+
+	if (isNil(props.value) || props.value === '') return null;
+
+	let value = String(props.value);
+
+	// Strip out all HTML tags
+	value = dompurify.sanitize(value, { ALLOWED_TAGS: [] });
+
+	// Decode any HTML encoded characters (like &copy;)
+	value = decode(value);
+
+	if (props.format) {
+		if (['string', 'text'].includes(props.type)) {
+			value = formatTitle(value);
+		} else if (['float', 'decimal'].includes(props.type)) {
+			value = n(parseFloat(value));
+		} else {
+			value = n(parseInt(value));
+		}
+	}
+
+	const prefix = props.prefix ?? '';
+	const suffix = props.suffix ?? '';
+
+	return `${prefix}${value}${suffix}`;
+});
+
+function matchString(left: string, right: string, operator: string) {
+	switch (operator) {
+		case 'eq':
+			return left === right;
+		case 'neq':
+			return left !== right;
+		case 'contains':
+			return left.includes(right);
+		case 'starts_with':
+			return left.startsWith(right);
+		case 'ends_with':
+			return left.endsWith(right);
+	}
+}
+
+function matchNumber(left: number, right: number, operator: string) {
+	switch (operator) {
+		case 'eq':
+			return left === right;
+		case 'neq':
+			return left !== right;
+		case 'gt':
+			return left > right;
+		case 'gte':
+			return left >= right;
+		case 'lt':
+			return left < right;
+		case 'lte':
+			return left <= right;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/displays/icon/icon.vue
+++ b/app/src/displays/icon/icon.vue
@@ -2,33 +2,18 @@
 	<v-icon small :name="value" :style="style" :filled="filled" />
 </template>
 
-<script lang="ts">
-import { computed, defineComponent } from 'vue';
+<script setup lang="ts">
 import { isHex } from '@/utils/is-hex';
+import { computed } from 'vue';
 
-export default defineComponent({
-	name: 'DisplayIcon',
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		color: {
-			type: String,
-			default: null,
-		},
-		filled: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const style = computed(() => {
-			if (isHex(props.color)) return { '--v-icon-color': props.color };
-			else return {};
-		});
+const props = defineProps<{
+	value: string | null;
+	color?: string;
+	filled?: boolean;
+}>();
 
-		return { style };
-	},
+const style = computed(() => {
+	if (props.color && isHex(props.color)) return { '--v-icon-color': props.color };
+	else return {};
 });
 </script>

--- a/app/src/displays/image/image.vue
+++ b/app/src/displays/image/image.vue
@@ -11,8 +11,8 @@
 	<value-null v-else />
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType, ref } from 'vue';
+<script setup lang="ts">
+import { computed, ref } from 'vue';
 
 type Image = {
 	id: string;
@@ -20,27 +20,16 @@ type Image = {
 	title: string;
 };
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Object as PropType<Image>,
-			default: null,
-		},
-		circle: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const imageError = ref(false);
+const props = defineProps<{
+	value: Image | null;
+	circle?: boolean;
+}>();
 
-		const src = computed(() => {
-			if (props.value?.id === null || props.value?.id === undefined) return null;
-			return `/assets/${props.value.id}?key=system-small-cover`;
-		});
+const imageError = ref(false);
 
-		return { src, imageError };
-	},
+const src = computed(() => {
+	if (props.value?.id === null || props.value?.id === undefined) return null;
+	return `/assets/${props.value.id}?key=system-small-cover`;
 });
 </script>
 

--- a/app/src/displays/labels/labels.vue
+++ b/app/src/displays/labels/labels.vue
@@ -21,10 +21,10 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, PropType } from 'vue';
+<script setup lang="ts">
 import formatTitle from '@cairncms/format-title';
 import { isEmpty } from 'lodash';
+import { computed } from 'vue';
 
 type Choice = {
 	value: string;
@@ -33,73 +33,58 @@ type Choice = {
 	background: string | null;
 };
 
-export default defineComponent({
-	props: {
-		value: {
-			type: [String, Array] as PropType<string | string[]>,
-			required: true,
-		},
-		format: {
-			type: Boolean,
-			default: true,
-		},
-		showAsDot: {
-			type: Boolean,
-			default: false,
-		},
-		choices: {
-			type: Array as PropType<Choice[]>,
-			default: () => [],
-		},
-		type: {
-			type: String,
-			required: true,
-			validator: (val: string) => ['text', 'string', 'json', 'csv'].includes(val),
-		},
-	},
-	setup(props) {
-		const items = computed(() => {
-			let items: string[];
+const props = withDefaults(
+	defineProps<{
+		value: string | string[];
+		type: 'text' | 'string' | 'json' | 'csv';
+		format?: boolean;
+		showAsDot?: boolean;
+		choices?: Choice[];
+	}>(),
+	{
+		format: true,
+		choices: () => [],
+	}
+);
 
-			if (isEmpty(props.value)) items = [];
-			else if (props.type === 'string') items = [props.value as string];
-			else items = props.value as string[];
+const items = computed(() => {
+	let items: string[];
 
-			return items.map((item) => {
-				const choice = (props.choices || []).find((choice) => choice.value === item);
+	if (isEmpty(props.value)) items = [];
+	else if (props.type === 'string') items = [props.value as string];
+	else items = props.value as string[];
 
-				let itemStringValue: string;
+	return items.map((item) => {
+		const choice = (props.choices || []).find((choice) => choice.value === item);
 
-				if (typeof item === 'object') {
-					itemStringValue = JSON.stringify(item);
-				} else {
-					if (props.format) {
-						itemStringValue = formatTitle(item);
-					} else {
-						itemStringValue = item;
-					}
-				}
+		let itemStringValue: string;
 
-				if (choice === undefined) {
-					return {
-						value: item,
-						text: itemStringValue,
-						foreground: 'var(--foreground-normal)',
-						background: 'var(--background-normal)',
-					};
-				} else {
-					return {
-						value: item,
-						text: choice.text || itemStringValue,
-						foreground: choice.foreground || 'var(--foreground-normal)',
-						background: choice.background || 'var(--background-normal)',
-					};
-				}
-			});
-		});
+		if (typeof item === 'object') {
+			itemStringValue = JSON.stringify(item);
+		} else {
+			if (props.format) {
+				itemStringValue = formatTitle(item);
+			} else {
+				itemStringValue = item;
+			}
+		}
 
-		return { items };
-	},
+		if (choice === undefined) {
+			return {
+				value: item,
+				text: itemStringValue,
+				foreground: 'var(--foreground-normal)',
+				background: 'var(--background-normal)',
+			};
+		} else {
+			return {
+				value: item,
+				text: choice.text || itemStringValue,
+				foreground: choice.foreground || 'var(--foreground-normal)',
+				background: choice.background || 'var(--background-normal)',
+			};
+		}
+	});
 });
 </script>
 

--- a/app/src/displays/rating/rating.vue
+++ b/app/src/displays/rating/rating.vue
@@ -37,7 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
 const starCount = computed(() => {
 	if (props.interfaceOptions === null) return 5;
 
-	return Math.ceil(props.interfaceOptions.maxValue ?? 5);
+	return Math.ceil(props.interfaceOptions?.maxValue ?? 5);
 });
 
 const ratingPercentage = computed(() => ({

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -1,22 +1,22 @@
 <template>
 	<value-null v-if="!relatedCollection" />
 	<v-menu
-		v-else-if="['o2m', 'm2m', 'm2a', 'translations', 'files'].includes(localType.toLowerCase())"
+		v-else-if="['o2m', 'm2m', 'm2a', 'translations', 'files'].includes(localType!.toLowerCase())"
 		show-arrow
-		:disabled="value.length === 0"
+		:disabled="value?.length === 0"
 	>
 		<template #activator="{ toggle }">
-			<span class="toggle" :class="{ subdued: value.length === 0 }" @click.stop="toggle">
+			<span class="toggle" :class="{ subdued: value?.length === 0 }" @click.stop="toggle">
 				<span class="label">
-					{{ value.length }}
-					<template v-if="value.length >= 100">+</template>
+					{{ value?.length }}
+					<template v-if="value?.length >= 100">+</template>
 					{{ unit }}
 				</span>
 			</span>
 		</template>
 
 		<v-list class="links">
-			<v-list-item v-for="item in value" :key="item[primaryKeyFieldPath]">
+			<v-list-item v-for="item in value" :key="item[primaryKeyFieldPath!]">
 				<v-list-item-content>
 					<render-template
 						:template="internalTemplate"
@@ -25,7 +25,7 @@
 					/>
 				</v-list-item-content>
 				<v-list-item-icon>
-					<router-link :to="getLinkForItem(item)"><v-icon name="launch" small /></router-link>
+					<router-link :to="getLinkForItem(item)!"><v-icon name="launch" small /></router-link>
 				</v-list-item-icon>
 			</v-list-item>
 		</v-list>
@@ -33,102 +33,77 @@
 	<render-template v-else :template="internalTemplate" :item="value" :collection="relatedCollection" />
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, PropType } from 'vue';
+<script setup lang="ts">
+import { getLocalTypeForField } from '@/utils/get-local-type';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { useCollection } from '@cairncms/composables';
-import { getLocalTypeForField } from '@/utils/get-local-type';
 import { get } from 'lodash';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		field: {
-			type: String,
-			required: true,
-		},
-		value: {
-			type: [Array, Object] as PropType<Record<string, any> | Record<string, any>[]>,
-			default: null,
-		},
-		template: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t, te } = useI18n();
+const props = defineProps<{
+	collection: string;
+	field: string;
+	value: Record<string, any> | Record<string, any>[] | null;
+	template?: string;
+}>();
 
-		const relatedCollectionData = computed(() => {
-			return getRelatedCollection(props.collection, props.field);
-		});
+const { t, te } = useI18n();
 
-		const relatedCollection = computed(() => {
-			return relatedCollectionData.value.relatedCollection;
-		});
-
-		const junctionCollection = computed(() => {
-			return relatedCollectionData.value.junctionCollection;
-		});
-
-		const localType = computed(() => {
-			return getLocalTypeForField(props.collection, props.field);
-		});
-
-		const { primaryKeyField } = useCollection(relatedCollection);
-
-		const primaryKeyFieldPath = computed(() => {
-			return relatedCollectionData.value.path
-				? [...relatedCollectionData.value.path, primaryKeyField.value?.field].join('.')
-				: primaryKeyField.value?.field;
-		});
-
-		const internalTemplate = computed(() => {
-			return props.template || `{{ ${primaryKeyFieldPath.value!} }}`;
-		});
-
-		const unit = computed(() => {
-			if (Array.isArray(props.value)) {
-				if (props.value.length === 1) {
-					if (te(`collection_names_singular.${relatedCollection.value}`)) {
-						return t(`collection_names_singular.${relatedCollection.value}`);
-					} else {
-						return t('item');
-					}
-				} else {
-					if (te(`collection_names_plural.${relatedCollection.value}`)) {
-						return t(`collection_names_plural.${relatedCollection.value}`);
-					} else {
-						return t('items');
-					}
-				}
-			}
-
-			return null;
-		});
-
-		return {
-			relatedCollection,
-			junctionCollection,
-			primaryKeyFieldPath,
-			getLinkForItem,
-			internalTemplate,
-			unit,
-			localType,
-		};
-
-		function getLinkForItem(item: any) {
-			if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;
-			const primaryKey = get(item, primaryKeyFieldPath.value);
-
-			return `/content/${relatedCollection.value}/${encodeURIComponent(primaryKey)}`;
-		}
-	},
+const relatedCollectionData = computed(() => {
+	return getRelatedCollection(props.collection, props.field);
 });
+
+const relatedCollection = computed(() => {
+	return relatedCollectionData.value!.relatedCollection;
+});
+
+const junctionCollection = computed(() => {
+	return relatedCollectionData.value!.junctionCollection;
+});
+
+const localType = computed(() => {
+	return getLocalTypeForField(props.collection, props.field);
+});
+
+const { primaryKeyField } = useCollection(relatedCollection);
+
+const primaryKeyFieldPath = computed(() => {
+	return relatedCollectionData.value!.path
+		? [...relatedCollectionData.value!.path, primaryKeyField.value?.field].join('.')
+		: primaryKeyField.value?.field;
+});
+
+const internalTemplate = computed(() => {
+	return props.template || `{{ ${primaryKeyFieldPath.value!} }}`;
+});
+
+const unit = computed(() => {
+	if (Array.isArray(props.value)) {
+		if (props.value.length === 1) {
+			if (te(`collection_names_singular.${relatedCollection.value}`)) {
+				return t(`collection_names_singular.${relatedCollection.value}`);
+			} else {
+				return t('item');
+			}
+		} else {
+			if (te(`collection_names_plural.${relatedCollection.value}`)) {
+				return t(`collection_names_plural.${relatedCollection.value}`);
+			} else {
+				return t('items');
+			}
+		}
+	}
+
+	return null;
+});
+
+function getLinkForItem(item: any) {
+	if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;
+	const primaryKey = get(item, primaryKeyFieldPath.value);
+
+	return `/content/${relatedCollection.value}/${encodeURIComponent(primaryKey)}`;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/displays/translations/translations.vue
+++ b/app/src/displays/translations/translations.vue
@@ -34,11 +34,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRefs } from 'vue';
-import { useUserStore } from '@/stores/user';
-import { isNil } from 'lodash';
 import { useRelationM2M } from '@/composables/use-relation-m2m';
 import { useFieldsStore } from '@/stores/fields';
+import { useUserStore } from '@/stores/user';
+import type { User } from '@cairncms/types';
+import { isNil } from 'lodash';
+import { computed, toRefs } from 'vue';
 
 interface Props {
 	collection: string;
@@ -83,7 +84,7 @@ const displayItem = computed(() => {
 
 	if (props.userLanguage) {
 		const user = useUserStore();
-		item = props.value.find((val) => val?.[langField]?.[langPkField] === user.currentUser?.language) ?? item;
+		item = props.value.find((val) => val?.[langField]?.[langPkField] === (user.currentUser as User)?.language) ?? item;
 	}
 
 	return item ?? {};

--- a/app/src/displays/user/user.vue
+++ b/app/src/displays/user/user.vue
@@ -20,48 +20,30 @@
 	</user-popover>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { userName } from '@/utils/user-name';
-import { computed, defineComponent, PropType } from 'vue';
+import { User } from '@cairncms/types';
+import { computed } from 'vue';
 
-type User = {
-	id: number;
-	avatar: {
-		id: string;
-	};
-	email: string;
-	first_name: string;
-	last_name: string;
-};
+const props = withDefaults(
+	defineProps<{
+		value: Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'> | null;
+		display?: 'avatar' | 'name' | 'both';
+		circle?: boolean;
+	}>(),
+	{
+		display: 'both',
+	}
+);
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Object as PropType<User>,
-			default: null,
-		},
-		display: {
-			type: String as PropType<'avatar' | 'name' | 'both'>,
-			default: 'both',
-		},
-		circle: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const src = computed(() => {
-			if (props.value === null) return null;
+const src = computed(() => {
+	if (props.value === null) return null;
 
-			if (props.value.avatar?.id) {
-				return `/assets/${props.value.avatar.id}?key=system-small-cover`;
-			}
+	if (props.value.avatar?.id) {
+		return `/assets/${props.value.avatar.id}?key=system-small-cover`;
+	}
 
-			return null;
-		});
-
-		return { src, userName };
-	},
+	return null;
 });
 </script>
 

--- a/app/src/interfaces/_system/system-collection/system-collection.vue
+++ b/app/src/interfaces/_system/system-collection/system-collection.vue
@@ -8,63 +8,52 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from 'vue';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		includeSystem: {
-			type: Boolean,
-			default: false,
-		},
-		includeSingleton: {
-			type: Boolean,
-			default: true,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		disabled?: boolean;
+		includeSystem?: boolean;
+		includeSingleton?: boolean;
+	}>(),
+	{ includeSingleton: true }
+);
 
-		const collectionsStore = useCollectionsStore();
+defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		const collections = computed(() => {
-			let collections = collectionsStore.collections;
+const { t } = useI18n();
 
-			if (!props.includeSingleton) {
-				collections = collections.filter((collection) => collection?.meta?.singleton === false);
-			}
+const collectionsStore = useCollectionsStore();
 
-			return [
-				...collections.filter((collection) => collection.collection.startsWith('directus_') === false),
-				...(props.includeSystem ? collectionsStore.crudSafeSystemCollections : []),
-			];
-		});
+const collections = computed(() => {
+	let collections = collectionsStore.collections;
 
-		const items = computed(() => {
-			return collections.value.reduce<{ text: string; value: string }[]>((acc, collection) => {
-				if (collection.type !== 'alias') {
-					acc.push({
-						text: collection.name,
-						value: collection.collection,
-					});
-				}
+	if (!props.includeSingleton) {
+		collections = collections.filter((collection) => collection?.meta?.singleton === false);
+	}
 
-				return acc;
-			}, []);
-		});
+	return [
+		...collections.filter((collection) => collection.collection.startsWith('directus_') === false),
+		...(props.includeSystem ? collectionsStore.crudSafeSystemCollections : []),
+	];
+});
 
-		return { items, t };
-	},
+const items = computed(() => {
+	return collections.value.reduce<{ text: string; value: string }[]>((acc, collection) => {
+		if (collection.type !== 'alias') {
+			acc.push({
+				text: collection.name,
+				value: collection.collection,
+			});
+		}
+
+		return acc;
+	}, []);
 });
 </script>

--- a/app/src/interfaces/_system/system-collection/system-collection.vue
+++ b/app/src/interfaces/_system/system-collection/system-collection.vue
@@ -52,10 +52,16 @@ export default defineComponent({
 		});
 
 		const items = computed(() => {
-			return collections.value.map((collection) => ({
-				text: collection.name,
-				value: collection.collection,
-			}));
+			return collections.value.reduce<{ text: string; value: string }[]>((acc, collection) => {
+				if (collection.type !== 'alias') {
+					acc.push({
+						text: collection.name,
+						value: collection.collection,
+					});
+				}
+
+				return acc;
+			}, []);
 		});
 
 		return { items, t };

--- a/app/src/interfaces/_system/system-collections/system-collections.vue
+++ b/app/src/interfaces/_system/system-collections/system-collections.vue
@@ -11,56 +11,45 @@
 	/>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Array,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		includeSystem: {
-			type: Boolean,
-			default: false,
-		},
-		includeSingleton: {
-			type: Boolean,
-			default: true,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string[] | null;
+		disabled?: boolean;
+		includeSystem?: boolean;
+		includeSingleton?: boolean;
+	}>(),
+	{ includeSingleton: true }
+);
 
-		const collectionsStore = useCollectionsStore();
+defineEmits<{
+	(e: 'input', value: string[] | null): void;
+}>();
 
-		const collections = computed(() => {
-			let collections = collectionsStore.collections;
+const { t } = useI18n();
 
-			if (!props.includeSingleton) {
-				collections = collections.filter((collection) => collection?.meta?.singleton === false);
-			}
+const collectionsStore = useCollectionsStore();
 
-			if (props.includeSystem) return collections;
+const collections = computed(() => {
+	let collections = collectionsStore.collections;
 
-			return collections.filter((collection) => collection.collection.startsWith('directus_') === false);
-		});
+	if (!props.includeSingleton) {
+		collections = collections.filter((collection) => collection?.meta?.singleton === false);
+	}
 
-		const items = computed(() => {
-			return collections.value.map((collection) => ({
-				text: collection.name,
-				value: collection.collection,
-			}));
-		});
+	if (props.includeSystem) return collections;
 
-		return { t, items };
-	},
+	return collections.filter((collection) => collection.collection.startsWith('directus_') === false);
+});
+
+const items = computed(() => {
+	return collections.value.map((collection) => ({
+		text: collection.name,
+		value: collection.collection,
+	}));
 });
 </script>

--- a/app/src/interfaces/_system/system-display-template/system-display-template.vue
+++ b/app/src/interfaces/_system/system-display-template/system-display-template.vue
@@ -14,55 +14,41 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, inject, ref, computed } from 'vue';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
+import { computed, inject, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: String,
-			default: null,
-		},
-		collectionField: {
-			type: String,
-			default: null,
-		},
-		collectionName: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	value: string | null;
+	disabled?: boolean;
+	collectionField?: string;
+	collectionName?: string;
+}>();
 
-		const collectionsStore = useCollectionsStore();
+defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		const values = inject('values', ref<Record<string, any>>({}));
+const { t } = useI18n();
 
-		const collection = computed(() => {
-			if (!props.collectionField) {
-				if (props.collectionName) return props.collectionName;
-				return null;
-			}
+const collectionsStore = useCollectionsStore();
 
-			const collectionName = values.value[props.collectionField];
+const values = inject('values', ref<Record<string, any>>({}));
 
-			const collectionExists = !!collectionsStore.collections.find(
-				(collection) => collection.collection === collectionName
-			);
+const collection = computed(() => {
+	if (!props.collectionField) {
+		if (props.collectionName) return props.collectionName;
+		return null;
+	}
 
-			if (collectionExists === false) return null;
-			return collectionName;
-		});
+	const collectionName = values.value[props.collectionField];
 
-		return { t, collection };
-	},
+	const collectionExists = !!collectionsStore.collections.find(
+		(collection) => collection.collection === collectionName
+	);
+
+	if (collectionExists === false) return null;
+	return collectionName;
 });
 </script>

--- a/app/src/interfaces/_system/system-field-tree/system-field-tree.vue
+++ b/app/src/interfaces/_system/system-field-tree/system-field-tree.vue
@@ -19,51 +19,31 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, inject, ref, PropType } from 'vue';
+<script setup lang="ts">
 import { useFieldTree } from '@/composables/use-field-tree';
+import { computed, inject, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		collectionField: {
-			type: String,
-			default: null,
-		},
-		collectionName: {
-			type: String,
-			default: null,
-		},
-		value: {
-			type: Array as PropType<string[]>,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		allowNone: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collectionField?: string;
+	collectionName?: string;
+	value: string[] | null;
+	disabled?: boolean;
+	placeholder?: string;
+	allowNone?: boolean;
+}>();
 
-		const values = inject('values', ref<Record<string, any>>({}));
+defineEmits<{
+	(e: 'input', value: string[] | null): void;
+}>();
 
-		const chosenCollection = computed(() => values.value[props.collectionField] || props.collectionName);
+const { t } = useI18n();
 
-		const { treeList, loadFieldRelations } = useFieldTree(chosenCollection);
+const values = inject('values', ref<Record<string, any>>({}));
 
-		return { t, values, treeList, chosenCollection, loadFieldRelations };
-	},
-});
+const chosenCollection = computed(() => values.value[props.collectionField!] || props.collectionName);
+
+const { treeList, loadFieldRelations } = useFieldTree(chosenCollection);
 </script>
 
 <style scoped>

--- a/app/src/interfaces/_system/system-field/system-field.vue
+++ b/app/src/interfaces/_system/system-field/system-field.vue
@@ -16,90 +16,67 @@
 	/>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, inject, ref, PropType, watch } from 'vue';
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { Field } from '@cairncms/types';
+import { computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		collectionField: {
-			type: String,
-			default: null,
-		},
-		collectionName: {
-			type: String,
-			default: null,
-		},
-		typeAllowList: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		value: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		allowNone: {
-			type: Boolean,
-			default: false,
-		},
-		allowPrimaryKey: {
-			type: Boolean,
-			default: false,
-		},
-		allowForeignKeys: {
-			type: Boolean,
-			default: true,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		collectionField?: string;
+		collectionName?: string;
+		typeAllowList?: string[];
+		disabled?: boolean;
+		placeholder?: string;
+		allowNone?: boolean;
+		allowPrimaryKey?: boolean;
+		allowForeignKeys?: boolean;
+	}>(),
+	{
+		typeAllowList: () => [],
+		allowForeignKeys: true,
+	}
+);
 
-		const fieldsStore = useFieldsStore();
+const emit = defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		const values = inject('values', ref<Record<string, any>>({}));
+const { t } = useI18n();
 
-		const collection = computed(() => values.value[props.collectionField] || props.collectionName);
+const fieldsStore = useFieldsStore();
 
-		const fields = computed(() => {
-			if (!props.collectionField && !props.collectionName) return [];
-			return fieldsStore.getFieldsForCollection(collection.value);
-		});
+const values = inject('values', ref<Record<string, any>>({}));
 
-		// Reset value whenever the chosen collection changes
-		watch(collection, (newCol, oldCol) => {
-			if (oldCol !== null && newCol !== oldCol) {
-				emit('input', null);
-			}
-		});
+const collection = computed(() => values.value[props.collectionField!] || props.collectionName);
 
-		const selectItems = computed(() =>
-			fields.value.map((field: Field) => {
-				let disabled = false;
-
-				if (props.allowPrimaryKey === false && field?.schema?.is_primary_key === true) disabled = true;
-				if (props.allowForeignKeys === false && field?.schema?.foreign_key_table) disabled = true;
-				if (props.typeAllowList.length > 0 && props.typeAllowList.includes(field.type) === false) disabled = true;
-
-				return {
-					text: field.name,
-					value: field.field,
-					disabled,
-				};
-			})
-		);
-
-		return { t, selectItems, values, fields };
-	},
+const fields = computed(() => {
+	if (!props.collectionField && !props.collectionName) return [];
+	return fieldsStore.getFieldsForCollection(collection.value);
 });
+
+// Reset value whenever the chosen collection changes
+watch(collection, (newCol, oldCol) => {
+	if (oldCol !== null && newCol !== oldCol) {
+		emit('input', null);
+	}
+});
+
+const selectItems = computed(() =>
+	fields.value.map((field: Field) => {
+		let disabled = false;
+
+		if (props.allowPrimaryKey === false && field?.schema?.is_primary_key === true) disabled = true;
+		if (props.allowForeignKeys === false && field?.schema?.foreign_key_table) disabled = true;
+		if (props.typeAllowList.length > 0 && props.typeAllowList.includes(field.type) === false) disabled = true;
+
+		return {
+			text: field.name,
+			value: field.field,
+			disabled,
+		};
+	})
+);
 </script>

--- a/app/src/interfaces/_system/system-filter/input-group.vue
+++ b/app/src/interfaces/_system/system-filter/input-group.vue
@@ -4,7 +4,7 @@
 			:is="interfaceType"
 			:choices="choices"
 			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value"
+			:value="value as (string | number)"
 			@input="value = $event"
 		/>
 	</template>
@@ -26,7 +26,7 @@
 			is="interface-input"
 			:choices="choices"
 			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value"
+			:value="value as (string | number)"
 			@input="value = $event"
 		/>
 	</template>
@@ -53,7 +53,7 @@
 			:is="interfaceType"
 			:choices="choices"
 			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value[0]"
+			:value="value as ((string | number)[])[0]"
 			@input="setValueAt(0, $event)"
 		/>
 		<div class="and">{{ t('interfaces.filter.and') }}</div>
@@ -61,137 +61,128 @@
 			:is="interfaceType"
 			:choices="choices"
 			:type="fieldInfo?.type ?? 'unknown'"
-			:value="value[1]"
+			:value="value as ((string | number)[])[1]"
 			@input="setValueAt(1, $event)"
 		/>
 	</template>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from 'vue';
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
-import { useI18n } from 'vue-i18n';
-import { clone, get } from 'lodash';
-import InputComponent from './input-component.vue';
-import { FieldFilter } from '@cairncms/types';
-import { fieldToFilter, getComparator, getField } from './utils';
 import { useRelationsStore } from '@/stores/relations';
+import { FieldFilter } from '@cairncms/types';
+import { clone, get } from 'lodash';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import InputComponent from './input-component.vue';
+import { fieldToFilter, getComparator, getField } from './utils';
 
-export default defineComponent({
-	components: { InputComponent },
-	props: {
-		field: {
-			type: Object as PropType<FieldFilter>,
-			required: true,
-		},
-		collection: {
-			type: String,
-			required: true,
-		},
+const props = defineProps<{
+	field: FieldFilter;
+	collection: string;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:field', value: FieldFilter): void;
+}>();
+
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
+const { t } = useI18n();
+
+const fieldInfo = computed(() => {
+	const fieldInfo = fieldsStore.getField(props.collection, getField(props.field));
+
+	// Alias uses the foreign key type
+	if (fieldInfo?.type === 'alias') {
+		const relations = relationsStore.getRelationsForField(props.collection, getField(props.field));
+
+		if (relations[0]) {
+			return fieldsStore.getField(relations[0].collection, relations[0].field);
+		}
+	}
+
+	return fieldInfo;
+});
+
+const comparator = computed(() => {
+	return getComparator(props.field);
+});
+
+const interfaceType = computed(() => {
+	if (fieldInfo.value?.meta?.options?.choices) return 'select';
+
+	const types: Record<string, string> = {
+		bigInteger: 'input',
+		binary: 'input',
+		boolean: 'boolean',
+		date: 'datetime',
+		dateTime: 'datetime',
+		decimal: 'input',
+		float: 'input',
+		integer: 'input',
+		json: 'input-code',
+		string: 'input',
+		text: 'input-multiline',
+		time: 'datetime',
+		timestamp: 'datetime',
+		uuid: 'input',
+		csv: 'input',
+		hash: 'input-hash',
+		geometry: 'map',
+	};
+
+	return 'interface-' + types[fieldInfo.value?.type || 'string'];
+});
+
+const value = computed<unknown | unknown[]>({
+	get() {
+		const fieldPath = getField(props.field);
+
+		const value = get(props.field, `${fieldPath}.${comparator.value}`);
+
+		if (['_in', '_nin'].includes(comparator.value)) {
+			return [...(value as string[]).filter((val) => val !== null && val !== ''), null];
+		} else {
+			return value;
+		}
 	},
-	emits: ['update:field'],
-	setup(props, { emit }) {
-		const fieldsStore = useFieldsStore();
-		const relationsStore = useRelationsStore();
-		const { t } = useI18n();
+	set(newVal) {
+		const fieldPath = getField(props.field);
 
-		const fieldInfo = computed(() => {
-			const fieldInfo = fieldsStore.getField(props.collection, getField(props.field));
+		let value;
 
-			// Alias uses the foreign key type
-			if (fieldInfo?.type === 'alias') {
-				const relations = relationsStore.getRelationsForField(props.collection, getField(props.field));
-
-				if (relations[0]) {
-					return fieldsStore.getField(relations[0].collection, relations[0].field);
-				}
-			}
-
-			return fieldInfo;
-		});
-
-		const comparator = computed(() => {
-			return getComparator(props.field);
-		});
-
-		const interfaceType = computed(() => {
-			if (fieldInfo.value?.meta?.options?.choices) return 'select';
-
-			const types: Record<string, string> = {
-				bigInteger: 'input',
-				binary: 'input',
-				boolean: 'boolean',
-				date: 'datetime',
-				dateTime: 'datetime',
-				decimal: 'input',
-				float: 'input',
-				integer: 'input',
-				json: 'input-code',
-				string: 'input',
-				text: 'input-multiline',
-				time: 'datetime',
-				timestamp: 'datetime',
-				uuid: 'input',
-				csv: 'input',
-				hash: 'input-hash',
-				geometry: 'map',
-			};
-
-			return 'interface-' + types[fieldInfo.value?.type || 'string'];
-		});
-
-		const value = computed<any | any[]>({
-			get() {
-				const fieldPath = getField(props.field);
-
-				const value = get(props.field, `${fieldPath}.${comparator.value}`);
-
-				if (['_in', '_nin'].includes(comparator.value)) {
-					return [...(value as string[]).filter((val) => val !== null && val !== ''), null];
-				} else {
-					return value;
-				}
-			},
-			set(newVal) {
-				const fieldPath = getField(props.field);
-
-				let value;
-
-				if (['_in', '_nin'].includes(comparator.value)) {
-					value = (newVal as string[])
-						.flatMap((val) => (typeof val === 'string' ? val.split(',').map((v) => v.trim()) : ''))
-						.filter((val) => val !== null && val !== '');
-				} else {
-					value = newVal;
-				}
-
-				emit('update:field', fieldToFilter(fieldPath, comparator.value, value));
-			},
-		});
-
-		const choices = computed(() => fieldInfo.value?.meta?.options?.choices ?? []);
-
-		return { t, choices, fieldInfo, interfaceType, value, comparator, setValueAt, getComparator, setListValue };
-
-		function setValueAt(index: number, newVal: any) {
-			let newArray = Array.isArray(value.value) ? clone(value.value) : new Array(index + 1);
-			newArray[index] = newVal;
-			value.value = newArray;
+		if (['_in', '_nin'].includes(comparator.value)) {
+			value = (newVal as string[])
+				.flatMap((val) => (typeof val === 'string' ? val.split(',').map((v) => v.trim()) : ''))
+				.filter((val) => val !== null && val !== '');
+		} else {
+			value = newVal;
 		}
 
-		function setListValue(index: number, newVal: any) {
-			if (typeof newVal === 'string' && newVal.includes(',')) {
-				const parts = newVal.split(',');
-
-				for (let i = 0; i < parts.length; i++) {
-					setValueAt(index + i, parts[i]);
-				}
-			} else {
-				setValueAt(index, newVal);
-			}
-		}
+		emit('update:field', fieldToFilter(fieldPath, comparator.value, value));
 	},
 });
+
+const choices = computed(() => fieldInfo.value?.meta?.options?.choices ?? []);
+
+function setValueAt(index: number, newVal: any) {
+	let newArray = Array.isArray(value.value) ? clone(value.value) : new Array(index + 1);
+	newArray[index] = newVal;
+	value.value = newArray;
+}
+
+function setListValue(index: number, newVal: any) {
+	if (typeof newVal === 'string' && newVal.includes(',')) {
+		const parts = newVal.split(',');
+
+		for (let i = 0; i < parts.length; i++) {
+			setValueAt(index + i, parts[i]);
+		}
+	} else {
+		setValueAt(index, newVal);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/_system/system-filter/nodes.vue
+++ b/app/src/interfaces/_system/system-filter/nodes.vue
@@ -38,8 +38,8 @@
 							inline
 							class="comparator"
 							placement="bottom-start"
-							:model-value="filterInfo[index].comparator"
-							:items="getCompareOptions(filterInfo[index].field)"
+							:model-value="(filterInfo[index] as FilterInfoField).comparator"
+							:items="getCompareOptions((filterInfo[index] as FilterInfoField).field)"
 							@update:model-value="updateComparator(index, $event)"
 						/>
 						<input-group :field="element" :collection="collection" @update:field="replaceNode(index, $event)" />
@@ -99,12 +99,20 @@
 	</draggable>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
 import { useSync } from '@cairncms/composables';
-import { FieldFilter, FieldFilterOperator, Filter, LogicalFilterAND, LogicalFilterOR, Type } from '@cairncms/types';
+import {
+	FieldFilter,
+	FieldFilterOperator,
+	FieldFunction,
+	Filter,
+	LogicalFilterAND,
+	LogicalFilterOR,
+	Type,
+} from '@cairncms/types';
 import { getFilterOperatorsForType, getOutputTypeForFunction, toArray } from '@cairncms/utils';
 import { get } from 'lodash';
 import { computed, toRefs } from 'vue';
@@ -113,21 +121,21 @@ import Draggable from 'vuedraggable';
 import InputGroup from './input-group.vue';
 import { fieldToFilter, getComparator, getField, getNodeName } from './utils';
 
-type FilterInfo =
-	| {
-			id: number;
-			isField: true;
-			name: string;
-			node: Filter;
-			field: string;
-			comparator: string;
-	  }
-	| {
-			id: number;
-			isField: false;
-			name: string;
-			node: Filter;
-	  };
+type FilterInfo = {
+	id: number;
+	isField: false;
+	name: string;
+	node: Filter;
+};
+
+type FilterInfoField = {
+	id: number;
+	isField: true;
+	name: string;
+	node: Filter;
+	field: string;
+	comparator: string;
+};
 
 interface Props {
 	filter: Filter[];
@@ -157,22 +165,22 @@ const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
 const { t } = useI18n();
 
-const filterInfo = computed<FilterInfo[]>({
+const filterInfo = computed<(FilterInfo | FilterInfoField)[]>({
 	get() {
 		return props.filter.map((node, id) => {
 			const name = getNodeName(node);
 			const isField = name.startsWith('_') === false;
 
 			return isField
-				? {
+				? ({
 						id,
 						isField,
 						name,
 						field: getField(node),
 						comparator: getComparator(node),
 						node,
-				  }
-				: { id, name, isField, node };
+				  } as FilterInfoField)
+				: ({ id, name, isField, node } as FilterInfo);
 		});
 	},
 	set(newVal) {
@@ -330,7 +338,7 @@ function getCompareOptions(name: string) {
 	let type: Type;
 
 	if (name.includes('(') && name.includes(')')) {
-		const functionName = name.split('(')[0];
+		const functionName = name.split('(')[0] as FieldFunction;
 		type = getOutputTypeForFunction(functionName);
 	} else {
 		const fieldInfo = fieldsStore.getField(props.collection, name);

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -82,10 +82,10 @@
 	</div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
-import { Filter, Type, FieldFunction } from '@cairncms/types';
+import { FieldFunction, Filter, Type } from '@cairncms/types';
 import {
 	getFilterOperatorsForType,
 	getOutputTypeForFunction,
@@ -134,7 +134,7 @@ const values = inject('values', ref<Record<string, any>>({}));
 
 const collection = computed(() => {
 	if (props.collectionName) return props.collectionName;
-	return values.value[props.collectionField] ?? null;
+	return values.value[props.collectionField!] ?? null;
 });
 
 const fieldsStore = useFieldsStore();

--- a/app/src/interfaces/_system/system-folder/folder-list-item.vue
+++ b/app/src/interfaces/_system/system-folder/folder-list-item.vue
@@ -26,45 +26,30 @@
 		</template>
 		<folder-list-item
 			v-for="childFolder in folder.children"
-			:key="childFolder.id"
+			:key="childFolder.id!"
 			:folder="childFolder"
 			:current-folder="currentFolder"
-			:disabled="disabledFolders.includes(childFolder.id)"
+			:disabled="disabledFolders.includes(childFolder.id!)"
 			:disabled-folders="disabledFolders"
 			@click="$emit('click', $event)"
 		/>
 	</v-list-group>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import type { Folder } from '@/composables/use-folders';
 
-type Folder = {
-	id: string;
-	name: string;
-	children: Folder[];
-};
+withDefaults(
+	defineProps<{
+		folder: Folder;
+		currentFolder: string | null;
+		disabled?: boolean;
+		disabledFolders?: string[];
+	}>(),
+	{ disabledFolders: () => [] }
+);
 
-export default defineComponent({
-	name: 'FolderListItem',
-	props: {
-		folder: {
-			type: Object as PropType<Folder>,
-			required: true,
-		},
-		currentFolder: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		disabledFolders: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-	},
-	emits: ['click'],
-});
+defineEmits<{
+	(e: 'click', folderId: Folder['id']): void;
+}>();
 </script>

--- a/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
+++ b/app/src/interfaces/_system/system-interface-options/system-interface-options.vue
@@ -27,102 +27,85 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, inject, ref } from 'vue';
+<script setup lang="ts">
 import { useExtension } from '@/composables/use-extension';
+import { computed, inject, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Object,
-			default: null,
-		},
-		interfaceField: {
-			type: String,
-			default: null,
-		},
-		interface: {
-			type: String,
-			default: null,
-		},
-		collection: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
+const props = defineProps<{
+	value: Record<string, unknown> | null;
+	interfaceField?: string;
+	interface?: string;
+	collection?: string;
+	disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+	(e: 'input', value: Record<string, unknown> | null): void;
+}>();
+
+const { t } = useI18n();
+
+const options = computed({
+	get() {
+		return props.value;
 	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const options = computed({
-			get() {
-				return props.value;
-			},
-			set(newVal: any) {
-				emit('input', newVal);
-			},
-		});
-
-		const values = inject('values', ref<Record<string, any>>({}));
-
-		const selectedInterfaceId = computed(() => props.interface ?? values.value[props.interfaceField] ?? null);
-		const selectedInterface = useExtension('interface', selectedInterfaceId);
-
-		const usesCustomComponent = computed(() => {
-			if (!selectedInterface.value) return false;
-			return selectedInterface.value.options && 'render' in selectedInterface.value.options;
-		});
-
-		const optionsFields = computed(() => {
-			if (!selectedInterface.value) return [];
-			if (!selectedInterface.value.options) return [];
-			if (usesCustomComponent.value === true) return [];
-
-			let optionsObjectOrArray;
-
-			if (typeof selectedInterface.value.options === 'function') {
-				optionsObjectOrArray = selectedInterface.value.options({
-					field: {
-						type: 'unknown',
-					},
-					editing: '+',
-					collection: props.collection,
-					relations: {
-						o2m: undefined,
-						m2o: undefined,
-						m2a: undefined,
-					},
-					collections: {
-						related: undefined,
-						junction: undefined,
-					},
-					fields: {
-						corresponding: undefined,
-						junctionCurrent: undefined,
-						junctionRelated: undefined,
-						sort: undefined,
-					},
-					items: {},
-					localType: 'standard',
-					autoGenerateJunctionRelation: false,
-					saving: false,
-				});
-			} else {
-				optionsObjectOrArray = selectedInterface.value.options;
-			}
-
-			if (Array.isArray(optionsObjectOrArray)) return optionsObjectOrArray;
-
-			return [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
-		});
-
-		return { t, selectedInterface, values, usesCustomComponent, optionsFields, options };
+	set(newVal: any) {
+		emit('input', newVal);
 	},
+});
+
+const values = inject('values', ref<Record<string, any>>({}));
+
+const selectedInterfaceId = computed(() => props.interface ?? values.value[props.interfaceField!] ?? null);
+const selectedInterface = useExtension('interface', selectedInterfaceId);
+
+const usesCustomComponent = computed(() => {
+	if (!selectedInterface.value) return false;
+	return selectedInterface.value.options && 'render' in selectedInterface.value.options;
+});
+
+const optionsFields = computed(() => {
+	if (!selectedInterface.value) return [];
+	if (!selectedInterface.value.options) return [];
+	if (usesCustomComponent.value === true) return [];
+
+	let optionsObjectOrArray;
+
+	if (typeof selectedInterface.value.options === 'function') {
+		optionsObjectOrArray = selectedInterface.value.options({
+			field: {
+				type: 'unknown',
+			},
+			editing: '+',
+			collection: props.collection,
+			relations: {
+				o2m: undefined,
+				m2o: undefined,
+				m2a: undefined,
+			},
+			collections: {
+				related: undefined,
+				junction: undefined,
+			},
+			fields: {
+				corresponding: undefined,
+				junctionCurrent: undefined,
+				junctionRelated: undefined,
+				sort: undefined,
+			},
+			items: {},
+			localType: 'standard',
+			autoGenerateJunctionRelation: false,
+			saving: false,
+		});
+	} else {
+		optionsObjectOrArray = selectedInterface.value.options;
+	}
+
+	if (Array.isArray(optionsObjectOrArray)) return optionsObjectOrArray;
+
+	return [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
 });
 </script>
 

--- a/app/src/interfaces/_system/system-interface/system-interface.vue
+++ b/app/src/interfaces/_system/system-interface/system-interface.vue
@@ -11,58 +11,48 @@
 	/>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, inject, ref, watch } from 'vue';
-import { InterfaceConfig } from '@cairncms/types';
+<script setup lang="ts">
 import { useExtensions } from '@/extensions';
+import { InterfaceConfig } from '@cairncms/types';
+import { computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		typeField: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	value: string | null;
+	typeField?: string;
+}>();
 
-		const { interfaces } = useExtensions();
+const emit = defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		const values = inject('values', ref<Record<string, any>>({}));
+const { t } = useI18n();
 
-		const selectedType = computed(() => {
-			if (props.typeField === null || !values.value[props.typeField]) return;
-			return values.value[props.typeField];
+const { interfaces } = useExtensions();
+
+const values = inject('values', ref<Record<string, any>>({}));
+
+const selectedType = computed(() => {
+	if (!props.typeField || !values.value[props.typeField]) return;
+	return values.value[props.typeField];
+});
+
+watch(
+	() => values.value[props.typeField!],
+	() => {
+		emit('input', null);
+	}
+);
+
+const items = computed(() => {
+	return interfaces.value
+		.filter((inter: InterfaceConfig) => inter.relational !== true && inter.system !== true)
+		.filter((inter: InterfaceConfig) => selectedType.value === undefined || inter.types.includes(selectedType.value))
+		.map((inter: InterfaceConfig) => {
+			return {
+				text: inter.name,
+				value: inter.id,
+			};
 		});
-
-		watch(
-			() => values.value[props.typeField],
-			() => {
-				emit('input', null);
-			}
-		);
-
-		const items = computed(() => {
-			return interfaces.value
-				.filter((inter: InterfaceConfig) => inter.relational !== true && inter.system !== true)
-				.filter(
-					(inter: InterfaceConfig) => selectedType.value === undefined || inter.types.includes(selectedType.value)
-				)
-				.map((inter: InterfaceConfig) => {
-					return {
-						text: inter.name,
-						value: inter.id,
-					};
-				});
-		});
-
-		return { t, items, selectedType, values };
-	},
 });
 </script>

--- a/app/src/interfaces/_system/system-language/system-language.vue
+++ b/app/src/interfaces/_system/system-language/system-language.vue
@@ -8,40 +8,28 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
 import availableLanguages from '@/lang/available-languages.yaml';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: String,
-			default: null,
-		},
-		includeProjectDefault: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	value: string | null;
+	disabled?: boolean;
+	includeProjectDefault?: boolean;
+}>();
 
-		const languages = Object.entries(availableLanguages).map(([key, value]) => ({
-			text: value,
-			value: key as string | null,
-		}));
+defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		if (props.includeProjectDefault) {
-			languages.splice(0, 0, { text: t('fields.directus_settings.default_language'), value: null });
-		}
+const { t } = useI18n();
 
-		return { t, languages };
-	},
-});
+const languages = Object.entries(availableLanguages).map(([key, value]) => ({
+	text: value,
+	value: key as string | null,
+}));
+
+if (props.includeProjectDefault) {
+	languages.splice(0, 0, { text: t('fields.directus_settings.default_language'), value: null });
+}
 </script>

--- a/app/src/interfaces/_system/system-mfa-setup/system-mfa-setup.vue
+++ b/app/src/interfaces/_system/system-mfa-setup/system-mfa-setup.vue
@@ -84,122 +84,92 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch, computed, nextTick } from 'vue';
-import { useUserStore } from '@/stores/user';
+<script setup lang="ts">
 import { useTFASetup } from '@/composables/use-tfa-setup';
+import { useUserStore } from '@/stores/user';
 import { User } from '@cairncms/types';
+import { computed, nextTick, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		primaryKey: {
-			type: String,
-			default: null,
-		},
+const props = defineProps<{
+	value: string | null;
+	primaryKey?: string;
+}>();
+
+const { t } = useI18n();
+
+const userStore = useUserStore();
+const enableActive = ref(false);
+const disableActive = ref(false);
+
+const inputOTP = ref<any>(null);
+
+const isCurrentUser = computed(() => (userStore.currentUser as User)?.id === props.primaryKey);
+
+const {
+	generateTFA,
+	enableTFA,
+	disableTFA,
+	adminDisableTFA,
+	loading,
+	password,
+	tfaEnabled,
+	tfaGenerated,
+	secret,
+	otp,
+	error,
+	canvasID,
+} = useTFASetup(!!props.value);
+
+watch(
+	() => props.value,
+	() => {
+		tfaEnabled.value = !!props.value;
 	},
-	setup(props) {
-		const { t } = useI18n();
+	{ immediate: true }
+);
 
-		const userStore = useUserStore();
-		const enableActive = ref(false);
-		const disableActive = ref(false);
-
-		const inputOTP = ref<any>(null);
-
-		const isCurrentUser = computed(() => (userStore.currentUser as User)?.id === props.primaryKey);
-
-		const {
-			generateTFA,
-			enableTFA,
-			disableTFA,
-			adminDisableTFA,
-			loading,
-			password,
-			tfaEnabled,
-			tfaGenerated,
-			secret,
-			otp,
-			error,
-			canvasID,
-		} = useTFASetup(!!props.value);
-
-		watch(
-			() => props.value,
-			() => {
-				tfaEnabled.value = !!props.value;
-			},
-			{ immediate: true }
-		);
-
-		watch(
-			() => tfaGenerated.value,
-			async (generated) => {
-				if (generated) {
-					await nextTick();
-					(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
-				}
-			}
-		);
-
-		return {
-			t,
-			tfaEnabled,
-			tfaGenerated,
-			generateTFA,
-			cancelAndClose,
-			enable,
-			toggle,
-			password,
-			enableActive,
-			disableActive,
-			loading,
-			canvasID,
-			secret,
-			disable,
-			otp,
-			error,
-			isCurrentUser,
-			inputOTP,
-		};
-
-		async function enable() {
-			const success = await enableTFA();
-			enableActive.value = !success;
-
-			if (!success) {
-				(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
-			}
+watch(
+	() => tfaGenerated.value,
+	async (generated) => {
+		if (generated) {
+			await nextTick();
+			(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
 		}
+	}
+);
 
-		async function disable() {
-			const success = await (isCurrentUser.value ? disableTFA() : adminDisableTFA(props.primaryKey));
-			disableActive.value = !success;
-		}
+async function enable() {
+	const success = await enableTFA();
+	enableActive.value = !success;
 
-		function toggle() {
-			if (tfaEnabled.value === false) {
-				enableActive.value = true;
-			} else {
-				disableActive.value = true;
-			}
-		}
+	if (!success) {
+		(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
+	}
+}
 
-		function cancelAndClose() {
-			tfaGenerated.value = false;
-			enableActive.value = false;
-			disableActive.value = false;
-			password.value = '';
-			otp.value = '';
-			secret.value = '';
-			error.value = null;
-		}
-	},
-});
+async function disable() {
+	const success = await (isCurrentUser.value ? disableTFA() : adminDisableTFA(props.primaryKey!));
+	disableActive.value = !success;
+}
+
+function toggle() {
+	if (tfaEnabled.value === false) {
+		enableActive.value = true;
+	} else {
+		disableActive.value = true;
+	}
+}
+
+function cancelAndClose() {
+	tfaGenerated.value = false;
+	enableActive.value = false;
+	disableActive.value = false;
+	password.value = '';
+	otp.value = '';
+	secret.value = '';
+	error.value = null;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -19,7 +19,7 @@
 						<v-icon class="drag-handle" name="drag_handle" />
 						<v-icon class="icon" :name="element.icon" />
 						<div class="info">
-							<div class="name">{{ element.name }}</div>
+							<div class="name">{{ element.displayName }}</div>
 							<div class="to">{{ element.to }}</div>
 						</div>
 						<div class="spacer" />
@@ -69,10 +69,12 @@ import { nanoid } from 'nanoid';
 import { Field, DeepPartial } from '@cairncms/types';
 import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useExtensions } from '@/extensions';
+import { translate } from '@/utils/translate-object-values';
 
 type PreviewExtra = {
 	to: string;
 	name: string;
+	displayName: string;
 	icon: string;
 };
 
@@ -201,6 +203,7 @@ export default defineComponent({
 							to: part.url,
 							icon: part.icon,
 							name: part.name,
+							displayName: translate(part.name),
 						};
 					}
 
@@ -210,6 +213,7 @@ export default defineComponent({
 						...part,
 						to: `/${module.id}`,
 						name: module.name,
+						displayName: module.name,
 						icon: module.icon,
 					};
 				});

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -58,18 +58,17 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed, ref } from 'vue';
-import { Settings, SettingsModuleBarModule, SettingsModuleBarLink } from '@cairncms/types';
-import { hideDragImage } from '@/utils/hide-drag-image';
-import Draggable from 'vuedraggable';
-import { assign } from 'lodash';
-import { useI18n } from 'vue-i18n';
-import { nanoid } from 'nanoid';
-import { Field, DeepPartial } from '@cairncms/types';
+<script setup lang="ts">
 import { MODULE_BAR_DEFAULT } from '@/constants';
 import { useExtensions } from '@/extensions';
+import { hideDragImage } from '@/utils/hide-drag-image';
 import { translate } from '@/utils/translate-object-values';
+import { DeepPartial, Field, Settings, SettingsModuleBarLink, SettingsModuleBarModule } from '@cairncms/types';
+import { assign } from 'lodash';
+import { nanoid } from 'nanoid';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
 
 type PreviewExtra = {
 	to: string;
@@ -115,176 +114,161 @@ const linkFields: DeepPartial<Field>[] = [
 	},
 ];
 
-export default defineComponent({
-	name: 'SystemModules',
-	components: { Draggable },
-	props: {
-		value: {
-			type: Array as PropType<Settings['module_bar']>,
-			default: () => MODULE_BAR_DEFAULT,
-		},
+const props = withDefaults(
+	defineProps<{
+		value: Settings['module_bar'];
+	}>(),
+	{
+		value: () => MODULE_BAR_DEFAULT as Settings['module_bar'],
+	}
+);
+
+const emit = defineEmits<{
+	(e: 'input', value: Settings['module_bar']): void;
+}>();
+
+const { t } = useI18n();
+
+const editing = ref<string | null>();
+const values = ref<SettingsModuleBarLink | null>();
+const initialValues = ref<SettingsModuleBarLink | null>();
+
+const { modules: registeredModules } = useExtensions();
+
+const availableModulesAsBarModule = computed<SettingsModuleBarModule[]>(() => {
+	return registeredModules.value
+		.filter((module) => module.hidden !== true)
+		.map(
+			(module): SettingsModuleBarModule => ({
+				type: 'module',
+				id: module.id,
+				enabled: false,
+			})
+		);
+});
+
+const valuesWithData = computed<PreviewValue[]>({
+	get() {
+		const savedModules = (
+			(props.value ?? MODULE_BAR_DEFAULT).filter((value) => value.type === 'module') as SettingsModuleBarModule[]
+		).map((value) => value.id);
+
+		return valueToPreview([
+			...(props.value ?? MODULE_BAR_DEFAULT),
+			...availableModulesAsBarModule.value.filter(
+				(availableModuleAsBarModule) => savedModules.includes(availableModuleAsBarModule.id) === false
+			),
+		]);
 	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+	set(previewValue: PreviewValue[]) {
+		emit('input', previewToValue(previewValue));
+	},
+});
 
-		const editing = ref<string | null>();
-		const values = ref<SettingsModuleBarLink | null>();
-		const initialValues = ref<SettingsModuleBarLink | null>();
-
-		const { modules: registeredModules } = useExtensions();
-
-		const availableModulesAsBarModule = computed<SettingsModuleBarModule[]>(() => {
-			return registeredModules.value
-				.filter((module) => module.hidden !== true)
-				.map(
-					(module): SettingsModuleBarModule => ({
-						type: 'module',
-						id: module.id,
-						enabled: false,
-					})
-				);
-		});
-
-		const valuesWithData = computed<PreviewValue[]>({
-			get() {
-				const savedModules = (
-					(props.value ?? MODULE_BAR_DEFAULT).filter((value) => value.type === 'module') as SettingsModuleBarModule[]
-				).map((value) => value.id);
-
-				return valueToPreview([
-					...(props.value ?? MODULE_BAR_DEFAULT),
-					...availableModulesAsBarModule.value.filter(
-						(availableModuleAsBarModule) => savedModules.includes(availableModuleAsBarModule.id) === false
-					),
-				]);
-			},
-			set(previewValue: PreviewValue[]) {
-				emit('input', previewToValue(previewValue));
-			},
-		});
-
-		const isSaveDisabled = computed(() => {
-			for (const field of linkFields) {
-				if (field.meta?.required && field.field) {
-					const fieldValue = (values.value as Record<string, any>)[field.field];
-					if (fieldValue === null || fieldValue === undefined || fieldValue === '') return true;
-				}
-			}
-
-			return false;
-		});
-
-		return {
-			t,
-			editing,
-			valuesWithData,
-			hideDragImage,
-			updateItem,
-			edit,
-			linkFields,
-			isSaveDisabled,
-			save,
-			values,
-			remove,
-			initialValues,
-		};
-
-		function valueToPreview(value: Settings['module_bar']): PreviewValue[] {
-			return value
-				.filter((part) => {
-					if (part.type === 'link') return true;
-					return !!registeredModules.value.find((module) => module.id === part.id);
-				})
-				.map((part) => {
-					if (part.type === 'link') {
-						return {
-							...part,
-							to: part.url,
-							icon: part.icon,
-							name: part.name,
-							displayName: translate(part.name),
-						};
-					}
-
-					const module = registeredModules.value.find((module) => module.id === part.id)!;
-
-					return {
-						...part,
-						to: `/${module.id}`,
-						name: module.name,
-						displayName: module.name,
-						icon: module.icon,
-					};
-				});
+const isSaveDisabled = computed(() => {
+	for (const field of linkFields) {
+		if (field.meta?.required && field.field) {
+			const fieldValue = (values.value as Record<string, any>)[field.field];
+			if (fieldValue === null || fieldValue === undefined || fieldValue === '') return true;
 		}
+	}
 
-		function previewToValue(preview: PreviewValue[]): Settings['module_bar'] {
-			return preview.map((previewValue) => {
-				if (previewValue.type === 'link') {
-					const { type, id, name, url, icon, enabled, locked } = previewValue;
-					return { type, id, name, url, icon, enabled, locked };
-				}
+	return false;
+});
 
-				const { type, id, enabled, locked } = previewValue;
-				return { type, id, enabled, locked };
-			});
-		}
-
-		function updateItem(item: PreviewValue, updates: Partial<PreviewValue>): void {
-			valuesWithData.value = valuesWithData.value.map((previewValue) => {
-				if (previewValue === item) {
-					return assign({}, item, updates);
-				}
-
-				return previewValue;
-			});
-		}
-
-		function edit(id: string) {
-			editing.value = id;
-
-			let value: SettingsModuleBarLink;
-
-			if (id !== '+') {
-				value = (props.value ?? MODULE_BAR_DEFAULT).find((val) => val.id === id) as SettingsModuleBarLink;
-			} else {
-				value = {
-					id: nanoid(),
-					type: 'link',
-					enabled: true,
-					url: '',
-					name: '',
-					icon: '',
+function valueToPreview(value: Settings['module_bar']): PreviewValue[] {
+	return value
+		.filter((part) => {
+			if (part.type === 'link') return true;
+			return !!registeredModules.value.find((module) => module.id === part.id);
+		})
+		.map((part) => {
+			if (part.type === 'link') {
+				return {
+					...part,
+					to: part.url,
+					icon: part.icon,
+					name: part.name,
+					displayName: translate(part.name),
 				};
 			}
 
-			values.value = value;
-			initialValues.value = value;
+			const module = registeredModules.value.find((module) => module.id === part.id)!;
+
+			return {
+				...part,
+				to: `/${module.id}`,
+				name: module.name,
+				displayName: module.name,
+				icon: module.icon,
+			};
+		});
+}
+
+function previewToValue(preview: PreviewValue[]): Settings['module_bar'] {
+	return preview.map((previewValue) => {
+		if (previewValue.type === 'link') {
+			const { type, id, name, url, icon, enabled, locked } = previewValue;
+			return { type, id, name, url, icon, enabled, locked };
 		}
 
-		function save() {
-			if (editing.value === '+') {
-				emit('input', [...(props.value ?? MODULE_BAR_DEFAULT), values.value]);
-			} else {
-				emit(
-					'input',
-					(props.value ?? MODULE_BAR_DEFAULT).map((val) => (val.id === editing.value ? values.value : val))
-				);
-			}
+		const { type, id, enabled, locked } = previewValue;
+		return { type, id, enabled, locked };
+	});
+}
 
-			values.value = null;
-			editing.value = null;
+function updateItem(item: PreviewValue, updates: Partial<PreviewValue>): void {
+	valuesWithData.value = valuesWithData.value.map((previewValue) => {
+		if (previewValue === item) {
+			return assign({}, item, updates);
 		}
 
-		function remove(id: string) {
-			emit(
-				'input',
-				(props.value ?? MODULE_BAR_DEFAULT).filter((val) => val.id !== id)
-			);
-		}
-	},
-});
+		return previewValue;
+	});
+}
+
+function edit(id: string) {
+	editing.value = id;
+
+	let value: SettingsModuleBarLink;
+
+	if (id !== '+') {
+		value = (props.value ?? MODULE_BAR_DEFAULT).find((val) => val.id === id) as SettingsModuleBarLink;
+	} else {
+		value = {
+			id: nanoid(),
+			type: 'link',
+			enabled: true,
+			url: '',
+			name: '',
+			icon: '',
+		};
+	}
+
+	values.value = value;
+	initialValues.value = value;
+}
+
+function save() {
+	if (editing.value === '+') {
+		emit('input', [...(props.value ?? MODULE_BAR_DEFAULT), values.value!]);
+	} else {
+		emit(
+			'input',
+			(props.value ?? MODULE_BAR_DEFAULT).map((val) => (val.id === editing.value ? values.value! : val))
+		);
+	}
+
+	values.value = null;
+	editing.value = null;
+}
+
+function remove(id: string) {
+	emit(
+		'input',
+		(props.value ?? MODULE_BAR_DEFAULT).filter((val) => val.id !== id)
+	);
+}
 </script>
 
 <style scoped>

--- a/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
+++ b/app/src/interfaces/_system/system-raw-editor/system-raw-editor.vue
@@ -6,12 +6,12 @@
 
 <script lang="ts" setup>
 import { useWindowSize } from '@/composables/use-window-size';
+import { parseJSON } from '@cairncms/utils';
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/mode/simple';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { mustacheMode } from './mustacheMode';
-import { parseJSON } from '@cairncms/utils';
 
 const props = withDefaults(
 	defineProps<{
@@ -42,7 +42,7 @@ const codemirrorEl = ref<HTMLTextAreaElement | null>();
 let codemirror: CodeMirror.Editor | null;
 let previousContent: string | null = null;
 
-const isMultiLine = computed(() => ['text', 'json'].includes(props.type));
+const isMultiLine = computed(() => ['text', 'json'].includes(props.type!));
 
 onMounted(async () => {
 	if (codemirrorEl.value) {

--- a/app/src/interfaces/_system/system-scope/system-scope.vue
+++ b/app/src/interfaces/_system/system-scope/system-scope.vue
@@ -13,127 +13,119 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, defineComponent, ref, watch } from 'vue';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+<script setup lang="ts">
 import api from '@/api';
-import { PUBLIC_ROLE_ID } from '@cairncms/constants';
-import { userName } from '@/utils/user-name';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { userName } from '@/utils/user-name';
+import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	components: {
-		DrawerCollection,
-	},
-	props: {
-		value: {
-			type: String,
-			default: null,
+const props = defineProps<{
+	value: string | null;
+}>();
+
+const emit = defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
+
+const { t } = useI18n();
+
+const collection = ref<string | null>(null);
+const itemName = ref<string | null>(null);
+const loading = ref(false);
+
+const isItem = computed(
+	() => props.value !== null && (props.value.startsWith('role_') || props.value.startsWith('user_'))
+);
+
+watch(() => props.value, loadItemName);
+
+loadItemName();
+
+const options = computed(() => {
+	let options: any[] = [
+		{
+			text: t('global') + ': ' + t('all_users'),
+			value: 'all',
 		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+		{
+			text: t('user') + ': ' + t('select'),
+			value: 'directus_users',
+		},
+		{
+			text: t('role') + ': ' + t('select'),
+			value: 'directus_roles',
+		},
+	];
 
-		const collection = ref<string | null>(null);
-		const itemName = ref<string | null>(null);
-		const loading = ref(false);
+	if (isItem.value) {
+		const [type, id] = props.value!.split('_');
 
-		const isItem = computed(
-			() => props.value !== null && (props.value.startsWith('role_') || props.value.startsWith('user_'))
-		);
+		options = [
+			{
+				text: t(type) + ': ' + (itemName.value || id),
+				value: props.value,
+			},
+			{ divider: true },
+			...options,
+		];
+	}
 
-		watch(() => props.value, loadItemName);
-
-		loadItemName();
-
-		const options = computed(() => {
-			let options: any[] = [
-				{
-					text: t('global') + ': ' + t('all_users'),
-					value: 'all',
-				},
-				{
-					text: t('user') + ': ' + t('select'),
-					value: 'directus_users',
-				},
-				{
-					text: t('role') + ': ' + t('select'),
-					value: 'directus_roles',
-				},
-			];
-
-			if (isItem.value) {
-				const [type, id] = props.value.split('_');
-
-				options = [
-					{
-						text: t(type) + ': ' + (itemName.value || id),
-						value: props.value,
-					},
-					{ divider: true },
-					...options,
-				];
-			}
-
-			return options;
-		});
-
-		const collectionFilter = computed(() =>
-			collection.value === 'directus_roles' ? { id: { _neq: PUBLIC_ROLE_ID } } : null
-		);
-
-		return { options, collection, collectionFilter, onSelect, onSelectItem, loading };
-
-		function onSelect(value: string) {
-			if (value === 'all') {
-				collection.value = null;
-				return emit('input', 'all');
-			}
-
-			collection.value = value;
-		}
-
-		function onSelectItem(value: string[]) {
-			if (collection.value === 'directus_users') return emit('input', 'user_' + value[0]);
-			if (collection.value === 'directus_roles') return emit('input', 'role_' + value[0]);
-		}
-
-		async function loadItemName() {
-			if (!isItem.value) {
-				itemName.value = null;
-				return;
-			}
-
-			loading.value = true;
-
-			const [endpoint, id] = props.value.split('_');
-
-			try {
-				if (endpoint === 'role') {
-					const result = await api.get('/roles/' + id, {
-						params: {
-							fields: ['id', 'name'],
-						},
-					});
-
-					itemName.value = result.data.data.name;
-				} else if (endpoint === 'user') {
-					const result = await api.get('/users/' + id, {
-						params: {
-							fields: ['id', 'first_name', 'last_name', 'email'],
-						},
-					});
-
-					itemName.value = userName(result.data.data);
-				}
-			} catch (error: any) {
-				unexpectedError(error);
-			} finally {
-				loading.value = false;
-			}
-		}
-	},
+	return options;
 });
+
+const collectionFilter = computed(() =>
+	collection.value === 'directus_roles' ? { id: { _neq: PUBLIC_ROLE_ID } } : null
+);
+
+function onSelect(value: string) {
+	if (value === 'all') {
+		collection.value = null;
+		return emit('input', 'all');
+	}
+
+	collection.value = value;
+}
+
+function onSelectItem(value: (string | number)[] | null) {
+	if (collection.value === 'directus_users') return emit('input', 'user_' + value![0]);
+	if (collection.value === 'directus_roles') return emit('input', 'role_' + value![0]);
+}
+
+async function loadItemName() {
+	if (!isItem.value) {
+		itemName.value = null;
+		return;
+	}
+
+	loading.value = true;
+
+	const [endpoint, id] = props.value!.split('_');
+
+	try {
+		if (endpoint === 'role') {
+			const result = await api.get('/roles/' + id, {
+				params: {
+					fields: ['id', 'name'],
+				},
+			});
+
+			itemName.value = result.data.data.name;
+		} else if (endpoint === 'user') {
+			const result = await api.get('/users/' + id, {
+				params: {
+					fields: ['id', 'first_name', 'last_name', 'email'],
+				},
+			});
+
+			itemName.value = userName(result.data.data);
+		}
+	} catch (error: any) {
+		unexpectedError(error);
+	} finally {
+		loading.value = false;
+	}
+}
 </script>

--- a/app/src/interfaces/boolean/boolean.vue
+++ b/app/src/interfaces/boolean/boolean.vue
@@ -15,41 +15,29 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import { i18n } from '@/lang';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Boolean,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		label: {
-			type: String,
-			default: () => i18n.global.t('enabled'),
-		},
-		iconOn: {
-			type: String,
-			default: 'check_box',
-		},
-		iconOff: {
-			type: String,
-			default: 'check_box_outline_blank',
-		},
-		colorOn: {
-			type: String,
-			default: 'var(--primary)',
-		},
-		colorOff: {
-			type: String,
-			default: 'var(--foreground-subdued)',
-		},
-	},
-	emits: ['input'],
-});
+withDefaults(
+	defineProps<{
+		value: boolean | null;
+		disabled?: false;
+		label?: string;
+		iconOn?: string;
+		iconOff?: string;
+		colorOn?: string;
+		colorOff?: string;
+	}>(),
+	{
+		label: () => i18n.global.t('enabled'),
+		iconOn: 'check_box',
+		iconOff: 'check_box_outline_blank',
+		colorOn: 'var(--primary)',
+		colorOff: 'var(--foreground-subdued)',
+	}
+);
+
+defineEmits<{
+	(e: 'input', value: boolean | null): void;
+}>();
 </script>

--- a/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
+++ b/app/src/interfaces/collection-item-dropdown/collection-item-dropdown.vue
@@ -22,7 +22,7 @@
 			v-model:active="selectDrawerOpen"
 			:collection="selectedCollection"
 			:selection="value?.key ? [value.key] : []"
-			:filter="filter"
+			:filter="filter!"
 			@input="onSelection"
 			@update:active="selectDrawerOpen = false"
 		/>
@@ -132,7 +132,7 @@ async function getDisplayItem() {
 	}
 }
 
-function onSelection(selectedIds: (number | string)[]) {
+function onSelection(selectedIds: (number | string)[] | null) {
 	selectDrawerOpen.value = false;
 	value.value = { key: Array.isArray(selectedIds) ? selectedIds[0] : null, collection: unref(selectedCollection) };
 }

--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -32,91 +32,78 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, defineComponent, PropType, ref, watch } from 'vue';
+<script setup lang="ts">
 import { localizedFormat } from '@/utils/localized-format';
 import { isValid, parse, parseISO } from 'date-fns';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: String,
-			default: null,
-		},
-		type: {
-			type: String as PropType<'timestamp' | 'dateTime' | 'time' | 'date'>,
-			required: true,
-			validator: (val: string) => ['dateTime', 'date', 'time', 'timestamp'].includes(val),
-		},
-		includeSeconds: {
-			type: Boolean,
-			default: false,
-		},
-		use24: {
-			type: Boolean,
-			default: true,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		type: 'timestamp' | 'dateTime' | 'time' | 'date';
+		disabled?: boolean;
+		includeSeconds?: boolean;
+		use24?: boolean;
+	}>(),
+	{
+		use24: true,
+	}
+);
 
-		const dateTimeMenu = ref();
+const emit = defineEmits<{
+	(e: 'input', value: string | null): void;
+}>();
 
-		const { displayValue, isValidValue } = useDisplayValue();
+const { t } = useI18n();
 
-		function useDisplayValue() {
-			const displayValue = ref<string | null>(null);
+const dateTimeMenu = ref();
 
-			const isValidValue = computed(() => isValid(parseValue(props.value)));
+const { displayValue, isValidValue } = useDisplayValue();
 
-			watch(() => props.value, setDisplayValue, { immediate: true });
+function useDisplayValue() {
+	const displayValue = ref<string | null>(null);
 
-			return { displayValue, isValidValue };
+	const isValidValue = computed(() => isValid(parseValue(props.value!)));
 
-			function setDisplayValue() {
-				if (!props.value || !isValidValue.value) {
-					displayValue.value = null;
-					return;
-				}
+	watch(() => props.value, setDisplayValue, { immediate: true });
 
-				let timeFormat = props.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
-				if (props.use24) timeFormat = props.includeSeconds ? 'date-fns_time_24hour' : 'date-fns_time_no_seconds_24hour';
-				let format = `${t('date-fns_date')} ${t(timeFormat)}`;
-				if (props.type === 'date') format = String(t('date-fns_date'));
-				if (props.type === 'time') format = String(t(timeFormat));
+	return { displayValue, isValidValue };
 
-				displayValue.value = localizedFormat(parseValue(props.value), format);
-			}
-
-			function parseValue(value: string): Date {
-				switch (props.type) {
-					case 'dateTime':
-						return parse(value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
-					case 'date':
-						return parse(value, 'yyyy-MM-dd', new Date());
-					case 'time':
-						return parse(value, 'HH:mm:ss', new Date());
-					case 'timestamp':
-						return parseISO(value);
-				}
-			}
+	function setDisplayValue() {
+		if (!props.value || !isValidValue.value) {
+			displayValue.value = null;
+			return;
 		}
 
-		function unsetValue(e: any) {
-			e.preventDefault();
-			e.stopPropagation();
-			emit('input', null);
-		}
+		let timeFormat = props.includeSeconds ? 'date-fns_time' : 'date-fns_time_no_seconds';
+		if (props.use24) timeFormat = props.includeSeconds ? 'date-fns_time_24hour' : 'date-fns_time_no_seconds_24hour';
+		let format = `${t('date-fns_date')} ${t(timeFormat)}`;
+		if (props.type === 'date') format = String(t('date-fns_date'));
+		if (props.type === 'time') format = String(t(timeFormat));
 
-		return { t, displayValue, unsetValue, dateTimeMenu, isValidValue };
-	},
-});
+		displayValue.value = localizedFormat(parseValue(props.value), format);
+	}
+
+	function parseValue(value: string): Date {
+		switch (props.type) {
+			case 'dateTime':
+				return parse(value, "yyyy-MM-dd'T'HH:mm:ss", new Date());
+			case 'date':
+				return parse(value, 'yyyy-MM-dd', new Date());
+			case 'time':
+				return parse(value, 'HH:mm:ss', new Date());
+			case 'timestamp':
+				return parseISO(value);
+		}
+	}
+}
+
+function unsetValue(e: any) {
+	e.preventDefault();
+	e.stopPropagation();
+	emit('input', null);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -236,9 +236,9 @@ const edits = computed(() => {
 	return props.value;
 });
 
-function setSelection(selection: number[]) {
-	if (selection[0]) {
-		update(selection[0]);
+function setSelection(selection: (string | number)[] | null) {
+	if (selection![0]) {
+		update(selection![0]);
 	} else {
 		remove();
 	}

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -181,8 +181,10 @@ const templateWithDefaults = computed(() => {
 	if (!relationInfo.value) return null;
 
 	if (props.template) return props.template;
-	if (relationInfo.value.junctionCollection.meta?.display_template)
+
+	if (relationInfo.value.junctionCollection.meta?.display_template) {
 		return relationInfo.value.junctionCollection.meta?.display_template;
+	}
 
 	let relatedDisplayTemplate = relationInfo.value.relatedCollection.meta?.display_template;
 
@@ -335,8 +337,8 @@ function onUpload(files: Record<string, any>[]) {
 	select(fileIds);
 }
 
-function onSelect(selected: string[]) {
-	select(selected.filter((id) => selectedPrimaryKeys.value.includes(id) === false));
+function onSelect(selected: (string | number)[] | null) {
+	select(selected!.filter((id) => selectedPrimaryKeys.value.includes(id) === false));
 }
 
 const downloadName = computed(() => {
@@ -390,12 +392,13 @@ const customFilter = computed(() => {
 		},
 	};
 
-	if (selectedPrimaryKeys.value.length > 0)
+	if (selectedPrimaryKeys.value.length > 0) {
 		filter._and.push({
 			[relationInfo.value.relatedPrimaryKeyField.field]: {
 				_nin: selectedPrimaryKeys.value,
 			},
 		});
+	}
 
 	if (props.primaryKey !== '+') filter._and.push(selectFilter);
 

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -33,136 +33,97 @@
 	</v-item>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
-import { merge, isNil } from 'lodash';
-import { Field } from '@cairncms/types';
-import { ValidationError } from '@cairncms/types';
+<script setup lang="ts">
+import { Field, ValidationError } from '@cairncms/types';
+import { isNil, merge } from 'lodash';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	name: 'AccordionSection',
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		fields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		values: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		initialValues: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		batchMode: {
-			type: Boolean,
-			default: false,
-		},
-		batchActiveFields: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		primaryKey: {
-			type: [Number, String],
-			required: true,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		validationErrors: {
-			type: Array as PropType<ValidationError[]>,
-			default: () => [],
-		},
-		badge: {
-			type: String,
-			default: null,
-		},
-		group: {
-			type: String,
-			required: true,
-		},
-		multiple: {
-			type: Boolean,
-			default: false,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['apply', 'toggleAll'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		field: Field;
+		fields: Field[];
+		values: Record<string, unknown>;
+		initialValues: Record<string, unknown>;
+		disabled?: boolean;
+		batchMode?: boolean;
+		batchActiveFields?: string[];
+		primaryKey: number | string;
+		loading?: boolean;
+		validationErrors?: ValidationError[];
+		badge?: string;
+		group: string;
+		multiple?: boolean;
+		direction?: string;
+	}>(),
+	{
+		batchActiveFields: () => [],
+		validationErrors: () => [],
+	}
+);
 
-		const fieldsInSection = computed(() => {
-			let fields: Field[] = [merge({}, props.field, { hideLabel: true })];
+const emit = defineEmits<{
+	(e: 'apply', value: Record<string, unknown>): void;
+	(e: 'toggleAll'): void;
+}>();
 
-			if (props.field.meta?.special?.includes('group')) {
-				fields.push(...getFieldsForGroup(props.field.meta?.field));
-			}
+const { t } = useI18n();
 
-			return fields;
-		});
+const fieldsInSection = computed(() => {
+	let fields: Field[] = [merge({}, props.field, { hideLabel: true })];
 
-		const edited = computed(() => {
-			if (!props.values) return false;
+	if (props.field.meta?.special?.includes('group')) {
+		fields.push(...getFieldsForGroup(props.field.meta?.field));
+	}
 
-			const editedFields = Object.keys(props.values);
-			return fieldsInSection.value.some((field) => editedFields.includes(field.field));
-		});
-
-		const validationMessage = computed(() => {
-			const validationError = props.validationErrors.find((error) => error.field === props.field.field);
-			if (validationError === undefined) return;
-
-			if (validationError.code === 'RECORD_NOT_UNIQUE') {
-				return t('validationError.unique');
-			} else {
-				return t(`validationError.${validationError.type}`, validationError);
-			}
-		});
-
-		return { t, fieldsInSection, edited, handleModifier, validationMessage };
-
-		function handleModifier(event: MouseEvent, toggle: () => void) {
-			if (props.multiple === false) {
-				toggle();
-				return;
-			}
-
-			if (event.shiftKey) {
-				emit('toggleAll');
-			} else {
-				toggle();
-			}
-		}
-
-		function getFieldsForGroup(group: null | string, passed: string[] = []): Field[] {
-			const fieldsInGroup: Field[] = props.fields.filter((field) => {
-				return field.meta?.group === group || (group === null && isNil(field.meta));
-			});
-
-			for (const field of fieldsInGroup) {
-				if (field.meta?.special?.includes('group') && !passed.includes(field.meta!.field)) {
-					passed.push(field.meta!.field);
-					fieldsInGroup.push(...getFieldsForGroup(field.meta!.field, passed));
-				}
-			}
-
-			return fieldsInGroup;
-		}
-	},
+	return fields;
 });
+
+const edited = computed(() => {
+	if (!props.values) return false;
+
+	const editedFields = Object.keys(props.values);
+	return fieldsInSection.value.some((field) => editedFields.includes(field.field));
+});
+
+const validationMessage = computed(() => {
+	const validationError = props.validationErrors.find((error) => error.field === props.field.field);
+	if (validationError === undefined) return;
+
+	if (validationError.code === 'RECORD_NOT_UNIQUE') {
+		return t('validationError.unique');
+	} else {
+		return t(`validationError.${validationError.type}`, validationError);
+	}
+});
+
+function handleModifier(event: MouseEvent, toggle: () => void) {
+	if (props.multiple === false) {
+		toggle();
+		return;
+	}
+
+	if (event.shiftKey) {
+		emit('toggleAll');
+	} else {
+		toggle();
+	}
+}
+
+function getFieldsForGroup(group: null | string, passed: string[] = []): Field[] {
+	const fieldsInGroup: Field[] = props.fields.filter((field) => {
+		return field.meta?.group === group || (group === null && isNil(field.meta));
+	});
+
+	for (const field of fieldsInGroup) {
+		if (field.meta?.special?.includes('group') && !passed.includes(field.meta!.field)) {
+			passed.push(field.meta!.field);
+			fieldsInGroup.push(...getFieldsForGroup(field.meta!.field, passed));
+		}
+	}
+
+	return fieldsInGroup;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/group-accordion/group-accordion.vue
+++ b/app/src/interfaces/group-accordion/group-accordion.vue
@@ -15,7 +15,7 @@
 			:validation-errors="validationErrors"
 			:badge="badge"
 			:raw-editor-enabled="rawEditorEnabled"
-			:group="field.meta.field"
+			:group="field.meta!.field"
 			:multiple="accordionMode === false"
 			:direction="direction"
 			@apply="$emit('apply', $event)"
@@ -24,154 +24,111 @@
 	</v-item-group>
 </template>
 
-<script lang="ts">
-import { Field } from '@cairncms/types';
-import { defineComponent, PropType, ref, watch } from 'vue';
-import { ValidationError } from '@cairncms/types';
-import AccordionSection from './accordion-section.vue';
+<script setup lang="ts">
+import { Field, ValidationError } from '@cairncms/types';
 import { isEqual } from 'lodash';
+import { ref, watch } from 'vue';
+import AccordionSection from './accordion-section.vue';
 
-export default defineComponent({
-	name: 'InterfaceGroupAccordion',
-	components: { AccordionSection },
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		fields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		values: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		initialValues: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		batchMode: {
-			type: Boolean,
-			default: false,
-		},
-		batchActiveFields: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		primaryKey: {
-			type: [Number, String],
-			required: true,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		validationErrors: {
-			type: Array as PropType<ValidationError[]>,
-			default: () => [],
-		},
-		badge: {
-			type: String,
-			default: null,
-		},
-		rawEditorEnabled: {
-			type: Boolean,
-			default: false,
-		},
-		accordionMode: {
-			type: Boolean,
-			default: true,
-		},
-		start: {
-			type: String,
-			enum: ['opened', 'closed', 'first'],
-			default: 'closed',
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['apply'],
-	setup(props) {
-		const selection = ref<string[]>([]);
-		const { groupFields, groupValues } = useComputedGroup();
+const props = withDefaults(
+	defineProps<{
+		field: Field;
+		fields: Field[];
+		values: Record<string, unknown>;
+		initialValues: Record<string, unknown>;
+		disabled?: boolean;
+		batchMode?: boolean;
+		batchActiveFields?: string[];
+		primaryKey: string | number;
+		loading?: boolean;
+		validationErrors?: ValidationError[];
+		badge?: string;
+		rawEditorEnabled?: boolean;
+		accordionMode?: boolean;
+		start?: 'opened' | 'closed' | 'first';
+		direction?: string;
+	}>(),
+	{
+		batchActiveFields: () => [],
+		validationErrors: () => [],
+		accordionMode: true,
+		start: 'closed',
+	}
+);
 
-		watch(
-			() => props.start,
-			(start) => {
-				if (start === 'opened') {
-					selection.value = groupFields.value.map((field) => field.field);
-				}
+defineEmits<{
+	(e: 'apply', value: Record<string, unknown>): void;
+}>();
 
-				if (start === 'first') {
-					selection.value = [groupFields.value[0].field];
-				}
-			},
-			{ immediate: true }
-		);
+const selection = ref<string[]>([]);
+const { groupFields, groupValues } = useComputedGroup();
 
-		watch(
-			() => props.validationErrors,
-			(newVal, oldVal) => {
-				if (!props.validationErrors) return;
-				if (isEqual(newVal, oldVal)) return;
-
-				const includedFieldsWithErrors = props.validationErrors.filter((validationError) =>
-					groupFields.value.find((rootField) => rootField.field === validationError.field)
-				);
-
-				if (includedFieldsWithErrors.length > 0) selection.value = [includedFieldsWithErrors[0].field];
-			}
-		);
-
-		return { groupFields, groupValues, selection, toggleAll };
-
-		function toggleAll() {
-			if (props.accordionMode === true) return;
-
-			if (selection.value.length === groupFields.value.length) {
-				selection.value = [];
-			} else {
-				selection.value = groupFields.value.map((field) => field.field);
-			}
+watch(
+	() => props.start,
+	(start) => {
+		if (start === 'opened') {
+			selection.value = groupFields.value.map((field) => field.field);
 		}
 
-		function useComputedGroup() {
-			const groupFields = ref<Field[]>(limitFields());
-			const groupValues = ref<Record<string, any>>({});
-
-			watch(
-				() => props.fields,
-				() => {
-					const newVal = limitFields();
-
-					if (!isEqual(groupFields.value, newVal)) {
-						groupFields.value = newVal;
-					}
-				}
-			);
-
-			watch(
-				() => props.values,
-				(newVal) => {
-					if (!isEqual(groupValues.value, newVal)) {
-						groupValues.value = newVal;
-					}
-				}
-			);
-
-			return { groupFields, groupValues };
-
-			function limitFields(): Field[] {
-				return props.fields.filter((field) => field.meta?.group === props.field.meta?.field);
-			}
+		if (start === 'first') {
+			selection.value = [groupFields.value[0].field];
 		}
 	},
-});
+	{ immediate: true }
+);
+
+watch(
+	() => props.validationErrors,
+	(newVal, oldVal) => {
+		if (!props.validationErrors) return;
+		if (isEqual(newVal, oldVal)) return;
+
+		const includedFieldsWithErrors = props.validationErrors.filter((validationError) =>
+			groupFields.value.find((rootField) => rootField.field === validationError.field)
+		);
+
+		if (includedFieldsWithErrors.length > 0) selection.value = [includedFieldsWithErrors[0].field];
+	}
+);
+
+function toggleAll() {
+	if (props.accordionMode === true) return;
+
+	if (selection.value.length === groupFields.value.length) {
+		selection.value = [];
+	} else {
+		selection.value = groupFields.value.map((field) => field.field);
+	}
+}
+
+function useComputedGroup() {
+	const groupFields = ref<Field[]>(limitFields());
+	const groupValues = ref<Record<string, any>>({});
+
+	watch(
+		() => props.fields,
+		() => {
+			const newVal = limitFields();
+
+			if (!isEqual(groupFields.value, newVal)) {
+				groupFields.value = newVal;
+			}
+		}
+	);
+
+	watch(
+		() => props.values,
+		(newVal) => {
+			if (!isEqual(groupValues.value, newVal)) {
+				groupValues.value = newVal;
+			}
+		}
+	);
+
+	return { groupFields, groupValues };
+
+	function limitFields(): Field[] {
+		return props.fields.filter((field) => field.meta?.group === props.field.meta?.field);
+	}
+}
 </script>

--- a/app/src/interfaces/group-detail/group-detail.vue
+++ b/app/src/interfaces/group-detail/group-detail.vue
@@ -31,7 +31,7 @@
 			:fields="fields"
 			:model-value="values"
 			:primary-key="primaryKey"
-			:group="field.meta.field"
+			:group="field.meta?.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:batch-mode="batchMode"
@@ -45,128 +45,82 @@
 	</v-detail>
 </template>
 
-<script lang="ts">
-import { Field } from '@cairncms/types';
-import { computed, defineComponent, PropType, ref, watch } from 'vue';
-import { ValidationError } from '@cairncms/types';
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
 import formatTitle from '@cairncms/format-title';
+import { Field, ValidationError } from '@cairncms/types';
 import { isEqual } from 'lodash';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	name: 'InterfaceGroupDetail',
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		fields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		values: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		initialValues: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		batchMode: {
-			type: Boolean,
-			default: false,
-		},
-		batchActiveFields: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		primaryKey: {
-			type: [Number, String],
-			required: true,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		validationErrors: {
-			type: Array as PropType<ValidationError[]>,
-			default: () => [],
-		},
-		badge: {
-			type: String,
-			default: null,
-		},
+const props = withDefaults(
+	defineProps<{
+		field: Field;
+		fields: Field[];
+		primaryKey: number | string;
+		values: Record<string, unknown>;
+		initialValues: Record<string, unknown>;
+		disabled?: boolean;
+		batchMode?: boolean;
+		batchActiveFields?: string[];
+		loading?: boolean;
+		validationErrors?: ValidationError[];
+		badge?: string;
+		start?: 'open' | 'closed';
+		headerIcon?: string;
+		headerColor?: string;
+		direction?: string;
+	}>(),
+	{
+		batchActiveFields: () => [],
+		validationErrors: () => [],
+		start: 'open',
+	}
+);
 
-		start: {
-			type: String,
-			enum: ['open', 'closed'],
-			default: 'open',
-		},
-		headerIcon: {
-			type: String,
-			default: null,
-		},
-		headerColor: {
-			type: String,
-			default: null,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['apply'],
-	setup(props) {
-		const { t } = useI18n();
+defineEmits(['apply']);
 
-		const detailOpen = ref(props.start === 'open');
+const { t } = useI18n();
 
-		const edited = computed(() => {
-			if (!props.values) return false;
+const detailOpen = ref(props.start === 'open');
 
-			const editedFields = Object.keys(props.values);
-			return props.fields.some((field) => editedFields.includes(field.field));
-		});
+const edited = computed(() => {
+	if (!props.values) return false;
 
-		const validationMessages = computed(() => {
-			if (!props.validationErrors) return;
+	const editedFields = Object.keys(props.values);
+	return props.fields.some((field) => editedFields.includes(field.field));
+});
 
-			const fields = props.fields.map((field) => field.field);
+const validationMessages = computed(() => {
+	if (!props.validationErrors) return;
 
-			const errors = props.validationErrors.reduce((acc, validationError) => {
-				if (fields.includes(validationError.field) === false) return acc;
+	const fields = props.fields.map((field) => field.field);
 
-				if (validationError.code === 'RECORD_NOT_UNIQUE') {
-					acc.push(`${formatTitle(validationError.field)} ${t('validationError.unique').toLowerCase()}`);
-				} else {
-					acc.push(
-						`${formatTitle(validationError.field)} ${t(
-							`validationError.${validationError.type}`,
-							validationError
-						).toLowerCase()}`
-					);
-				}
+	const errors = props.validationErrors.reduce((acc, validationError) => {
+		if (fields.includes(validationError.field) === false) return acc;
 
-				return acc;
-			}, [] as string[]);
+		if (validationError.code === 'RECORD_NOT_UNIQUE') {
+			acc.push(`${formatTitle(validationError.field)} ${t('validationError.unique').toLowerCase()}`);
+		} else {
+			acc.push(
+				`${formatTitle(validationError.field)} ${t(
+					`validationError.${validationError.type}`,
+					validationError
+				).toLowerCase()}`
+			);
+		}
 
-			if (errors.length === 0) return [];
+		return acc;
+	}, [] as string[]);
 
-			return errors;
-		});
+	if (errors.length === 0) return [];
 
-		watch(validationMessages, (newVal, oldVal) => {
-			if (!validationMessages.value) return;
-			if (isEqual(newVal, oldVal)) return;
-			detailOpen.value = validationMessages.value.length > 0;
-		});
+	return errors;
+});
 
-		return { t, edited, validationMessages, detailOpen };
-	},
+watch(validationMessages, (newVal, oldVal) => {
+	if (!validationMessages.value) return;
+	if (isEqual(newVal, oldVal)) return;
+	detailOpen.value = validationMessages.value.length > 0;
 });
 </script>
 

--- a/app/src/interfaces/group-raw/group-raw.vue
+++ b/app/src/interfaces/group-raw/group-raw.vue
@@ -5,7 +5,7 @@
 			:fields="fields"
 			:model-value="values"
 			:primary-key="primaryKey"
-			:group="field.meta.field"
+			:group="field.meta?.field"
 			:validation-errors="validationErrors"
 			:loading="loading"
 			:disabled="disabled"
@@ -19,65 +19,30 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { Field, ValidationError } from '@cairncms/types';
-import { defineComponent, PropType } from 'vue';
-export default defineComponent({
-	name: 'InterfaceGroupRaw',
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		fields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		values: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		initialValues: {
-			type: Object as PropType<Record<string, unknown>>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		batchMode: {
-			type: Boolean,
-			default: false,
-		},
-		batchActiveFields: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		primaryKey: {
-			type: [Number, String],
-			required: true,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		validationErrors: {
-			type: Array as PropType<ValidationError[]>,
-			default: () => [],
-		},
-		badge: {
-			type: String,
-			default: null,
-		},
-		rawEditorEnabled: {
-			type: Boolean,
-			default: false,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['apply'],
-});
+
+withDefaults(
+	defineProps<{
+		field: Field;
+		fields: Field[];
+		values: Record<string, unknown>;
+		initialValues: Record<string, unknown>;
+		primaryKey: number | string;
+		disabled?: boolean;
+		batchMode?: boolean;
+		batchActiveFields?: string[];
+		loading?: boolean;
+		validationErrors?: ValidationError[];
+		badge?: string;
+		rawEditorEnabled?: boolean;
+		direction?: string;
+	}>(),
+	{
+		batchActiveFields: () => [],
+		validationErrors: () => [],
+	}
+);
+
+defineEmits(['apply']);
 </script>

--- a/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
+++ b/app/src/interfaces/input-autocomplete-api/input-autocomplete-api.vue
@@ -28,125 +28,89 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, PropType } from 'vue';
-import axios from 'axios';
-import { throttle, get, debounce } from 'lodash';
-import { render } from 'micromustache';
+<script setup lang="ts">
 import api from '@/api';
+import axios from 'axios';
+import { debounce, get, throttle } from 'lodash';
+import { render } from 'micromustache';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: [String, Number],
-			default: null,
-		},
-		url: {
-			type: String,
-			default: null,
-		},
-		resultsPath: {
-			type: String,
-			default: null,
-		},
-		textPath: {
-			type: String,
-			default: null,
-		},
-		valuePath: {
-			type: String,
-			default: null,
-		},
-		trigger: {
-			type: String as PropType<'debounce' | 'throttle'>,
-			default: 'throttle',
-		},
-		rate: {
-			type: [Number, String],
-			default: 500,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		iconLeft: {
-			type: String,
-			default: null,
-		},
-		iconRight: {
-			type: String,
-			default: null,
-		},
-		font: {
-			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,
-			default: 'sans-serif',
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string | number | null;
+		url?: string;
+		resultsPath?: string;
+		textPath?: string;
+		valuePath?: string;
+		trigger?: 'debounce' | 'throttle';
+		rate?: number | string;
+		placeholder?: string;
+		iconLeft?: string;
+		iconRight?: string;
+		font?: 'sans-serif' | 'serif' | 'monospace';
+		disabled?: boolean;
+		direction?: string;
+	}>(),
+	{
+		trigger: 'throttle',
+		rate: 500,
+		font: 'sans-serif',
+	}
+);
 
-		const results = ref<Record<string, any>[]>([]);
+const emit = defineEmits(['input']);
 
-		const fetchResultsRaw = async (value: string | null) => {
-			if (!value) {
-				results.value = [];
-				return;
-			}
+const { t } = useI18n();
 
-			const url = render(props.url, { value });
+const results = ref<Record<string, any>[]>([]);
 
-			try {
-				const result = await (url.startsWith('/') ? api.get(url) : axios.get(url));
-				const resultsArray = props.resultsPath ? get(result.data, props.resultsPath) : result.data;
+const fetchResultsRaw = async (value: string | null) => {
+	if (!value) {
+		results.value = [];
+		return;
+	}
 
-				if (Array.isArray(resultsArray) === false) {
-					// eslint-disable-next-line no-console
-					console.warn(`Expected results type of array, "${typeof resultsArray}" received`);
-					return;
-				}
+	const url = render(props.url!, { value });
 
-				results.value = resultsArray.map((result: Record<string, unknown>) => {
-					if (props.textPath && props.valuePath) {
-						return { text: get(result, props.textPath), value: get(result, props.valuePath) };
-					} else if (props.valuePath) {
-						return { value: get(result, props.valuePath) };
-					} else {
-						return { value: result };
-					}
-				});
-			} catch (err: any) {
-				// eslint-disable-next-line no-console
-				console.warn(err);
-			}
-		};
+	try {
+		const result = await (url.startsWith('/') ? api.get(url) : axios.get(url));
+		const resultsArray = props.resultsPath ? get(result.data, props.resultsPath) : result.data;
 
-		const fetchResults =
-			props.trigger === 'debounce'
-				? debounce(fetchResultsRaw, Number(props.rate))
-				: throttle(fetchResultsRaw, Number(props.rate));
-
-		return { t, results, onInput, emitValue };
-
-		function onInput(value: string) {
-			emitValue(value);
-			fetchResults(value);
+		if (Array.isArray(resultsArray) === false) {
+			// eslint-disable-next-line no-console
+			console.warn(`Expected results type of array, "${typeof resultsArray}" received`);
+			return;
 		}
 
-		function emitValue(value: string) {
-			emit('input', value);
-		}
-	},
-});
+		results.value = resultsArray.map((result: Record<string, unknown>) => {
+			if (props.textPath && props.valuePath) {
+				return { text: get(result, props.textPath), value: get(result, props.valuePath) };
+			} else if (props.valuePath) {
+				return { value: get(result, props.valuePath) };
+			} else {
+				return { value: result };
+			}
+		});
+	} catch (err: any) {
+		// eslint-disable-next-line no-console
+		console.warn(err);
+	}
+};
+
+const fetchResults =
+	props.trigger === 'debounce'
+		? debounce(fetchResultsRaw, Number(props.rate))
+		: throttle(fetchResultsRaw, Number(props.rate));
+
+function onInput(value: string) {
+	emitValue(value);
+	fetchResults(value);
+}
+
+function emitValue(value: string) {
+	emit('input', value);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -8,324 +8,289 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
+import { useWindowSize } from '@/composables/use-window-size';
 import CodeMirror, { ModeSpec } from 'codemirror';
-
-import { defineComponent, computed, ref, onMounted, watch, PropType } from 'vue';
+import { Ref, computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import importCodemirrorMode from './import-codemirror-mode';
 
 import 'codemirror/mode/meta';
-import 'codemirror/addon/search/searchcursor.js';
-import 'codemirror/addon/search/matchesonscrollbar.js';
-import 'codemirror/addon/scroll/annotatescrollbar.js';
-import 'codemirror/addon/lint/lint.js';
-import 'codemirror/addon/search/search.js';
-import 'codemirror/addon/display/placeholder.js';
 
 import 'codemirror/addon/comment/comment.js';
 import 'codemirror/addon/dialog/dialog.js';
+import 'codemirror/addon/display/placeholder.js';
+import 'codemirror/addon/lint/lint.js';
+import 'codemirror/addon/scroll/annotatescrollbar.js';
+import 'codemirror/addon/search/matchesonscrollbar.js';
+import 'codemirror/addon/search/search.js';
+import 'codemirror/addon/search/searchcursor.js';
+
 import 'codemirror/keymap/sublime.js';
 
-import formatTitle from '@cairncms/format-title';
-import importCodemirrorMode from './import-codemirror-mode';
-import { useWindowSize } from '@/composables/use-window-size';
+const props = withDefaults(
+	defineProps<{
+		value?: string | Record<string, unknown> | unknown[] | boolean | number | null;
+		disabled?: boolean;
+		altOptions?: Record<string, any>;
+		template?: string;
+		lineNumber?: boolean;
+		lineWrapping?: boolean;
+		placeholder?: string;
+		language?: string;
+		type?: string;
+	}>(),
+	{
+		lineNumber: true,
+		language: 'plaintext',
+	}
+);
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: [String, Object, Array, Number, Boolean] as PropType<string | Record<string, any> | any[]>,
-			default: null,
-		},
-		altOptions: {
-			type: Object,
-			default: null,
-		},
-		template: {
-			type: String,
-			default: null,
-		},
-		lineNumber: {
-			type: Boolean,
-			default: true,
-		},
-		lineWrapping: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		language: {
-			type: String,
-			default: 'plaintext',
-		},
-		type: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const emit = defineEmits(['input']);
 
-		const { width } = useWindowSize();
+const { t } = useI18n();
 
-		const codemirrorEl = ref<HTMLTextAreaElement | null>(null);
-		let codemirror: CodeMirror.Editor | null;
-		let previousContent: string | null = null;
+const { width } = useWindowSize();
 
-		onMounted(async () => {
-			if (codemirrorEl.value) {
-				await getImports(cmOptions.value);
+const codemirrorEl: Ref<HTMLTextAreaElement | null> = ref(null);
+let codemirror: CodeMirror.Editor | null;
+let previousContent: string | null = null;
 
-				await importCodemirrorMode(cmOptions.value.mode);
+onMounted(async () => {
+	if (codemirrorEl.value) {
+		await getImports(cmOptions.value);
 
-				codemirror = CodeMirror(codemirrorEl.value, {
-					...cmOptions.value,
-					value: stringValue.value,
-				});
+		await importCodemirrorMode(cmOptions.value.mode);
 
-				codemirror.setOption('mode', { name: 'javascript ' });
-
-				await setLanguage();
-
-				codemirror.on('change', (cm, { origin }) => {
-					const content = cm.getValue();
-
-					// prevent duplicate emits with same content
-					if (content === previousContent) return;
-					previousContent = content;
-
-					if (origin === 'setValue') return;
-
-					if (props.type === 'json') {
-						if (content.length === 0) {
-							return emit('input', null);
-						}
-
-						try {
-							const parsedJson = JSON.parse(content);
-							if (typeof parsedJson !== 'string') return emit('input', parsedJson);
-							return emit('input', content);
-						} catch {
-							// We won't stage invalid JSON
-						}
-					} else {
-						emit('input', content);
-					}
-				});
-			}
+		codemirror = CodeMirror(codemirrorEl.value, {
+			...cmOptions.value,
+			value: stringValue.value,
 		});
 
-		const stringValue = computed<string>(() => {
-			if (props.value === null) return '';
+		codemirror.setOption('mode', { name: 'javascript ' });
 
-			if (props.type === 'json' || typeof props.value === 'object') {
-				return JSON.stringify(props.value, null, 4);
-			}
+		await setLanguage();
 
-			return props.value as string;
-		});
+		codemirror.on('change', (cm, { origin }) => {
+			const content = cm.getValue();
 
-		watch(
-			() => props.language,
-			() => {
-				setLanguage();
-			}
-		);
+			// prevent duplicate emits with same content
+			if (content === previousContent) return;
+			previousContent = content;
 
-		watch(stringValue, () => {
-			// prevent setting redundantly stringified json value when it's actually the same value
-			if (props.type === 'json' && codemirror?.getValue() === props.value) return;
+			if (origin === 'setValue') return;
 
-			if (codemirror?.getValue() !== stringValue.value) {
-				codemirror?.setValue(stringValue.value || '');
-			}
-		});
-
-		async function setLanguage() {
-			if (codemirror) {
-				const lang = props.language.toLowerCase();
-
-				if (props.type === 'json' || lang === 'json') {
-					// @ts-ignore
-					await import('codemirror/mode/javascript/javascript.js');
-
-					const jsonlint = (await import('jsonlint-mod')) as any;
-
-					codemirror.setOption('mode', { name: 'javascript', json: true } as ModeSpec<{ json: boolean }>);
-
-					CodeMirror.registerHelper('lint', 'json', (text: string) => {
-						const found: Record<string, any>[] = [];
-						const parser = jsonlint.parser;
-
-						parser.parseError = (str: string, hash: any) => {
-							const loc = hash.loc;
-
-							found.push({
-								from: CodeMirror.Pos(loc.first_line - 1, loc.first_column),
-								to: CodeMirror.Pos(loc.last_line - 1, loc.last_column),
-								message: str,
-							});
-						};
-
-						if (text.length > 0) {
-							try {
-								jsonlint.parse(text);
-							} catch {
-								// Do nothing
-							}
-						}
-
-						return found;
-					});
-				} else if (lang === 'plaintext') {
-					codemirror.setOption('mode', { name: 'plaintext' });
-				} else {
-					await importCodemirrorMode(lang);
-					codemirror.setOption('mode', { name: lang });
-				}
-			}
-		}
-
-		async function getImports(optionsObj: Record<string, any>): Promise<void> {
-			const imports = [] as Promise<any>[];
-
-			if (optionsObj && optionsObj.size > 0) {
-				if (optionsObj.styleActiveLine) {
-					imports.push(import('codemirror/addon/selection/active-line.js'));
-				}
-
-				if (optionsObj.markSelection) {
-					// @ts-ignore - @types/codemirror is missing this export
-					imports.push(import('codemirror/addon/selection/mark-selection.js'));
-				}
-
-				if (optionsObj.highlightSelectionMatches) {
-					imports.push(import('codemirror/addon/search/match-highlighter.js'));
-				}
-
-				if (optionsObj.autoRefresh) {
-					imports.push(import('codemirror/addon/display/autorefresh.js'));
-				}
-
-				if (optionsObj.matchBrackets) {
-					imports.push(import('codemirror/addon/edit/matchbrackets.js'));
-				}
-
-				if (optionsObj.hintOptions || optionsObj.showHint) {
-					imports.push(import('codemirror/addon/hint/show-hint.js'));
-					// @ts-ignore - @types/codemirror is missing this export
-					imports.push(import('codemirror/addon/hint/show-hint.css'));
-					// @ts-ignore - @types/codemirror is missing this export
-					imports.push(import('codemirror/addon/hint/javascript-hint.js'));
-				}
-
-				await Promise.all(imports);
-			}
-		}
-
-		const lineCount = computed(() => {
-			if (codemirror) {
-				return codemirror.lineCount();
-			}
-
-			return 0;
-		});
-
-		const readOnly = computed(() => {
-			if (width.value < 600) {
-				// mobile requires 'nocursor' to avoid bringing up the keyboard
-				return props.disabled ? 'nocursor' : false;
-			} else {
-				// desktop cannot use 'nocursor' as it prevents copy/paste
-				return props.disabled;
-			}
-		});
-
-		const defaultOptions: CodeMirror.EditorConfiguration = {
-			tabSize: 4,
-			autoRefresh: true,
-			indentUnit: 4,
-			styleActiveLine: true,
-			highlightSelectionMatches: { showToken: /\w/, annotateScrollbar: true, delay: 100 },
-			hintOptions: {
-				completeSingle: true,
-				hint: () => undefined,
-			},
-			matchBrackets: true,
-			showCursorWhenSelecting: true,
-			lineWiseCopyCut: false,
-			theme: 'default',
-			extraKeys: { Ctrl: 'autocomplete' },
-			lint: true,
-			gutters: ['CodeMirror-lint-markers'],
-		};
-
-		const cmOptions = computed<Record<string, any>>(() => {
-			return Object.assign(
-				{},
-				defaultOptions,
-				{
-					lineNumbers: props.lineNumber,
-					lineWrapping: props.lineWrapping,
-					readOnly: readOnly.value,
-					cursorBlinkRate: props.disabled ? -1 : 530,
-					mode: props.language,
-					placeholder: props.placeholder,
-				},
-				props.altOptions ? props.altOptions : {}
-			);
-		});
-
-		watch(
-			() => props.disabled,
-			(disabled) => {
-				codemirror?.setOption('readOnly', readOnly.value);
-				codemirror?.setOption('cursorBlinkRate', disabled ? -1 : 530);
-			},
-			{ immediate: true }
-		);
-
-		watch(
-			() => props.altOptions,
-			async (altOptions) => {
-				if (!altOptions || altOptions.size === 0) return;
-				await getImports(altOptions);
-
-				for (const key in altOptions) {
-					codemirror?.setOption(key as any, altOptions[key]);
-				}
-			}
-		);
-
-		watch(
-			() => props.lineNumber,
-			(lineNumber) => {
-				codemirror?.setOption('lineNumbers', lineNumber);
-			}
-		);
-
-		return { t, cmOptions, lineCount, codemirrorEl, stringValue, fillTemplate, formatTitle };
-
-		function fillTemplate() {
 			if (props.type === 'json') {
+				if (content.length === 0) {
+					return emit('input', null);
+				}
+
 				try {
-					emit('input', JSON.parse(props.template));
-				} finally {
-					// Do nothing
+					const parsedJson = JSON.parse(content);
+					if (typeof parsedJson !== 'string') return emit('input', parsedJson);
+					return emit('input', content);
+				} catch {
+					// We won't stage invalid JSON
 				}
 			} else {
-				emit('input', props.template);
+				emit('input', content);
 			}
-		}
-	},
+		});
+	}
 });
+
+const stringValue = computed(() => {
+	if (props.value === null || props.value === undefined) return '';
+
+	if (props.type === 'json' || typeof props.value === 'object') {
+		return JSON.stringify(props.value, null, 4);
+	}
+
+	return props.value as string;
+});
+
+watch(
+	() => props.language,
+	() => {
+		setLanguage();
+	}
+);
+
+watch(stringValue, () => {
+	// prevent setting redundantly stringified json value when it's actually the same value
+	if (props.type === 'json' && codemirror?.getValue() === props.value) return;
+
+	if (codemirror?.getValue() !== stringValue.value) {
+		codemirror?.setValue(stringValue.value || '');
+	}
+});
+
+async function setLanguage() {
+	if (codemirror) {
+		const lang = props.language.toLowerCase();
+
+		if (props.type === 'json' || lang === 'json') {
+			// @ts-ignore
+			await import('codemirror/mode/javascript/javascript.js');
+
+			const jsonlint = (await import('jsonlint-mod')) as any;
+
+			codemirror.setOption('mode', { name: 'javascript', json: true } as ModeSpec<{ json: boolean }>);
+
+			CodeMirror.registerHelper('lint', 'json', (text: string) => {
+				const found: Record<string, any>[] = [];
+				const parser = jsonlint.parser;
+
+				parser.parseError = (str: string, hash: any) => {
+					const loc = hash.loc;
+
+					found.push({
+						from: CodeMirror.Pos(loc.first_line - 1, loc.first_column),
+						to: CodeMirror.Pos(loc.last_line - 1, loc.last_column),
+						message: str,
+					});
+				};
+
+				if (text.length > 0) {
+					try {
+						jsonlint.parse(text);
+					} catch {
+						// Do nothing
+					}
+				}
+
+				return found;
+			});
+		} else if (lang === 'plaintext') {
+			codemirror.setOption('mode', { name: 'plaintext' });
+		} else {
+			await importCodemirrorMode(lang);
+			codemirror.setOption('mode', { name: lang });
+		}
+	}
+}
+
+async function getImports(optionsObj: Record<string, any>): Promise<void> {
+	const imports = [] as Promise<any>[];
+
+	if (optionsObj && optionsObj.size > 0) {
+		if (optionsObj.styleActiveLine) {
+			imports.push(import('codemirror/addon/selection/active-line.js'));
+		}
+
+		if (optionsObj.markSelection) {
+			// @ts-ignore - @types/codemirror is missing this export
+			imports.push(import('codemirror/addon/selection/mark-selection.js'));
+		}
+
+		if (optionsObj.highlightSelectionMatches) {
+			imports.push(import('codemirror/addon/search/match-highlighter.js'));
+		}
+
+		if (optionsObj.autoRefresh) {
+			imports.push(import('codemirror/addon/display/autorefresh.js'));
+		}
+
+		if (optionsObj.matchBrackets) {
+			imports.push(import('codemirror/addon/edit/matchbrackets.js'));
+		}
+
+		if (optionsObj.hintOptions || optionsObj.showHint) {
+			imports.push(import('codemirror/addon/hint/show-hint.js'));
+			// @ts-ignore - @types/codemirror is missing this export
+			imports.push(import('codemirror/addon/hint/show-hint.css'));
+			// @ts-ignore - @types/codemirror is missing this export
+			imports.push(import('codemirror/addon/hint/javascript-hint.js'));
+		}
+
+		await Promise.all(imports);
+	}
+}
+
+const readOnly = computed(() => {
+	if (width.value < 600) {
+		// mobile requires 'nocursor' to avoid bringing up the keyboard
+		return props.disabled ? 'nocursor' : false;
+	} else {
+		// desktop cannot use 'nocursor' as it prevents copy/paste
+		return props.disabled;
+	}
+});
+
+const defaultOptions: CodeMirror.EditorConfiguration = {
+	tabSize: 4,
+	autoRefresh: true,
+	indentUnit: 4,
+	styleActiveLine: true,
+	highlightSelectionMatches: { showToken: /\w/, annotateScrollbar: true, delay: 100 },
+	hintOptions: {
+		completeSingle: true,
+		hint: () => undefined,
+	},
+	matchBrackets: true,
+	showCursorWhenSelecting: true,
+	lineWiseCopyCut: false,
+	theme: 'default',
+	extraKeys: { Ctrl: 'autocomplete' },
+	lint: true,
+	gutters: ['CodeMirror-lint-markers'],
+};
+
+const cmOptions = computed<Record<string, any>>(() => {
+	return Object.assign(
+		{},
+		defaultOptions,
+		{
+			lineNumbers: props.lineNumber,
+			lineWrapping: props.lineWrapping,
+			readOnly: readOnly.value,
+			cursorBlinkRate: props.disabled ? -1 : 530,
+			mode: props.language,
+			placeholder: props.placeholder,
+		},
+		props.altOptions ? props.altOptions : {}
+	);
+});
+
+watch(
+	() => props.disabled,
+	(disabled) => {
+		codemirror?.setOption('readOnly', readOnly.value);
+		codemirror?.setOption('cursorBlinkRate', disabled ? -1 : 530);
+	},
+	{ immediate: true }
+);
+
+watch(
+	() => props.altOptions,
+	async (altOptions) => {
+		if (!altOptions || altOptions.size === 0) return;
+		await getImports(altOptions);
+
+		for (const key in altOptions) {
+			codemirror?.setOption(key as any, altOptions[key]);
+		}
+	}
+);
+
+watch(
+	() => props.lineNumber,
+	(lineNumber) => {
+		codemirror?.setOption('lineNumbers', lineNumber);
+	}
+);
+
+function fillTemplate() {
+	if (props.type === 'json') {
+		try {
+			emit('input', JSON.parse(props.template));
+		} finally {
+			// Do nothing
+		}
+	} else {
+		emit('input', props.template);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -15,56 +15,47 @@
 </template>
 
 <script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref, watch } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
 	inheritAttrs: false,
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		masked: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const isHashed = ref(false);
-		const localValue = ref<string | null>(null);
-
-		const internalPlaceholder = computed(() => {
-			return isHashed.value ? t('value_hashed') : props.placeholder;
-		});
-
-		watch(
-			() => props.value,
-			() => {
-				isHashed.value = !!(props.value && props.value.length > 0);
-			},
-			{ immediate: true }
-		);
-
-		return { internalPlaceholder, isHashed, localValue, emitValue };
-
-		function emitValue(newValue: string) {
-			emit('input', newValue);
-			localValue.value = newValue;
-		}
-	},
 });
+</script>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+	value: string | null;
+	disabled?: boolean;
+	placeholder?: string;
+	masked?: boolean;
+}>();
+
+const emit = defineEmits(['input']);
+
+const { t } = useI18n();
+
+const isHashed = ref(false);
+const localValue = ref<string | null>(null);
+
+const internalPlaceholder = computed(() => {
+	return isHashed.value ? t('value_hashed') : props.placeholder;
+});
+
+watch(
+	() => props.value,
+	() => {
+		isHashed.value = !!(props.value && props.value.length > 0);
+	},
+	{ immediate: true }
+);
+
+function emitValue(newValue: string) {
+	emit('input', newValue);
+	localValue.value = newValue;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/input-multiline/input-multiline.vue
+++ b/app/src/interfaces/input-multiline/input-multiline.vue
@@ -13,8 +13,8 @@
 				v-if="(percentageRemaining && percentageRemaining <= 20) || softLength"
 				class="remaining"
 				:class="{
-					warning: percentageRemaining < 10,
-					danger: percentageRemaining < 5,
+					warning: percentageRemaining! < 10,
+					danger: percentageRemaining! < 5,
 				}"
 			>
 				{{ charsRemaining }}
@@ -23,72 +23,46 @@
 	</v-textarea>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		clear: {
-			type: Boolean,
-			default: false,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		trim: {
-			type: Boolean,
-			default: false,
-		},
-		font: {
-			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,
-			default: 'sans-serif',
-		},
-		softLength: {
-			type: Number,
-			default: undefined,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const charsRemaining = computed(() => {
-			if (typeof props.value === 'number') return null;
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		clear?: boolean;
+		disabled?: boolean;
+		placeholder?: string;
+		trim?: boolean;
+		font?: 'sans-serif' | 'serif' | 'monospace';
+		softLength?: number;
+		direction?: string;
+	}>(),
+	{
+		font: 'sans-serif',
+	}
+);
 
-			if (!props.softLength) return null;
-			if (!props.value && props.softLength) return props.softLength;
-			const realValue = props.value.replaceAll('\n', ' ').length;
+defineEmits(['input']);
 
-			if (props.softLength) return +props.softLength - realValue;
-			return null;
-		});
+const charsRemaining = computed(() => {
+	if (typeof props.value === 'number') return null;
 
-		const percentageRemaining = computed(() => {
-			if (typeof props.value === 'number') return null;
+	if (!props.softLength) return null;
+	if (!props.value && props.softLength) return props.softLength;
+	const realValue = props.value!.replaceAll('\n', ' ').length;
 
-			if (!props.softLength) return null;
-			if (!props.value) return 100;
+	if (props.softLength) return +props.softLength - realValue;
+	return null;
+});
 
-			if (props.softLength) return 100 - (props.value.length / +props.softLength) * 100;
-			return 100;
-		});
+const percentageRemaining = computed(() => {
+	if (typeof props.value === 'number') return null;
 
-		return {
-			charsRemaining,
-			percentageRemaining,
-		};
-	},
+	if (!props.softLength) return null;
+	if (!props.value) return 100;
+
+	if (props.softLength) return 100 - (props.value.length / +props.softLength) * 100;
+	return 100;
 });
 </script>
 

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -173,22 +173,23 @@
 	</div>
 </template>
 
-<script lang="ts">
-import Editor from '@tinymce/tinymce-vue';
+<script setup lang="ts">
+import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
-import { ComponentPublicInstance, computed, defineComponent, PropType, ref, toRefs, watch } from 'vue';
+import { SettingsStorageAssetPreset } from '@cairncms/types';
+import Editor from '@tinymce/tinymce-vue';
+import { ComponentPublicInstance, computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import getEditorStyles from './get-editor-styles';
 import useImage from './useImage';
 import useLink from './useLink';
 import useMedia from './useMedia';
 import useSourceCode from './useSourceCode';
-import { useSettingsStore } from '@/stores/settings';
-import { SettingsStorageAssetPreset } from '@cairncms/types';
 
 import 'tinymce/tinymce';
+
+import 'tinymce/icons/default';
 import 'tinymce/models/dom';
-import 'tinymce/themes/silver';
 import 'tinymce/plugins/autoresize/plugin';
 import 'tinymce/plugins/code/plugin';
 import 'tinymce/plugins/directionality/plugin';
@@ -201,7 +202,7 @@ import 'tinymce/plugins/media/plugin';
 import 'tinymce/plugins/pagebreak/plugin';
 import 'tinymce/plugins/preview/plugin';
 import 'tinymce/plugins/table/plugin';
-import 'tinymce/icons/default';
+import 'tinymce/themes/silver';
 
 type CustomFormat = {
 	title: string;
@@ -211,328 +212,257 @@ type CustomFormat = {
 	attributes: Record<string, string>;
 };
 
-export default defineComponent({
-	components: { Editor },
-	props: {
-		value: {
-			type: String,
-			default: '',
-		},
-		field: {
-			type: String,
-			default: '',
-		},
-		toolbar: {
-			type: Array as PropType<string[] | null>,
-			default: () => [
-				'bold',
-				'italic',
-				'underline',
-				'h1',
-				'h2',
-				'h3',
-				'numlist',
-				'bullist',
-				'removeformat',
-				'blockquote',
-				'customLink',
-				'customImage',
-				'customMedia',
-				'code',
-				'fullscreen',
-			],
-		},
-		font: {
-			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,
-			default: 'sans-serif',
-		},
-		customFormats: {
-			type: Array as PropType<CustomFormat[]>,
-			default: () => [],
-		},
-		tinymceOverrides: {
-			type: Object,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: true,
-		},
-		imageToken: {
-			type: String,
-			default: undefined,
-		},
-		folder: {
-			type: String,
-			default: undefined,
-		},
-		softLength: {
-			type: Number,
-			default: undefined,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
+const props = withDefaults(
+	defineProps<{
+		value: string | null;
+		field?: string;
+		toolbar?: string[];
+		font?: 'sans-serif' | 'serif' | 'monospace';
+		customFormats?: CustomFormat[];
+		tinymceOverrides?: Record<string, unknown>;
+		disabled?: boolean;
+		imageToken?: string;
+		folder?: string;
+		softLength?: number;
+		direction?: string;
+	}>(),
+	{
+		toolbar: () => [
+			'bold',
+			'italic',
+			'underline',
+			'h1',
+			'h2',
+			'h3',
+			'numlist',
+			'bullist',
+			'removeformat',
+			'blockquote',
+			'customLink',
+			'customImage',
+			'customMedia',
+			'code',
+			'fullscreen',
+		],
+		font: 'sans-serif',
+		customFormats: () => [],
+		disabled: true,
+	}
+);
+
+const emit = defineEmits(['input']);
+
+const { t } = useI18n();
+const editorRef = ref<any | null>(null);
+const editorElement = ref<ComponentPublicInstance | null>(null);
+const { imageToken } = toRefs(props);
+const settingsStore = useSettingsStore();
+
+let storageAssetTransform = ref('all');
+let storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
+
+if (settingsStore.settings?.storage_asset_transform) {
+	storageAssetTransform.value = settingsStore.settings.storage_asset_transform;
+	storageAssetPresets.value = settingsStore.settings.storage_asset_presets ?? [];
+}
+
+let count = ref(0);
+
+const { imageDrawerOpen, imageSelection, closeImageDrawer, onImageSelect, saveImage, imageButton } = useImage(
+	editorRef,
+	imageToken!,
+	{
+		storageAssetTransform,
+		storageAssetPresets,
+	}
+);
+
+const {
+	mediaDrawerOpen,
+	mediaSelection,
+	closeMediaDrawer,
+	openMediaTab,
+	onMediaSelect,
+	embed,
+	saveMedia,
+	mediaHeight,
+	mediaWidth,
+	mediaSource,
+	mediaButton,
+} = useMedia(editorRef, imageToken!);
+
+const { linkButton, linkDrawerOpen, closeLinkDrawer, saveLink, linkSelection, linkNode } = useLink(editorRef);
+
+const { codeDrawerOpen, code, closeCodeDrawer, saveCode, sourceCodeButton } = useSourceCode(editorRef);
+
+const internalValue = computed({
+	get() {
+		return props.value || '';
 	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-		const editorRef = ref<any | null>(null);
-		const editorElement = ref<ComponentPublicInstance | null>(null);
-		const { imageToken } = toRefs(props);
-		const settingsStore = useSettingsStore();
-
-		let storageAssetTransform = ref('all');
-		let storageAssetPresets = ref<SettingsStorageAssetPreset[]>([]);
-
-		if (settingsStore.settings?.storage_asset_transform) {
-			storageAssetTransform.value = settingsStore.settings.storage_asset_transform;
-			storageAssetPresets.value = settingsStore.settings.storage_asset_presets ?? [];
-		}
-
-		let count = ref(0);
-
-		const { imageDrawerOpen, imageSelection, closeImageDrawer, onImageSelect, saveImage, imageButton } = useImage(
-			editorRef,
-			imageToken,
-			{
-				storageAssetTransform,
-				storageAssetPresets,
-			}
-		);
-
-		const {
-			mediaDrawerOpen,
-			mediaSelection,
-			closeMediaDrawer,
-			openMediaTab,
-			onMediaSelect,
-			embed,
-			saveMedia,
-			mediaHeight,
-			mediaWidth,
-			mediaSource,
-			mediaButton,
-		} = useMedia(editorRef, imageToken);
-
-		const { linkButton, linkDrawerOpen, closeLinkDrawer, saveLink, linkSelection, linkNode } = useLink(editorRef);
-
-		const { codeDrawerOpen, code, closeCodeDrawer, saveCode, sourceCodeButton } = useSourceCode(editorRef);
-
-		const internalValue = computed({
-			get() {
-				return props.value || '';
-			},
-			set(value) {
-				if (props.value !== value) {
-					contentUpdated();
-				}
-
-				return;
-			},
-		});
-
-		watch(
-			() => [props.direction, editorRef],
-			() => {
-				if (editorRef.value) {
-					if (props.direction === 'rtl') {
-						editorRef.value.editorCommands?.commands?.exec?.mcedirectionrtl();
-					} else {
-						editorRef.value.editorCommands?.commands?.exec?.mcedirectionltr();
-					}
-				}
-			}
-		);
-
-		const editorOptions = computed(() => {
-			let styleFormats = null;
-
-			if (Array.isArray(props.customFormats) && props.customFormats.length > 0) {
-				styleFormats = props.customFormats;
-			}
-
-			let toolbarString = (props.toolbar ?? [])
-				.map((t) =>
-					t
-						.replace(/^link$/g, 'customLink')
-						.replace(/^media$/g, 'customMedia')
-						.replace(/^code$/g, 'customCode')
-						.replace(/^image$/g, 'customImage')
-				)
-				.join(' ');
-
-			if (styleFormats) {
-				toolbarString += ' styles';
-			}
-
-			return {
-				skin: false,
-				content_css: false,
-				content_style: getEditorStyles(props.font as 'sans-serif' | 'serif' | 'monospace'),
-				plugins: [
-					'media',
-					'table',
-					'lists',
-					'image',
-					'link',
-					'pagebreak',
-					'code',
-					'insertdatetime',
-					'autoresize',
-					'preview',
-					'fullscreen',
-					'directionality',
-				],
-				branding: false,
-				max_height: 1000,
-				elementpath: false,
-				statusbar: false,
-				menubar: false,
-				convert_urls: false,
-				image_dimensions: false,
-				extended_valid_elements: 'audio[loop|controls],source[src|type]',
-				toolbar: toolbarString,
-				style_formats: styleFormats,
-				file_picker_types: 'customImage customMedia image media',
-				link_default_protocol: 'https',
-				browser_spellcheck: true,
-				directionality: props.direction,
-				paste_data_images: false,
-				setup,
-				...(props.tinymceOverrides || {}),
-			};
-		});
-
-		const percRemaining = computed(() => percentage(count.value, props.softLength) ?? 100);
-
-		let observer: MutationObserver;
-		let emittedValue: any;
-
-		return {
-			t,
-			percRemaining,
-			count,
-			editorElement,
-			editorOptions,
-			internalValue,
-			setFocus,
-			onImageSelect,
-			saveImage,
-			imageDrawerOpen,
-			closeImageDrawer,
-			imageSelection,
-			mediaDrawerOpen,
-			mediaSelection,
-			closeMediaDrawer,
-			openMediaTab,
-			embed,
-			onMediaSelect,
-			saveMedia,
-			mediaHeight,
-			mediaWidth,
-			mediaSource,
-			linkButton,
-			linkDrawerOpen,
-			closeLinkDrawer,
-			saveLink,
-			linkSelection,
-			linkNode,
-			codeDrawerOpen,
-			code,
-			closeCodeDrawer,
-			saveCode,
-			sourceCodeButton,
-			setupContentWatcher,
-			setCount,
-			contentUpdated,
-			storageAssetTransform,
-			storageAssetPresets,
-		};
-
-		function setCount() {
-			const iframeContents = editorRef.value?.contentWindow.document.getElementById('tinymce');
-			count.value = iframeContents?.textContent?.replace('\n', '')?.length ?? 0;
-		}
-
-		function contentUpdated() {
-			setCount();
-
-			if (!observer) return;
-
-			const newValue = editorRef.value.getContent() ? editorRef.value.getContent() : null;
-
-			if (newValue === emittedValue) return;
-
-			emittedValue = newValue;
-			emit('input', newValue);
-		}
-
-		function setupContentWatcher() {
-			if (observer) return;
-
-			const iframeContents = editorRef.value.contentWindow.document.getElementById('tinymce');
-
-			observer = new MutationObserver((_mutations) => {
-				contentUpdated();
-			});
-
-			const config = { characterData: true, childList: true, subtree: true };
-			observer.observe(iframeContents, config);
-		}
-
-		function setup(editor: any) {
-			editorRef.value = editor;
-
-			editor.ui.registry.addToggleButton('customImage', imageButton);
-			editor.ui.registry.addToggleButton('customMedia', mediaButton);
-			editor.ui.registry.addToggleButton('customLink', linkButton);
-			editor.ui.registry.addButton('customCode', sourceCodeButton);
-
-			editor.on('init', function () {
-				editor.shortcuts.remove('meta+k');
-
-				editor.addShortcut('meta+k', 'Insert Link', () => {
-					editor.ui.registry.getAll().buttons.customlink.onAction();
-				});
-
-				setCount();
-			});
-
-			editor.on('OpenWindow', function (e: any) {
-				if (e.dialog?.getData) {
-					const data = e.dialog?.getData();
-
-					if (data) {
-						if (data.url) {
-							e.dialog.close();
-							editor.ui.registry.getAll().buttons.customlink.onAction();
-						}
-
-						if (data.src) {
-							e.dialog.close();
-							editor.ui.registry.getAll().buttons.customimage.onAction(true);
-						}
-					}
-				}
-			});
-		}
-
-		function setFocus(val: boolean) {
-			if (editorElement.value == null) return;
-			const body = editorElement.value.$el.parentElement?.querySelector('.tox-tinymce');
-
-			if (body == null) return;
-
-			if (val) {
-				body.classList.add('focus');
-			} else {
-				body.classList.remove('focus');
-			}
+	set(value) {
+		if (props.value !== value) {
+			contentUpdated();
 		}
 	},
 });
+
+watch(
+	() => [props.direction, editorRef],
+	() => {
+		if (editorRef.value) {
+			if (props.direction === 'rtl') {
+				editorRef.value.editorCommands?.commands?.exec?.mcedirectionrtl();
+			} else {
+				editorRef.value.editorCommands?.commands?.exec?.mcedirectionltr();
+			}
+		}
+	}
+);
+
+const editorOptions = computed(() => {
+	let styleFormats = null;
+
+	if (Array.isArray(props.customFormats) && props.customFormats.length > 0) {
+		styleFormats = props.customFormats;
+	}
+
+	let toolbarString = (props.toolbar ?? [])
+		.map((t) =>
+			t
+				.replace(/^link$/g, 'customLink')
+				.replace(/^media$/g, 'customMedia')
+				.replace(/^code$/g, 'customCode')
+				.replace(/^image$/g, 'customImage')
+		)
+		.join(' ');
+
+	if (styleFormats) {
+		toolbarString += ' styles';
+	}
+
+	return {
+		skin: false,
+		content_css: false,
+		content_style: getEditorStyles(props.font as 'sans-serif' | 'serif' | 'monospace'),
+		plugins: [
+			'media',
+			'table',
+			'lists',
+			'image',
+			'link',
+			'pagebreak',
+			'code',
+			'insertdatetime',
+			'autoresize',
+			'preview',
+			'fullscreen',
+			'directionality',
+		],
+		branding: false,
+		max_height: 1000,
+		elementpath: false,
+		statusbar: false,
+		menubar: false,
+		convert_urls: false,
+		image_dimensions: false,
+		extended_valid_elements: 'audio[loop|controls],source[src|type]',
+		toolbar: toolbarString,
+		style_formats: styleFormats,
+		file_picker_types: 'customImage customMedia image media',
+		link_default_protocol: 'https',
+		browser_spellcheck: true,
+		directionality: props.direction,
+		paste_data_images: false,
+		setup,
+		...(props.tinymceOverrides || {}),
+	};
+});
+
+const percRemaining = computed(() => percentage(count.value, props.softLength) ?? 100);
+
+let observer: MutationObserver;
+let emittedValue: any;
+
+function setCount() {
+	const iframeContents = editorRef.value?.contentWindow.document.getElementById('tinymce');
+	count.value = iframeContents?.textContent?.replace('\n', '')?.length ?? 0;
+}
+
+function contentUpdated() {
+	setCount();
+
+	if (!observer) return;
+
+	const newValue = editorRef.value.getContent() ? editorRef.value.getContent() : null;
+
+	if (newValue === emittedValue) return;
+
+	emittedValue = newValue;
+	emit('input', newValue);
+}
+
+function setupContentWatcher() {
+	if (observer) return;
+
+	const iframeContents = editorRef.value.contentWindow.document.getElementById('tinymce');
+
+	observer = new MutationObserver((_mutations) => {
+		contentUpdated();
+	});
+
+	const config = { characterData: true, childList: true, subtree: true };
+	observer.observe(iframeContents, config);
+}
+
+function setup(editor: any) {
+	editorRef.value = editor;
+
+	editor.ui.registry.addToggleButton('customImage', imageButton);
+	editor.ui.registry.addToggleButton('customMedia', mediaButton);
+	editor.ui.registry.addToggleButton('customLink', linkButton);
+	editor.ui.registry.addButton('customCode', sourceCodeButton);
+
+	editor.on('init', function () {
+		editor.shortcuts.remove('meta+k');
+
+		editor.addShortcut('meta+k', 'Insert Link', () => {
+			editor.ui.registry.getAll().buttons.customlink.onAction();
+		});
+
+		setCount();
+	});
+
+	editor.on('OpenWindow', function (e: any) {
+		if (e.dialog?.getData) {
+			const data = e.dialog?.getData();
+
+			if (data) {
+				if (data.url) {
+					e.dialog.close();
+					editor.ui.registry.getAll().buttons.customlink.onAction();
+				}
+
+				if (data.src) {
+					e.dialog.close();
+					editor.ui.registry.getAll().buttons.customimage.onAction(true);
+				}
+			}
+		}
+	});
+}
+
+function setFocus(val: boolean) {
+	if (editorElement.value == null) return;
+	const body = editorElement.value.$el.parentElement?.querySelector('.tox-tinymce');
+
+	if (body == null) return;
+
+	if (val) {
+		body.classList.add('focus');
+	} else {
+		body.classList.remove('focus');
+	}
+}
 </script>
 
 <style lang="scss">

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -23,8 +23,8 @@
 			</span>
 		</template>
 		<v-dialog v-model="linkDrawerOpen">
-			<v-card class="card">
-				<v-card-title class="card-title">{{ t('wysiwyg_options.link') }}</v-card-title>
+			<v-card>
+				<v-card-title>{{ t('wysiwyg_options.link') }}</v-card-title>
 				<v-card-text>
 					<div class="grid">
 						<div class="field">
@@ -583,14 +583,5 @@ export default defineComponent({
 	padding: var(--content-padding);
 	padding-top: 0;
 	padding-bottom: var(--content-padding);
-}
-
-.card {
-	overflow: auto;
-
-	.card-title {
-		margin-bottom: 24px;
-		font-size: 24px;
-	}
 }
 </style>

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -23,8 +23,8 @@
 				v-if="(percentageRemaining !== null && percentageRemaining <= 20) || softLength"
 				class="remaining"
 				:class="{
-					warning: percentageRemaining < 10,
-					danger: percentageRemaining < 5,
+					warning: percentageRemaining! < 10,
+					danger: percentageRemaining! < 5,
 				}"
 			>
 				{{ charsRemaining }}
@@ -34,122 +34,66 @@
 	</v-input>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: [String, Number],
-			default: null,
-		},
-		type: {
-			type: String,
-			default: null,
-		},
-		clear: {
-			type: Boolean,
-			default: false,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		masked: {
-			type: Boolean,
-			default: false,
-		},
-		iconLeft: {
-			type: String,
-			default: null,
-		},
-		iconRight: {
-			type: String,
-			default: null,
-		},
-		trim: {
-			type: Boolean,
-			default: false,
-		},
-		font: {
-			type: String as PropType<'sans-serif' | 'serif' | 'monospace'>,
-			default: 'sans-serif',
-		},
-		length: {
-			type: Number,
-			default: null,
-		},
-		softLength: {
-			type: Number,
-			default: undefined,
-		},
-		dbSafe: {
-			type: Boolean,
-			default: false,
-		},
-		autofocus: {
-			type: Boolean,
-			default: false,
-		},
+const props = withDefaults(
+	defineProps<{
+		value: string | number | null;
+		type?: string;
+		clear?: boolean;
+		disabled?: boolean;
+		placeholder?: string;
+		masked?: boolean;
+		iconLeft?: string;
+		iconRight?: string;
+		trim?: boolean;
+		font?: 'sans-serif' | 'serif' | 'monospace';
+		length?: number;
+		softLength?: number;
+		dbSafe?: boolean;
+		autofocus?: boolean;
+		slug?: boolean;
+		min?: number;
+		max?: number;
+		step?: number;
+		direction?: string;
+	}>(),
+	{
+		font: 'sans-serif',
+		step: 1,
+	}
+);
 
-		slug: {
-			type: Boolean,
-			default: false,
-		},
-		min: {
-			type: Number,
-			default: undefined,
-		},
-		max: {
-			type: Number,
-			default: undefined,
-		},
-		step: {
-			type: Number,
-			default: 1,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['input'],
-	setup(props) {
-		const charsRemaining = computed(() => {
-			if (typeof props.value === 'number') return null;
+defineEmits(['input']);
 
-			if (!props.length && !props.softLength) return null;
-			if (!props.value && !props.softLength) return null;
-			if (!props.value && props.softLength) return props.softLength;
-			if (props.softLength) return +props.softLength - props.value.length;
-			if (props.length) return +props.length - props.value.length;
-			return null;
-		});
+const charsRemaining = computed(() => {
+	if (typeof props.value === 'number') return null;
 
-		const percentageRemaining = computed(() => {
-			if (typeof props.value === 'number') return null;
+	if (!props.length && !props.softLength) return null;
+	if (!props.value && !props.softLength) return null;
+	if (!props.value && props.softLength) return props.softLength;
+	if (props.softLength) return +props.softLength - props.value!.length;
+	if (props.length) return +props.length - props.value!.length;
+	return null;
+});
 
-			if (!props.length && !props.softLength) return null;
-			if (!props.value) return 100;
+const percentageRemaining = computed(() => {
+	if (typeof props.value === 'number') return null;
 
-			if (props.softLength) return 100 - (props.value.length / +props.softLength) * 100;
-			if (props.length) return 100 - (props.value.length / +props.length) * 100;
+	if (!props.length && !props.softLength) return null;
+	if (!props.value) return 100;
 
-			return 100;
-		});
+	if (props.softLength) return 100 - (props.value.length / +props.softLength) * 100;
+	if (props.length) return 100 - (props.value.length / +props.length) * 100;
 
-		const inputType = computed(() => {
-			if (props.masked) return 'password';
-			if (['bigInteger', 'integer', 'float', 'decimal'].includes(props.type)) return 'number';
-			return 'text';
-		});
+	return 100;
+});
 
-		return { inputType, charsRemaining, percentageRemaining };
-	},
+const inputType = computed(() => {
+	if (props.masked) return 'password';
+	if (['bigInteger', 'integer', 'float', 'decimal'].includes(props.type!)) return 'number';
+	return 'text';
 });
 </script>
 

--- a/app/src/interfaces/list-m2a/list-m2a.vue
+++ b/app/src/interfaces/list-m2a/list-m2a.vue
@@ -117,7 +117,7 @@
 			:active="!!selectingFrom"
 			:collection="selectingFrom"
 			:filter="customFilter"
-			@input="select($event, selectingFrom ?? undefined)"
+			@input="select($event!, selectingFrom ?? undefined)"
 			@update:active="selectingFrom = null"
 		/>
 
@@ -380,10 +380,15 @@ function getCollectionName(item: DisplayItem) {
 	if (!info) return false;
 
 	const collection = allowedCollections.value.find((coll) => coll.collection === item[info.collectionField.field]);
-	if (te(`collection_names_singular.${collection?.collection}`))
+
+	if (te(`collection_names_singular.${collection?.collection}`)) {
 		return t(`collection_names_singular.${collection?.collection}`);
-	if (te(`collection_names_plural.${collection?.collection}`))
+	}
+
+	if (te(`collection_names_plural.${collection?.collection}`)) {
 		return t(`collection_names_plural.${collection?.collection}`);
+	}
+
 	return collection?.name;
 }
 
@@ -398,7 +403,7 @@ const customFilter = computed(() => {
 
 	const reverseRelation = `$FOLLOW(${info.junctionCollection.collection},${info.junctionField.field},${info.collectionField.field})`;
 
-	const selectFilter: Filter = {
+	const selectFilter = {
 		[reverseRelation]: {
 			_none: {
 				_and: [
@@ -415,7 +420,7 @@ const customFilter = computed(() => {
 				],
 			},
 		},
-	};
+	} as Filter;
 
 	const junctionField = info.junctionField.field;
 
@@ -425,12 +430,13 @@ const customFilter = computed(() => {
 		return acc;
 	}, [] as (string | number)[]);
 
-	if (selectedPrimaryKeys.length > 0)
+	if (selectedPrimaryKeys.length > 0) {
 		filter._and.push({
 			[info.relationPrimaryKeyFields[selectingFrom.value].field]: {
 				_nin: selectedPrimaryKeys,
 			},
 		});
+	}
 
 	if (props.primaryKey !== '+') filter._and.push(selectFilter);
 

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -72,7 +72,7 @@
 					<router-link
 						v-if="enableLink"
 						v-tooltip="t('navigate_to_item')"
-						:to="getLinkForItem(item)"
+						:to="getLinkForItem(item)!"
 						class="item-link"
 						:class="{ disabled: item.$type === 'created' }"
 					>
@@ -131,7 +131,7 @@
 							<router-link
 								v-if="enableLink"
 								v-tooltip="t('navigate_to_item')"
-								:to="getLinkForItem(element)"
+								:to="getLinkForItem(element)!"
 								class="item-link"
 								:class="{ disabled: element.$type === 'created' }"
 								@click.stop
@@ -201,26 +201,26 @@
 </template>
 
 <script setup lang="ts">
+import { Sort } from '@/components/v-table/types';
 import { useRelationM2M } from '@/composables/use-relation-m2m';
-import { useRelationMultiple, RelationQueryMultiple, DisplayItem } from '@/composables/use-relation-multiple';
+import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
+import { useRelationPermissionsM2M } from '@/composables/use-relation-permissions';
+import { useFieldsStore } from '@/stores/fields';
+import { LAYOUTS } from '@/types/interfaces';
+import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
+import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
 import { parseFilter } from '@/utils/parse-filter';
+import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
+import SearchInput from '@/views/private/components/search-input.vue';
 import { Filter } from '@cairncms/types';
 import { deepMap, getFieldsFromTemplate } from '@cairncms/utils';
+import { clamp, get, isEmpty, isNil, set } from 'lodash';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import SearchInput from '@/views/private/components/search-input.vue';
-import DrawerItem from '@/views/private/components/drawer-item.vue';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
-import { Sort } from '@/components/v-table/types';
 import Draggable from 'vuedraggable';
-import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
-import { isEmpty, get, clamp, isNil, set } from 'lodash';
-import { useFieldsStore } from '@/stores/fields';
-import { LAYOUTS } from '@/types/interfaces';
-import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
-import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
-import { useRelationPermissionsM2M } from '@/composables/use-relation-permissions';
 
 const props = withDefaults(
 	defineProps<{
@@ -278,8 +278,10 @@ const templateWithDefaults = computed(() => {
 	if (!relationInfo.value) return null;
 
 	if (props.template) return props.template;
-	if (relationInfo.value.junctionCollection.meta?.display_template)
+
+	if (relationInfo.value.junctionCollection.meta?.display_template) {
 		return relationInfo.value.junctionCollection.meta.display_template;
+	}
 
 	let relatedDisplayTemplate = relationInfo.value.relatedCollection.meta?.display_template;
 

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -25,18 +25,17 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { ref, computed, inject, toRefs } from 'vue';
-import { getFieldsFromTemplate } from '@cairncms/utils';
-import NestedDraggable from './nested-draggable.vue';
-import { Filter } from '@cairncms/types';
-import { parseFilter } from '@/utils/parse-filter';
-import { render } from 'micromustache';
-import { deepMap } from '@cairncms/utils';
-import { useRelationO2M } from '@/composables/use-relation-o2m';
 import { ChangesItem } from '@/composables/use-relation-multiple';
+import { useRelationO2M } from '@/composables/use-relation-o2m';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { parseFilter } from '@/utils/parse-filter';
+import { Filter } from '@cairncms/types';
+import { deepMap, getFieldsFromTemplate } from '@cairncms/utils';
+import { render } from 'micromustache';
+import { computed, inject, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import NestedDraggable from './nested-draggable.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -65,12 +64,14 @@ const { collection, field, primaryKey } = toRefs(props);
 
 const _value = computed<ChangesItem>({
 	get() {
-		if (Array.isArray(props.value))
+		if (Array.isArray(props.value)) {
 			return {
 				create: [],
 				update: [],
 				delete: [],
 			};
+		}
+
 		return props.value as ChangesItem;
 	},
 	set: (val) => {

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -71,7 +71,7 @@
 					<router-link
 						v-if="enableLink"
 						v-tooltip="t('navigate_to_item')"
-						:to="getLinkForItem(item)"
+						:to="getLinkForItem(item)!"
 						class="item-link"
 						:class="{ disabled: item.$type === 'created' }"
 					>
@@ -129,7 +129,7 @@
 							<router-link
 								v-if="enableLink"
 								v-tooltip="t('navigate_to_item')"
-								:to="getLinkForItem(element)"
+								:to="getLinkForItem(element)!"
 								class="item-link"
 								:class="{ disabled: element.$type === 'created' }"
 								@click.stop
@@ -197,26 +197,26 @@
 </template>
 
 <script setup lang="ts">
+import { Sort } from '@/components/v-table/types';
+import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import { useRelationO2M } from '@/composables/use-relation-o2m';
-import { useRelationMultiple, RelationQueryMultiple, DisplayItem } from '@/composables/use-relation-multiple';
+import { useRelationPermissionsO2M } from '@/composables/use-relation-permissions';
+import { useFieldsStore } from '@/stores/fields';
+import { LAYOUTS } from '@/types/interfaces';
+import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
+import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
 import { parseFilter } from '@/utils/parse-filter';
+import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
+import SearchInput from '@/views/private/components/search-input.vue';
 import { Filter } from '@cairncms/types';
 import { deepMap, getFieldsFromTemplate } from '@cairncms/utils';
+import { clamp, get, isEmpty, isNil } from 'lodash';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import SearchInput from '@/views/private/components/search-input.vue';
-import DrawerItem from '@/views/private/components/drawer-item.vue';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
-import { Sort } from '@/components/v-table/types';
 import Draggable from 'vuedraggable';
-import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
-import { isEmpty, clamp, get, isNil } from 'lodash';
-import { useFieldsStore } from '@/stores/fields';
-import { LAYOUTS } from '@/types/interfaces';
-import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
-import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
-import { useRelationPermissionsO2M } from '@/composables/use-relation-permissions';
 
 const props = withDefaults(
 	defineProps<{

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -82,274 +82,211 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed, ref, toRefs } from 'vue';
-import { Field } from '@cairncms/types';
-import Draggable from 'vuedraggable';
+<script setup lang="ts">
 import { i18n } from '@/lang';
 import { renderStringTemplate } from '@/utils/render-string-template';
-import { hideDragImage } from '@/utils/hide-drag-image';
 import formatTitle from '@cairncms/format-title';
+import { DeepPartial, Field, FieldMeta } from '@cairncms/types';
 import { isEqual, sortBy } from 'lodash';
+import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
 
-export default defineComponent({
-	components: { Draggable },
-	props: {
-		value: {
-			type: Array as PropType<Record<string, any>[]>,
-			default: null,
-		},
-		fields: {
-			type: Array as PropType<Partial<Field>[]>,
-			default: () => [],
-		},
-		template: {
-			type: String,
-			default: null,
-		},
-		addLabel: {
-			type: String,
-			default: () => i18n.global.t('create_new'),
-		},
-		sort: {
-			type: String,
-			default: null,
-		},
-		limit: {
-			type: Number,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		headerPlaceholder: {
-			type: String,
-			default: () => i18n.global.t('empty_item'),
-		},
-		collection: {
-			type: String,
-			default: null,
-		},
-		placeholder: {
-			type: String,
-			default: () => i18n.global.t('no_items'),
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: Record<string, unknown>[] | null;
+		fields?: DeepPartial<Field>[];
+		template?: string;
+		addLabel?: string;
+		sort?: string;
+		limit?: number;
+		disabled?: boolean;
+		headerPlaceholder?: string;
+		collection?: string;
+		placeholder?: string;
+		direction?: string;
+	}>(),
+	{
+		fields: () => [],
+		addLabel: () => i18n.global.t('create_new'),
+		headerPlaceholder: () => i18n.global.t('empty_item'),
+		placeholder: () => i18n.global.t('no_items'),
+	}
+);
 
-		const active = ref<number | null>(null);
-		const drawerOpen = computed(() => active.value !== null);
-		const { value } = toRefs(props);
+const emit = defineEmits<{
+	(e: 'input', value: FieldMeta[] | null): void;
+}>();
 
-		const templateWithDefaults = computed(() =>
-			props.fields?.[0]?.field ? props.template || `{{${props.fields[0].field}}}` : ''
-		);
+const { t } = useI18n();
 
-		const showAddNew = computed(() => {
-			if (props.disabled) return false;
-			if (props.value === null) return true;
-			if (props.limit === null) return true;
-			if (Array.isArray(props.value) && props.value.length < props.limit) return true;
-			return false;
-		});
+const active = ref<number | null>(null);
+const drawerOpen = computed(() => active.value !== null);
+const { value } = toRefs(props);
 
-		const activeItem = computed(() => (active.value !== null ? edits.value : null));
+const templateWithDefaults = computed(() =>
+	props.fields?.[0]?.field ? props.template || `{{${props.fields[0].field}}}` : ''
+);
 
-		const isSaveDisabled = computed(() => {
-			for (const field of props.fields) {
-				if (
-					field.meta?.required &&
-					field.field &&
-					(edits.value[field.field] === null || edits.value[field.field] === undefined)
-				) {
-					return true;
-				}
-			}
+const showAddNew = computed(() => {
+	if (props.disabled) return false;
+	if (props.value === null) return true;
+	if (props.limit === undefined) return true;
+	if (Array.isArray(props.value) && props.value.length < props.limit) return true;
+	return false;
+});
 
-			return false;
-		});
+const activeItem = computed(() => (active.value !== null ? edits.value : null));
 
-		const { displayValue } = renderStringTemplate(templateWithDefaults, activeItem);
+const isSaveDisabled = computed(() => {
+	for (const field of props.fields) {
+		if (
+			field.meta?.required &&
+			field.field &&
+			(edits.value[field.field] === null || edits.value[field.field] === undefined)
+		) {
+			return true;
+		}
+	}
 
-		const defaults = computed(() => {
-			const values: Record<string, any> = {};
+	return false;
+});
 
-			for (const field of props.fields) {
-				if (field.schema?.default_value !== undefined && field.schema?.default_value !== null) {
-					values[field.field!] = field.schema.default_value;
-				}
-			}
+const { displayValue } = renderStringTemplate(templateWithDefaults, activeItem);
 
-			return values;
-		});
+const defaults = computed(() => {
+	const values: Record<string, any> = {};
 
-		const fieldsWithNames = computed(() =>
-			props.fields?.map((field) => {
-				return {
-					...field,
-					name: formatTitle(field.name ?? field.field!),
-				};
-			})
-		);
+	for (const field of props.fields) {
+		if (field.schema?.default_value !== undefined && field.schema?.default_value !== null) {
+			values[field.field!] = field.schema.default_value;
+		}
+	}
 
-		const internalValue = computed({
-			get: () => {
-				if (props.fields && props.sort) return sortBy(value.value, props.sort);
-				return value.value;
-			},
-			set: (newVal) => {
-				value.value = props.fields && props.sort ? sortBy(value.value, props.sort) : newVal;
-			},
-		});
+	return values;
+});
 
-		const isNewItem = ref(false);
-		const edits = ref({} as Record<string, any>);
-		const confirmDiscard = ref(false);
-
+const fieldsWithNames = computed(() =>
+	props.fields?.map((field) => {
 		return {
-			t,
-			internalValue,
-			updateValues,
-			removeItem,
-			addNew,
-			showAddNew,
-			hideDragImage,
-			active,
-			drawerOpen,
-			displayValue,
-			activeItem,
-			isSaveDisabled,
-			closeDrawer,
-			onSort,
-			templateWithDefaults,
-			defaults,
-			fieldsWithNames,
-			isNewItem,
-			edits,
-			confirmDiscard,
-			openItem,
-			saveItem,
-			trackEdits,
-			checkDiscard,
-			discardAndLeave,
+			...field,
+			name: formatTitle(field.name ?? field.field!),
 		};
+	})
+);
 
-		function openItem(index: number) {
-			isNewItem.value = false;
-
-			edits.value = { ...internalValue.value[index] };
-			active.value = index;
-		}
-
-		function saveItem(index: number) {
-			isNewItem.value = false;
-
-			updateValues(index, edits.value);
-			closeDrawer();
-		}
-
-		function trackEdits(updatedValues: any) {
-			const combinedValues = Object.assign({}, defaults.value, updatedValues);
-			Object.assign(edits.value, combinedValues);
-		}
-
-		function checkDiscard() {
-			if (active.value !== null && !isEqual(edits.value, internalValue.value[active.value])) {
-				confirmDiscard.value = true;
-			} else {
-				closeDrawer();
-			}
-		}
-
-		function discardAndLeave() {
-			closeDrawer();
-			confirmDiscard.value = false;
-		}
-
-		function updateValues(index: number, updatedValues: any) {
-			const newValue = internalValue.value.map((item: any, i: number) => {
-				if (i === index) {
-					return updatedValues;
-				}
-
-				return item;
-			});
-
-			if (props.fields && props.sort) {
-				emitValue(sortBy(newValue, props.sort));
-			} else {
-				emitValue(newValue);
-			}
-		}
-
-		function removeItem(item: Record<string, any>) {
-			if (value.value) {
-				emitValue(internalValue.value.filter((i) => i !== item));
-			} else {
-				emitValue(null);
-			}
-		}
-
-		function addNew() {
-			isNewItem.value = true;
-
-			const newDefaults: any = {};
-
-			props.fields.forEach((field) => {
-				newDefaults[field.field!] = field.schema?.default_value;
-			});
-
-			if (Array.isArray(internalValue.value)) {
-				emitValue([...internalValue.value, newDefaults]);
-			} else {
-				if (internalValue.value != null) {
-					// eslint-disable-next-line no-console
-					console.warn(
-						'The repeater interface expects an array as value, but the given value is no array. Overriding given value.'
-					);
-				}
-
-				emitValue([newDefaults]);
-			}
-
-			edits.value = { ...newDefaults };
-			active.value = (internalValue.value || []).length;
-		}
-
-		function emitValue(value: null | any[]) {
-			if (!value || value.length === 0) {
-				return emit('input', null);
-			}
-
-			return emit('input', value);
-		}
-
-		function onSort(sortedItems: any[]) {
-			if (sortedItems === null || sortedItems.length === 0) {
-				return emit('input', null);
-			}
-
-			return emit('input', sortedItems);
-		}
-
-		function closeDrawer() {
-			if (isNewItem.value) {
-				emitValue(internalValue.value.slice(0, -1));
-			}
-
-			edits.value = {};
-			active.value = null;
-		}
+const internalValue = computed({
+	get: () => {
+		if (props.fields && props.sort) return sortBy(value.value, props.sort);
+		return value.value;
+	},
+	set: (newVal) => {
+		value.value = props.fields && props.sort ? sortBy(value.value, props.sort) : newVal;
 	},
 });
+
+const isNewItem = ref(false);
+const edits = ref({} as Record<string, any>);
+const confirmDiscard = ref(false);
+
+function openItem(index: number) {
+	isNewItem.value = false;
+
+	edits.value = { ...internalValue.value?.[index] };
+	active.value = index;
+}
+
+function saveItem(index: number) {
+	isNewItem.value = false;
+
+	updateValues(index, edits.value);
+	closeDrawer();
+}
+
+function trackEdits(updatedValues: any) {
+	const combinedValues = Object.assign({}, defaults.value, updatedValues);
+	Object.assign(edits.value, combinedValues);
+}
+
+function checkDiscard() {
+	if (active.value !== null && !isEqual(edits.value, internalValue.value?.[active.value])) {
+		confirmDiscard.value = true;
+	} else {
+		closeDrawer();
+	}
+}
+
+function discardAndLeave() {
+	closeDrawer();
+	confirmDiscard.value = false;
+}
+
+function updateValues(index: number, updatedValues: any) {
+	const newValue = internalValue.value?.map((item: any, i: number) => {
+		if (i === index) {
+			return updatedValues;
+		}
+
+		return item;
+	});
+
+	if (props.fields && props.sort) {
+		emitValue(sortBy(newValue, props.sort));
+	} else {
+		emitValue(newValue);
+	}
+}
+
+function removeItem(item: Record<string, any>) {
+	if (value.value) {
+		emitValue(internalValue.value?.filter((i) => i !== item));
+	} else {
+		emitValue();
+	}
+}
+
+function addNew() {
+	isNewItem.value = true;
+
+	const newDefaults: any = {};
+
+	props.fields.forEach((field) => {
+		newDefaults[field.field!] = field.schema?.default_value;
+	});
+
+	if (Array.isArray(internalValue.value)) {
+		emitValue([...internalValue.value, newDefaults]);
+	} else {
+		if (internalValue.value != null) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'The repeater interface expects an array as value, but the given value is no array. Overriding given value.'
+			);
+		}
+
+		emitValue([newDefaults]);
+	}
+
+	edits.value = { ...newDefaults };
+	active.value = (internalValue.value || []).length;
+}
+
+function emitValue(value?: Record<string, unknown>[]) {
+	if (!value || value.length === 0) {
+		return emit('input', null);
+	}
+
+	return emit('input', value);
+}
+
+function closeDrawer() {
+	if (isNewItem.value) {
+		emitValue(internalValue.value?.slice(0, -1));
+	}
+
+	edits.value = {};
+	active.value = null;
+}
 </script>
 
 <style lang="scss" scoped>
@@ -367,7 +304,7 @@ export default defineComponent({
 }
 
 .drag-handle {
-	cursor: grap;
+	cursor: grab;
 }
 
 .drawer-item-content {

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -29,7 +29,7 @@
 			<p class="type-label">{{ t('interfaces.list.edit_fields') }}</p>
 			<repeater
 				:value="repeaterValue"
-				:template="`{{ field }} — {{ interface }}`"
+				template="{{ field }} — {{ interface }}"
 				:fields="repeaterFields"
 				@input="repeaterValue = $event"
 			/>
@@ -37,203 +37,196 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import Repeater from './list.vue';
-import { Field, FieldMeta } from '@cairncms/types';
+<script setup lang="ts">
 import { FIELD_TYPES_SELECT } from '@/constants';
-import { DeepPartial } from '@cairncms/types';
 import { translate } from '@/utils/translate-object-values';
+import { DeepPartial, Field, FieldMeta } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Repeater from './list.vue';
 
-export default defineComponent({
-	components: { Repeater },
-	props: {
-		value: {
-			type: Object as PropType<Record<string, any>>,
-			default: null,
+const props = defineProps<{
+	value: Record<string, any> | null;
+}>();
+
+const emit = defineEmits<{
+	(e: 'input', value: Record<string, any> | null): void;
+}>();
+
+const { t } = useI18n();
+
+const repeaterValue = computed({
+	get() {
+		return props.value?.fields?.map((field: Field) => field.meta);
+	},
+	set(newVal: FieldMeta[] | null) {
+		const fields = (newVal || []).map((meta: Record<string, any>) => ({
+			field: meta.field,
+			name: meta.name || meta.field,
+			type: meta.type,
+			meta,
+		}));
+
+		emit('input', {
+			...(props.value || {}),
+			fields,
+		});
+	},
+});
+
+const repeaterFields: DeepPartial<Field>[] = [
+	{
+		name: t('field', 1),
+		field: 'field',
+		type: 'string',
+		meta: {
+			interface: 'input',
+			width: 'half',
+			sort: 2,
+			required: true,
+			options: {
+				dbSafe: true,
+				font: 'monospace',
+				placeholder: t('field_name_placeholder'),
+			},
+		},
+		schema: null,
+	},
+	{
+		name: t('field_width'),
+		field: 'width',
+		type: 'string',
+		meta: {
+			interface: 'select-dropdown',
+			width: 'half',
+			sort: 3,
+			options: {
+				choices: [
+					{
+						value: 'half',
+						text: t('half_width'),
+					},
+					{
+						value: 'full',
+						text: t('full_width'),
+					},
+				],
+			},
+		},
+		schema: null,
+	},
+	{
+		name: t('type'),
+		field: 'type',
+		type: 'string',
+		meta: {
+			interface: 'select-dropdown',
+			width: 'half',
+			sort: 4,
+			options: {
+				choices: translate(FIELD_TYPES_SELECT),
+			},
+		},
+		schema: null,
+	},
+	{
+		name: t('interface_label'),
+		field: 'interface',
+		type: 'string',
+		meta: {
+			interface: 'system-interface',
+			width: 'half',
+			sort: 5,
+			options: {
+				typeField: 'type',
+			},
+		},
+		schema: null,
+	},
+	{
+		name: t('note'),
+		field: 'note',
+		type: 'string',
+		meta: {
+			interface: 'system-input-translated-string',
+			width: 'full',
+			sort: 6,
+			options: {
+				placeholder: t('interfaces.list.field_note_placeholder'),
+			},
+		},
+		schema: null,
+	},
+	{
+		name: t('required'),
+		field: 'required',
+		type: 'boolean',
+		meta: {
+			interface: 'boolean',
+			sort: 7,
+			options: {
+				label: t('requires_value'),
+			},
+			width: 'half',
 		},
 	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const repeaterValue = computed({
-			get() {
-				return props.value?.fields?.map((field: Field) => field.meta);
+	{
+		name: t('options'),
+		field: 'options',
+		type: 'string',
+		meta: {
+			interface: 'system-interface-options',
+			width: 'full',
+			sort: 8,
+			options: {
+				interfaceField: 'interface',
 			},
-			set(newVal: FieldMeta[] | null) {
-				const fields = (newVal || []).map((meta: Record<string, any>) => ({
-					field: meta.field,
-					name: meta.name || meta.field,
-					type: meta.type,
-					meta,
-				}));
-
-				emit('input', {
-					...(props.value || {}),
-					fields: fields,
-				});
-			},
-		});
-
-		const repeaterFields: DeepPartial<Field>[] = [
-			{
-				name: t('field', 1),
-				field: 'field',
-				type: 'string',
-				meta: {
-					interface: 'input',
-					width: 'half',
-					sort: 2,
-					required: true,
-					options: {
-						dbSafe: true,
-						font: 'monospace',
-						placeholder: t('field_name_placeholder'),
-					},
-				},
-				schema: null,
-			},
-			{
-				name: t('field_width'),
-				field: 'width',
-				type: 'string',
-				meta: {
-					interface: 'select-dropdown',
-					width: 'half',
-					sort: 3,
-					options: {
-						choices: [
-							{
-								value: 'half',
-								text: t('half_width'),
-							},
-							{
-								value: 'full',
-								text: t('full_width'),
-							},
-						],
-					},
-				},
-				schema: null,
-			},
-			{
-				name: t('type'),
-				field: 'type',
-				type: 'string',
-				meta: {
-					interface: 'select-dropdown',
-					width: 'half',
-					sort: 4,
-					options: {
-						choices: translate(FIELD_TYPES_SELECT),
-					},
-				},
-				schema: null,
-			},
-			{
-				name: t('interface_label'),
-				field: 'interface',
-				type: 'string',
-				meta: {
-					interface: 'system-interface',
-					width: 'half',
-					sort: 5,
-					options: {
-						typeField: 'type',
-					},
-				},
-				schema: null,
-			},
-			{
-				name: t('note'),
-				field: 'note',
-				type: 'string',
-				meta: {
-					interface: 'system-input-translated-string',
-					width: 'full',
-					sort: 6,
-					options: {
-						placeholder: t('interfaces.list.field_note_placeholder'),
-					},
-				},
-				schema: null,
-			},
-			{
-				name: t('required'),
-				field: 'required',
-				type: 'boolean',
-				meta: {
-					interface: 'boolean',
-					sort: 7,
-					options: {
-						label: t('requires_value'),
-					},
-					width: 'half',
-				},
-			},
-			{
-				name: t('options'),
-				field: 'options',
-				type: 'string',
-				meta: {
-					interface: 'system-interface-options',
-					width: 'full',
-					sort: 8,
-					options: {
-						interfaceField: 'interface',
-					},
-				},
-			},
-		];
-
-		const template = computed({
-			get() {
-				return props.value?.template;
-			},
-			set(newTemplate: string) {
-				emit('input', {
-					...(props.value || {}),
-					template: newTemplate,
-				});
-			},
-		});
-
-		const addLabel = computed({
-			get() {
-				return props.value?.addLabel;
-			},
-			set(newAddLabel: string) {
-				emit('input', {
-					...(props.value || {}),
-					addLabel: newAddLabel,
-				});
-			},
-		});
-
-		const sort = computed({
-			get() {
-				return props.value?.sort;
-			},
-			set(newSort: string) {
-				emit('input', {
-					...(props.value || {}),
-					sort: newSort,
-				});
-			},
-		});
-
-		const sortFields = computed(() => {
-			if (!repeaterValue.value) return [];
-
-			return repeaterValue.value.map((val) => {
-				return { text: val.field, value: val.field };
-			});
-		});
-
-		return { t, repeaterValue, repeaterFields, template, addLabel, sort, sortFields };
+		},
 	},
+];
+
+const template = computed({
+	get() {
+		return props.value?.template;
+	},
+	set(newTemplate: string) {
+		emit('input', {
+			...(props.value || {}),
+			template: newTemplate,
+		});
+	},
+});
+
+const addLabel = computed({
+	get() {
+		return props.value?.addLabel;
+	},
+	set(newAddLabel: string) {
+		emit('input', {
+			...(props.value || {}),
+			addLabel: newAddLabel,
+		});
+	},
+});
+
+const sort = computed({
+	get() {
+		return props.value?.sort;
+	},
+	set(newSort: string) {
+		emit('input', {
+			...(props.value || {}),
+			sort: newSort,
+		});
+	},
+});
+
+const sortFields = computed(() => {
+	if (!repeaterValue.value) return [];
+
+	return repeaterValue.value.map((val) => {
+		return { text: val.field, value: val.field };
+	});
 });
 </script>
 

--- a/app/src/interfaces/map/map.vue
+++ b/app/src/interfaces/map/map.vue
@@ -13,7 +13,7 @@
 		<div
 			v-if="location"
 			class="mapboxgl-user-location-dot mapboxgl-search-location-dot"
-			:style="`transform: translate(${projection.x}px, ${projection.y}px) translate(-50%, -50%) rotateX(0deg) rotateZ(0deg)`"
+			:style="`transform: translate(${projection!.x}px, ${projection!.y}px) translate(-50%, -50%) rotateX(0deg) rotateZ(0deg)`"
 		></div>
 		<transition name="fade">
 			<div
@@ -61,9 +61,19 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { useAppStore } from '@/stores/app';
+import { useSettingsStore } from '@/stores/settings';
+import { flatten, getBBox, getGeometryFormatForType, getParser, getSerializer } from '@/utils/geometry';
+import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
+import { ButtonControl } from '@/utils/geometry/controls';
+import { Field, GeoJSONParser, GeoJSONSerializer, GeometryType, MultiGeometry, SimpleGeometry } from '@cairncms/types';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
+import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
+import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
+import { Geometry } from 'geojson';
+import { debounce, isEqual, snakeCase } from 'lodash';
 import maplibre, {
 	AnimationOptions,
 	AttributionControl,
@@ -75,18 +85,13 @@ import maplibre, {
 	NavigationControl,
 } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { computed, defineComponent, onMounted, onUnmounted, PropType, ref, toRefs, watch } from 'vue';
-import { useSettingsStore } from '@/stores/settings';
-import { flatten, getBBox, getGeometryFormatForType, getParser, getSerializer } from '@/utils/geometry';
-import { ButtonControl } from '@/utils/geometry/controls';
-import { Field, GeoJSONParser, GeoJSONSerializer, GeometryType, MultiGeometry, SimpleGeometry } from '@cairncms/types';
+import type { Ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue';
+import { TranslateResult, useI18n } from 'vue-i18n';
+import { getMapStyle } from './style';
+
 // @ts-ignore
 import StaticMode from '@mapbox/mapbox-gl-draw-static-mode';
-import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
-import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
-import { Geometry } from 'geojson';
-import { debounce, isEqual, snakeCase } from 'lodash';
-import { getMapStyle } from './style';
 
 const activeLayers = [
 	'directus-point',
@@ -97,401 +102,364 @@ const activeLayers = [
 	'directus-polygon-and-line-vertex',
 ].flatMap((name) => [name + '.hot', name + '.cold']);
 
-import { useAppStore } from '@/stores/app';
-import { TranslateResult, useI18n } from 'vue-i18n';
+const props = withDefaults(
+	defineProps<{
+		value: Record<string, unknown> | unknown[] | string | null;
+		type: 'geometry' | 'json' | 'csv' | 'string' | 'text';
+		fieldData?: Field;
+		loading?: boolean;
+		disabled?: boolean;
+		geometryType?: GeometryType;
+		defaultView?: Record<string, unknown>;
+	}>(),
+	{
+		loading: true,
+		defaultView: () => ({}),
+	}
+);
 
-import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
+const emit = defineEmits<{
+	(e: 'input', value: Record<string, unknown> | unknown[] | string | null): void;
+}>();
 
-export default defineComponent({
-	props: {
-		type: {
-			type: String as PropType<'geometry' | 'json' | 'csv' | 'string' | 'text'>,
-			default: null,
-		},
-		fieldData: {
-			type: Object as PropType<Field | undefined>,
-			default: undefined,
-		},
-		value: {
-			type: [Object, Array, String] as PropType<any>,
-			default: null,
-		},
-		loading: {
-			type: Boolean,
-			default: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		geometryType: {
-			type: String as PropType<GeometryType>,
-			default: undefined,
-		},
-		defaultView: {
-			type: Object,
-			default: () => ({}),
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-		const container = ref<HTMLElement | null>(null);
-		let map: Map;
-		let mapLoading = ref(true);
-		let currentGeometry: Geometry | null | undefined;
+const { t } = useI18n();
+const container: Ref<HTMLElement | null> = ref(null);
+let map: Map;
+let mapLoading = ref(true);
+let currentGeometry: Geometry | null | undefined;
 
-		const geometryOptionsError = ref<string | null>();
-		const geometryParsingError = ref<string | TranslateResult>();
+const geometryOptionsError = ref<string | null>();
+const geometryParsingError = ref<string | TranslateResult>();
 
-		const geometryType = props.fieldData?.type.split('.')[1] as GeometryType;
-		const geometryFormat = getGeometryFormatForType(props.type)!;
+const geometryType = props.fieldData?.type.split('.')[1] as GeometryType;
+const geometryFormat = getGeometryFormatForType(props.type)!;
 
-		const settingsStore = useSettingsStore();
-		const mapboxKey = settingsStore.settings?.mapbox_key;
+const settingsStore = useSettingsStore();
+const mapboxKey = settingsStore.settings?.mapbox_key;
 
-		const basemaps = getBasemapSources();
-		const appStore = useAppStore();
-		const { basemap } = toRefs(appStore);
+const basemaps = getBasemapSources();
+const appStore = useAppStore();
+const { basemap } = toRefs(appStore);
 
-		const style = computed(() => {
-			const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
-			return basemap.value, getStyleFromBasemapSource(source);
-		});
-
-		let parse: GeoJSONParser;
-		let serialize: GeoJSONSerializer;
-
-		try {
-			parse = getParser({ geometryFormat, geometryField: 'value' });
-			serialize = getSerializer({ geometryFormat, geometryField: 'value' });
-		} catch (error: any) {
-			geometryOptionsError.value = error;
-		}
-
-		const selection = ref<GeoJSON.Feature[]>([]);
-
-		const location = ref<LngLatLike | null>();
-		const projection = ref<{ x: number; y: number } | null>();
-
-		function updateProjection() {
-			projection.value = !location.value ? null : map.project(location.value as any);
-		}
-
-		watch(location, updateProjection);
-
-		const controls = {
-			attribution: new AttributionControl(),
-			draw: new MapboxDraw(getDrawOptions(geometryType)),
-			fitData: new ButtonControl('mapboxgl-ctrl-fitdata', fitDataBounds),
-			navigation: new NavigationControl({
-				showCompass: false,
-			}),
-			geolocate: new GeolocateControl({
-				showUserLocation: false,
-			}),
-			geocoder: undefined as MapboxGeocoder | undefined,
-		};
-
-		if (mapboxKey) {
-			controls.geocoder = new MapboxGeocoder({
-				accessToken: mapboxKey,
-				collapsed: true,
-				flyTo: { speed: 1.4 },
-				marker: false,
-				mapboxgl: maplibre as any,
-				placeholder: t('layouts.map.find_location'),
-			});
-		}
-
-		const tooltipVisible = ref(false);
-		const tooltipMessage = ref('');
-		const tooltipPosition = ref({ x: 0, y: 0 });
-
-		function hideTooltip() {
-			tooltipVisible.value = false;
-		}
-
-		const updateTooltipDebounce = debounce((event: any) => {
-			const feature = event.features?.[0];
-
-			if (feature && feature.properties!.active === 'false') {
-				tooltipMessage.value = t('interfaces.map.click_to_select', { geometry: feature.geometry.type });
-				tooltipVisible.value = true;
-				tooltipPosition.value = event.point;
-			}
-		}, 200);
-
-		function updateTooltip(event: any) {
-			tooltipVisible.value = false;
-			updateTooltipDebounce({ point: event.point, features: event.features });
-		}
-
-		onMounted(() => {
-			const cleanup = setupMap();
-			onUnmounted(cleanup);
-		});
-
-		return {
-			t,
-			tooltipPosition,
-			tooltipVisible,
-			tooltipMessage,
-			container,
-			mapLoading,
-			resetValue,
-			geometryParsingError,
-			geometryOptionsError,
-			basemaps,
-			basemap,
-			location,
-			projection,
-			selection,
-		};
-
-		function setupMap(): () => void {
-			map = new Map({
-				container: container.value!,
-				style: style.value,
-				dragRotate: false,
-				logoPosition: 'bottom-left',
-				attributionControl: false,
-				...props.defaultView,
-				...(mapboxKey ? { accessToken: mapboxKey } : {}),
-			});
-
-			if (controls.geocoder) {
-				map.addControl(controls.geocoder as any, 'top-right');
-
-				controls.geocoder.on('result', (event: any) => {
-					location.value = event.result.center;
-				});
-
-				controls.geocoder.on('clear', () => {
-					location.value = null;
-				});
-			}
-
-			controls.geolocate.on('geolocate', (event: any) => {
-				const { longitude, latitude } = event.coords;
-				location.value = [longitude, latitude];
-			});
-
-			map.addControl(controls.attribution, 'bottom-left');
-			map.addControl(controls.navigation, 'top-left');
-			map.addControl(controls.geolocate, 'top-left');
-			map.addControl(controls.fitData, 'top-left');
-			map.addControl(controls.draw as any, 'top-left');
-
-			map.on('load', async () => {
-				map.resize();
-				mapLoading.value = false;
-				map.on('draw.create', handleDrawUpdate);
-				map.on('draw.delete', handleDrawUpdate);
-				map.on('draw.update', handleDrawUpdate);
-				map.on('draw.modechange', handleDrawModeChange);
-				map.on('draw.selectionchange', handleSelectionChange);
-				map.on('move', updateProjection);
-
-				for (const layer of activeLayers) {
-					map.on('mousedown', layer, hideTooltip);
-					map.on('mousemove', layer, updateTooltip);
-					map.on('mouseleave', layer, updateTooltip);
-				}
-
-				window.addEventListener('keydown', handleKeyDown);
-			});
-
-			watch(() => props.value, updateValue, { immediate: true });
-			watch(() => style.value, updateStyle);
-			watch(() => props.disabled, updateStyle);
-
-			return () => {
-				window.removeEventListener('keydown', handleKeyDown);
-				map.remove();
-			};
-		}
-
-		function updateValue(value: any) {
-			if (!value) {
-				controls.draw.deleteAll();
-				currentGeometry = null;
-
-				if (geometryType) {
-					const snaked = snakeCase(geometryType.replace('Multi', ''));
-					const mode = `draw_${snaked}` as any;
-					controls.draw.changeMode(mode);
-				}
-			} else {
-				if (!isEqual(value, currentGeometry && serialize(currentGeometry))) {
-					loadValueFromProps();
-					controls.draw.changeMode('simple_select');
-				}
-			}
-
-			if (props.disabled) {
-				controls.draw.changeMode('static');
-			}
-		}
-
-		function updateStyle() {
-			map.removeControl(controls.draw as any);
-			map.setStyle(style.value, { diff: false });
-			controls.draw = new MapboxDraw(getDrawOptions(geometryType));
-			map.addControl(controls.draw as any, 'top-left');
-			loadValueFromProps();
-		}
-
-		function resetValue(hard: boolean) {
-			geometryParsingError.value = undefined;
-			if (hard) emit('input', null);
-		}
-
-		function fitDataBounds(options: CameraOptions & AnimationOptions) {
-			if (map && currentGeometry) {
-				const bbox = getBBox(currentGeometry);
-
-				map.fitBounds(bbox as LngLatBoundsLike, {
-					padding: 80,
-					maxZoom: 8,
-					...options,
-				});
-			}
-		}
-
-		function getDrawOptions(type: GeometryType): any {
-			const options = {
-				styles: getMapStyle(),
-				controls: {},
-				userProperties: true,
-				displayControlsDefault: false,
-				modes: Object.assign(MapboxDraw.modes, {
-					static: StaticMode,
-				}),
-			} as any;
-
-			if (props.disabled) {
-				return options;
-			}
-
-			if (!type) {
-				options.controls.line_string = true;
-				options.controls.polygon = true;
-				options.controls.point = true;
-				options.controls.trash = true;
-				return options;
-			} else {
-				const base = snakeCase(type!.replace('Multi', ''));
-				options.controls[base] = true;
-				options.controls.trash = true;
-				return options;
-			}
-		}
-
-		function isTypeCompatible(a?: GeometryType, b?: GeometryType): boolean {
-			if (!a || !b) {
-				return true;
-			}
-
-			if (a.startsWith('Multi')) {
-				return a.replace('Multi', '') == b.replace('Multi', '');
-			}
-
-			return a == b;
-		}
-
-		function loadValueFromProps() {
-			try {
-				controls.draw.deleteAll();
-				const initialValue = parse(props);
-
-				if (!initialValue) {
-					return;
-				}
-
-				if (!props.disabled && !isTypeCompatible(geometryType, initialValue!.type)) {
-					geometryParsingError.value = t('interfaces.map.unexpected_geometry', {
-						expected: geometryType,
-						got: initialValue!.type,
-					});
-				}
-
-				const flattened = flatten(initialValue);
-
-				for (const geometry of flattened) {
-					controls.draw.add(geometry);
-				}
-
-				currentGeometry = getCurrentGeometry();
-				currentGeometry!.bbox = getBBox(currentGeometry!);
-
-				if (geometryParsingError.value) {
-					const bbox = getBBox(initialValue!) as LngLatBoundsLike;
-					map.fitBounds(bbox, { padding: 0, maxZoom: 8, duration: 0 });
-				} else {
-					fitDataBounds({ duration: 0 });
-				}
-			} catch (error: any) {
-				geometryParsingError.value = error;
-			}
-		}
-
-		function getCurrentGeometry(): Geometry | null {
-			const features = controls.draw.getAll().features;
-			const geometries = features.map((f) => f.geometry) as (SimpleGeometry | MultiGeometry)[];
-			let result: Geometry;
-
-			if (geometries.length == 0) {
-				return null;
-			} else if (!geometryType) {
-				if (geometries.length > 1) {
-					result = { type: 'GeometryCollection', geometries };
-				} else {
-					result = geometries[0];
-				}
-			} else if (geometryType.startsWith('Multi')) {
-				const coordinates = geometries
-					.filter(({ type }) => `Multi${type}` == geometryType)
-					.map(({ coordinates }) => coordinates);
-
-				result = { type: geometryType, coordinates } as Geometry;
-			} else {
-				result = geometries[geometries.length - 1];
-			}
-
-			return result;
-		}
-
-		function handleDrawModeChange(event: any) {
-			if (!props.disabled && event.mode.startsWith('draw') && geometryType && !geometryType.startsWith('Multi')) {
-				for (const feature of controls.draw.getAll().features.slice(0, -1)) {
-					controls.draw.delete(feature.id as string);
-				}
-			}
-		}
-
-		function handleSelectionChange(event: any) {
-			selection.value = event.features;
-		}
-
-		function handleDrawUpdate() {
-			currentGeometry = getCurrentGeometry();
-
-			if (!currentGeometry) {
-				controls.draw.deleteAll();
-				emit('input', null);
-			} else {
-				emit('input', serialize(currentGeometry));
-			}
-		}
-
-		function handleKeyDown(event: any) {
-			if ([8, 46].includes(event.keyCode)) {
-				controls.draw.trash();
-			}
-		}
-	},
+const style = computed(() => {
+	const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
+	return basemap.value, getStyleFromBasemapSource(source);
 });
+
+let parse: GeoJSONParser;
+let serialize: GeoJSONSerializer;
+
+try {
+	parse = getParser({ geometryFormat, geometryField: 'value' });
+	serialize = getSerializer({ geometryFormat, geometryField: 'value' });
+} catch (error: any) {
+	geometryOptionsError.value = error;
+}
+
+const selection = ref<GeoJSON.Feature[]>([]);
+
+const location = ref<LngLatLike | null>();
+const projection = ref<{ x: number; y: number } | null>();
+
+function updateProjection() {
+	projection.value = !location.value ? null : map.project(location.value as any);
+}
+
+watch(location, updateProjection);
+
+const controls = {
+	attribution: new AttributionControl(),
+	draw: new MapboxDraw(getDrawOptions(geometryType)),
+	fitData: new ButtonControl('mapboxgl-ctrl-fitdata', fitDataBounds),
+	navigation: new NavigationControl({
+		showCompass: false,
+	}),
+	geolocate: new GeolocateControl({
+		showUserLocation: false,
+	}),
+	geocoder: undefined as MapboxGeocoder | undefined,
+};
+
+if (mapboxKey) {
+	controls.geocoder = new MapboxGeocoder({
+		accessToken: mapboxKey,
+		collapsed: true,
+		flyTo: { speed: 1.4 },
+		marker: false,
+		mapboxgl: maplibre as any,
+		placeholder: t('layouts.map.find_location'),
+	});
+}
+
+const tooltipVisible = ref(false);
+const tooltipMessage = ref('');
+const tooltipPosition = ref({ x: 0, y: 0 });
+
+function hideTooltip() {
+	tooltipVisible.value = false;
+}
+
+const updateTooltipDebounce = debounce((event: any) => {
+	const feature = event.features?.[0];
+
+	if (feature && feature.properties!.active === 'false') {
+		tooltipMessage.value = t('interfaces.map.click_to_select', { geometry: feature.geometry.type });
+		tooltipVisible.value = true;
+		tooltipPosition.value = event.point;
+	}
+}, 200);
+
+function updateTooltip(event: any) {
+	tooltipVisible.value = false;
+	updateTooltipDebounce({ point: event.point, features: event.features });
+}
+
+onMounted(() => {
+	const cleanup = setupMap();
+	onUnmounted(cleanup);
+});
+
+function setupMap(): () => void {
+	map = new Map({
+		container: container.value!,
+		style: style.value,
+		dragRotate: false,
+		logoPosition: 'bottom-left',
+		attributionControl: false,
+		...props.defaultView,
+		...(mapboxKey ? { accessToken: mapboxKey } : {}),
+	});
+
+	if (controls.geocoder) {
+		map.addControl(controls.geocoder as any, 'top-right');
+
+		controls.geocoder.on('result', (event: any) => {
+			location.value = event.result.center;
+		});
+
+		controls.geocoder.on('clear', () => {
+			location.value = null;
+		});
+	}
+
+	controls.geolocate.on('geolocate', (event: any) => {
+		const { longitude, latitude } = event.coords;
+		location.value = [longitude, latitude];
+	});
+
+	map.addControl(controls.attribution, 'bottom-left');
+	map.addControl(controls.navigation, 'top-left');
+	map.addControl(controls.geolocate, 'top-left');
+	map.addControl(controls.fitData, 'top-left');
+	map.addControl(controls.draw as any, 'top-left');
+
+	map.on('load', async () => {
+		map.resize();
+		mapLoading.value = false;
+		map.on('draw.create', handleDrawUpdate);
+		map.on('draw.delete', handleDrawUpdate);
+		map.on('draw.update', handleDrawUpdate);
+		map.on('draw.modechange', handleDrawModeChange);
+		map.on('draw.selectionchange', handleSelectionChange);
+		map.on('move', updateProjection);
+
+		for (const layer of activeLayers) {
+			map.on('mousedown', layer, hideTooltip);
+			map.on('mousemove', layer, updateTooltip);
+			map.on('mouseleave', layer, updateTooltip);
+		}
+
+		window.addEventListener('keydown', handleKeyDown);
+	});
+
+	watch(() => props.value, updateValue, { immediate: true });
+	watch(() => style.value, updateStyle);
+	watch(() => props.disabled, updateStyle);
+
+	return () => {
+		window.removeEventListener('keydown', handleKeyDown);
+		map.remove();
+	};
+}
+
+function updateValue(value: any) {
+	if (!value) {
+		controls.draw.deleteAll();
+		currentGeometry = null;
+
+		if (geometryType) {
+			const snaked = snakeCase(geometryType.replace('Multi', ''));
+			const mode = `draw_${snaked}` as any;
+			controls.draw.changeMode(mode);
+		}
+	} else {
+		if (!isEqual(value, currentGeometry && serialize(currentGeometry as any))) {
+			loadValueFromProps();
+			controls.draw.changeMode('simple_select');
+		}
+	}
+
+	if (props.disabled) {
+		controls.draw.changeMode('static');
+	}
+}
+
+function updateStyle() {
+	map.removeControl(controls.draw as any);
+	map.setStyle(style.value, { diff: false });
+	controls.draw = new MapboxDraw(getDrawOptions(geometryType));
+	map.addControl(controls.draw as any, 'top-left');
+	loadValueFromProps();
+}
+
+function resetValue(hard: boolean) {
+	geometryParsingError.value = undefined;
+	if (hard) emit('input', null);
+}
+
+function fitDataBounds(options: CameraOptions & AnimationOptions) {
+	if (map && currentGeometry) {
+		const bbox = getBBox(currentGeometry);
+
+		map.fitBounds(bbox as LngLatBoundsLike, {
+			padding: 80,
+			maxZoom: 8,
+			...options,
+		});
+	}
+}
+
+function getDrawOptions(type: GeometryType): any {
+	const options = {
+		styles: getMapStyle(),
+		controls: {},
+		userProperties: true,
+		displayControlsDefault: false,
+		modes: Object.assign(MapboxDraw.modes, {
+			static: StaticMode,
+		}),
+	} as any;
+
+	if (props.disabled) {
+		return options;
+	}
+
+	if (!type) {
+		options.controls.line_string = true;
+		options.controls.polygon = true;
+		options.controls.point = true;
+		options.controls.trash = true;
+		return options;
+	} else {
+		const base = snakeCase(type!.replace('Multi', ''));
+		options.controls[base] = true;
+		options.controls.trash = true;
+		return options;
+	}
+}
+
+function isTypeCompatible(a?: GeometryType, b?: GeometryType): boolean {
+	if (!a || !b) {
+		return true;
+	}
+
+	if (a.startsWith('Multi')) {
+		return a.replace('Multi', '') == b.replace('Multi', '');
+	}
+
+	return a == b;
+}
+
+function loadValueFromProps() {
+	try {
+		controls.draw.deleteAll();
+		const initialValue = parse(props);
+
+		if (!initialValue) {
+			return;
+		}
+
+		if (!props.disabled && !isTypeCompatible(geometryType, initialValue!.type)) {
+			geometryParsingError.value = t('interfaces.map.unexpected_geometry', {
+				expected: geometryType,
+				got: initialValue!.type,
+			});
+		}
+
+		const flattened = flatten(initialValue);
+
+		for (const geometry of flattened) {
+			controls.draw.add(geometry);
+		}
+
+		currentGeometry = getCurrentGeometry();
+		currentGeometry!.bbox = getBBox(currentGeometry!);
+
+		if (geometryParsingError.value) {
+			const bbox = getBBox(initialValue!) as LngLatBoundsLike;
+			map.fitBounds(bbox, { padding: 0, maxZoom: 8, duration: 0 });
+		} else {
+			fitDataBounds({ duration: 0 });
+		}
+	} catch (error: any) {
+		geometryParsingError.value = error;
+	}
+}
+
+function getCurrentGeometry(): Geometry | null {
+	const features = controls.draw.getAll().features;
+	const geometries = features.map((f) => f.geometry) as (SimpleGeometry | MultiGeometry)[];
+	let result: Geometry;
+
+	if (geometries.length == 0) {
+		return null;
+	} else if (!geometryType) {
+		if (geometries.length > 1) {
+			result = { type: 'GeometryCollection', geometries };
+		} else {
+			result = geometries[0];
+		}
+	} else if (geometryType.startsWith('Multi')) {
+		const coordinates = geometries
+			.filter(({ type }) => `Multi${type}` == geometryType)
+			.map(({ coordinates }) => coordinates);
+
+		result = { type: geometryType, coordinates } as Geometry;
+	} else {
+		result = geometries[geometries.length - 1];
+	}
+
+	return result;
+}
+
+function handleDrawModeChange(event: any) {
+	if (!props.disabled && event.mode.startsWith('draw') && geometryType && !geometryType.startsWith('Multi')) {
+		for (const feature of controls.draw.getAll().features.slice(0, -1)) {
+			controls.draw.delete(feature.id as string);
+		}
+	}
+}
+
+function handleSelectionChange(event: any) {
+	selection.value = event.features;
+}
+
+function handleDrawUpdate() {
+	currentGeometry = getCurrentGeometry();
+
+	if (!currentGeometry) {
+		controls.draw.deleteAll();
+		emit('input', null);
+	} else {
+		emit('input', serialize(currentGeometry as any));
+	}
+}
+
+function handleKeyDown(event: any) {
+	if ([8, 46].includes(event.keyCode)) {
+		controls.draw.trash();
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/map/options.vue
+++ b/app/src/interfaces/map/options.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="form-grid">
-		<div v-if="!nativeGeometryType && field.type !== 'csv'" class="field half-left">
+		<div v-if="!nativeGeometryType && field?.type !== 'csv'" class="field half-left">
 			<div class="type-label">{{ t('interfaces.map.geometry_type') }}</div>
 			<v-select
 				v-model="geometryType"
@@ -16,104 +16,86 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { ref, defineComponent, PropType, watch, onMounted, onUnmounted, computed, toRefs } from 'vue';
-import { GEOMETRY_TYPES } from '@cairncms/constants';
-import { Field, GeometryType, GeometryOptions } from '@cairncms/types';
-import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
-import 'maplibre-gl/dist/maplibre-gl.css';
-import { Map, CameraOptions } from 'maplibre-gl';
+<script setup lang="ts">
 import { useAppStore } from '@/stores/app';
 import { useSettingsStore } from '@/stores/settings';
+import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
+import { GEOMETRY_TYPES } from '@cairncms/constants';
+import { Field, GeometryOptions, GeometryType } from '@cairncms/types';
+import { CameraOptions, Map } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import type { Ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		field: {
-			type: Object as PropType<Field>,
-			default: null,
-		},
-		value: {
-			type: Object as PropType<GeometryOptions & { defaultView?: CameraOptions }>,
-			default: null,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: string;
+	field?: Field;
+	value?: GeometryOptions & { defaultView?: CameraOptions };
+}>();
 
-		const nativeGeometryType = computed(() => (props.field?.type.split('.')[1] as GeometryType) ?? 'Point');
-		const geometryType = ref<GeometryType>(nativeGeometryType.value ?? props.value?.geometryType ?? 'Point');
-		const defaultView = ref<CameraOptions | undefined>(props.value?.defaultView);
+const emit = defineEmits(['input']);
 
-		const settingsStore = useSettingsStore();
+const { t } = useI18n();
 
-		watch(() => props.field?.type, watchType);
-		watch(nativeGeometryType, watchNativeType);
-		watch([geometryType, defaultView], input, { immediate: true });
+const nativeGeometryType = computed(() => (props.field?.type.split('.')[1] as GeometryType) ?? 'Point');
+const geometryType = ref<GeometryType>(nativeGeometryType.value ?? props.value?.geometryType ?? 'Point');
+const defaultView = ref<CameraOptions | undefined>(props.value?.defaultView);
 
-		function watchType(type: string | undefined) {
-			if (type === 'csv') geometryType.value = 'Point';
-		}
+const settingsStore = useSettingsStore();
 
-		function watchNativeType(type: GeometryType) {
-			geometryType.value = type;
-		}
+watch(() => props.field?.type, watchType);
+watch(nativeGeometryType, watchNativeType);
+watch([geometryType, defaultView], input, { immediate: true });
 
-		function input() {
-			emit('input', {
-				defaultView,
-				geometryType: geometryType.value,
-			});
-		}
+function watchType(type: string | undefined) {
+	if (type === 'csv') geometryType.value = 'Point';
+}
 
-		const mapContainer = ref<HTMLElement | null>(null);
-		let map: Map;
+function watchNativeType(type: GeometryType) {
+	geometryType.value = type;
+}
 
-		const mapboxKey = settingsStore.settings?.mapbox_key;
-		const basemaps = getBasemapSources();
-		const appStore = useAppStore();
-		const { basemap } = toRefs(appStore);
+function input() {
+	emit('input', {
+		defaultView,
+		geometryType: geometryType.value,
+	});
+}
 
-		const style = computed(() => {
-			const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
-			return getStyleFromBasemapSource(source);
-		});
+const mapContainer: Ref<HTMLElement | null> = ref(null);
+let map: Map;
 
-		onMounted(() => {
-			map = new Map({
-				container: mapContainer.value!,
-				style: style.value,
-				...(defaultView.value || {}),
-				...(mapboxKey ? { accessToken: mapboxKey } : {}),
-			});
+const mapboxKey = settingsStore.settings?.mapbox_key;
+const basemaps = getBasemapSources();
+const appStore = useAppStore();
+const { basemap } = toRefs(appStore);
 
-			map.on('moveend', () => {
-				defaultView.value = {
-					center: map.getCenter(),
-					zoom: map.getZoom(),
-					bearing: map.getBearing(),
-					pitch: map.getPitch(),
-				};
-			});
-		});
+const style = computed(() => {
+	const source = basemaps.find((source) => source.name == basemap.value) ?? basemaps[0];
+	return getStyleFromBasemapSource(source);
+});
 
-		onUnmounted(() => {
-			map.remove();
-		});
+onMounted(() => {
+	map = new Map({
+		container: mapContainer.value!,
+		style: style.value,
+		...(defaultView.value || {}),
+		...(mapboxKey ? { accessToken: mapboxKey } : {}),
+	});
 
-		return {
-			t,
-			nativeGeometryType,
-			GEOMETRY_TYPES,
-			geometryType,
-			mapContainer,
+	map.on('moveend', () => {
+		defaultView.value = {
+			center: map.getCenter(),
+			zoom: map.getZoom(),
+			bearing: map.getBearing(),
+			pitch: map.getPitch(),
 		};
-	},
+	});
+});
+
+onUnmounted(() => {
+	map.remove();
 });
 </script>
 

--- a/app/src/interfaces/presentation-divider/presentation-divider.vue
+++ b/app/src/interfaces/presentation-divider/presentation-divider.vue
@@ -13,29 +13,13 @@
 	</v-divider>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-	props: {
-		color: {
-			type: String,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: null,
-		},
-		title: {
-			type: String,
-			default: null,
-		},
-		inlineTitle: {
-			type: Boolean,
-			default: false,
-		},
-	},
-});
+<script setup lang="ts">
+defineProps<{
+	color?: string;
+	icon?: string;
+	title?: string;
+	inlineTitle?: boolean;
+}>();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/presentation-links/presentation-links.vue
+++ b/app/src/interfaces/presentation-links/presentation-links.vue
@@ -17,14 +17,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, toRefs } from 'vue';
-import { render } from 'micromustache';
-import { omit } from 'lodash';
 import { useItem } from '@/composables/use-item';
-import { getFieldsFromTemplate } from '@cairncms/utils';
-import { Query } from '@cairncms/types';
 import { useCollection } from '@cairncms/composables';
 import { RELATIONAL_TYPES } from '@cairncms/constants';
+import { Query } from '@cairncms/types';
+import { getFieldsFromTemplate } from '@cairncms/utils';
+import { omit } from 'lodash';
+import { render } from 'micromustache';
+import { computed, inject, ref, toRefs } from 'vue';
 
 type Link = {
 	icon: string;
@@ -66,7 +66,11 @@ const fullItem = computed(() => {
 	const itemValue = item.value ?? {};
 
 	for (const field of fields.value) {
-		if (field.meta?.special?.some((special) => RELATIONAL_TYPES.includes(special))) continue;
+		if (
+			field.meta?.special?.some((special) => RELATIONAL_TYPES.includes(special as (typeof RELATIONAL_TYPES)[number]))
+		) {
+			continue;
+		}
 
 		itemValue[field.field] = values.value[field.field];
 	}

--- a/app/src/interfaces/presentation-notice/presentation-notice.vue
+++ b/app/src/interfaces/presentation-notice/presentation-notice.vue
@@ -6,25 +6,19 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-	props: {
-		color: {
-			type: String,
-			default: 'normal',
-		},
-		icon: {
-			type: String,
-			default: 'info',
-		},
-		text: {
-			type: String,
-			default: 'No text configured...',
-		},
-	},
-});
+<script setup lang="ts">
+withDefaults(
+	defineProps<{
+		color?: string;
+		icon?: string;
+		text?: string;
+	}>(),
+	{
+		color: 'normal',
+		icon: 'info',
+		text: 'No text configured...',
+	}
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -76,8 +76,9 @@
 </template>
 
 <script setup lang="ts">
-import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
 import { useRelationM2O } from '@/composables/use-relation-m2o';
+import { useRelationPermissionsM2O } from '@/composables/use-relation-permissions';
+import { RelationQuerySingle, useRelationSingle } from '@/composables/use-relation-single';
 import { useCollectionsStore } from '@/stores/collections';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { parseFilter } from '@/utils/parse-filter';
@@ -89,7 +90,6 @@ import { get } from 'lodash';
 import { render } from 'micromustache';
 import { computed, inject, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRelationPermissionsM2O } from '@/composables/use-relation-permissions';
 
 const props = withDefaults(
 	defineProps<{
@@ -220,11 +220,11 @@ const selection = computed<(number | string)[]>(() => {
 	return [props.value];
 });
 
-function onSelection(selection: (number | string)[]) {
-	if (selection.length === 0) {
+function onSelection(selection: (number | string)[] | null) {
+	if (selection!.length === 0) {
 		remove();
 	} else {
-		update(selection[0]);
+		update(selection![0]);
 	}
 
 	selectModalActive.value = false;

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -18,10 +18,9 @@
 	</v-select>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
 import { i18n } from '@/lang';
+import { useI18n } from 'vue-i18n';
 
 type Option = {
 	text: string;
@@ -29,41 +28,22 @@ type Option = {
 	children?: Option[];
 };
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: [String, Number],
-			default: null,
-		},
-		choices: {
-			type: Array as PropType<Option[]>,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: null,
-		},
-		allowNone: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: () => i18n.global.t('select_an_item'),
-		},
-		allowOther: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['input'],
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+withDefaults(
+	defineProps<{
+		value: string | number | null;
+		disabled?: boolean;
+		choices?: Option[];
+		icon?: string;
+		allowNone?: boolean;
+		placeholder?: string;
+		allowOther?: boolean;
+	}>(),
+	{
+		placeholder: () => i18n.global.t('select_an_item'),
+	}
+);
+
+defineEmits(['input']);
+
+const { t } = useI18n();
 </script>

--- a/app/src/interfaces/select-icon/select-icon.vue
+++ b/app/src/interfaces/select-icon/select-icon.vue
@@ -45,55 +45,47 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import formatTitle from '@cairncms/format-title';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import icons from './icons.json';
-import { defineComponent, ref, computed } from 'vue';
-import formatTitle from '@cairncms/format-title';
 
-export default defineComponent({
-	props: {
-		value: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		width: {
-			type: String,
-			default: 'half',
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+withDefaults(
+	defineProps<{
+		value: string | null;
+		disabled?: boolean;
+		width?: string;
+	}>(),
+	{
+		width: 'half',
+	}
+);
 
-		const searchQuery = ref('');
+const emit = defineEmits(['input']);
 
-		const filteredIcons = computed(() => {
-			if (searchQuery.value.length === 0) return icons;
+const { t } = useI18n();
 
-			return icons.map((group) => {
-				const icons = group.icons.filter((icon) => icon.includes(searchQuery.value.toLowerCase()));
+const searchQuery = ref('');
 
-				return {
-					name: group.name,
-					icons,
-				};
-			});
-		});
+const filteredIcons = computed(() => {
+	if (searchQuery.value.length === 0) return icons;
 
-		return { t, icons, setIcon, searchQuery, filteredIcons, formatTitle };
+	return icons.map((group) => {
+		const icons = group.icons.filter((icon) => icon.includes(searchQuery.value.toLowerCase()));
 
-		function setIcon(icon: string | null) {
-			searchQuery.value = '';
-
-			emit('input', icon);
-		}
-	},
+		return {
+			name: group.name,
+			icons,
+		};
+	});
 });
+
+function setIcon(icon: string | null) {
+	searchQuery.value = '';
+
+	emit('input', icon);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
+++ b/app/src/interfaces/select-multiple-checkbox-tree/select-multiple-checkbox-tree.vue
@@ -34,9 +34,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { debounce } from 'lodash';
-import { defineComponent, PropType, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 type Choice = {
@@ -45,43 +45,34 @@ type Choice = {
 	children?: Choice[];
 };
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		choices: {
-			type: Array as PropType<Choice[]>,
-			default: () => [],
-		},
-		valueCombining: {
-			type: String as PropType<'all' | 'branch' | 'leaf' | 'indeterminate' | 'exclusive'>,
-			default: 'all',
-		},
-	},
-	emits: ['input'],
-	setup() {
-		const { t } = useI18n();
-		const search = ref('');
+withDefaults(
+	defineProps<{
+		value: string[] | null;
+		disabled?: boolean;
+		choices?: Choice[];
+		valueCombining?: 'all' | 'branch' | 'leaf' | 'indeterminate' | 'exclusive';
+	}>(),
+	{
+		value: () => [],
+		choices: () => [],
+		valueCombining: 'all',
+	}
+);
 
-		const showSelectionOnly = ref(false);
+defineEmits(['input']);
 
-		const setSearchDebounced = debounce((val: string) => {
-			searchDebounced.value = val;
-		}, 250);
+const { t } = useI18n();
+const search = ref('');
 
-		watch(search, setSearchDebounced);
+const showSelectionOnly = ref(false);
 
-		const searchDebounced = ref('');
+const setSearchDebounced = debounce((val: string) => {
+	searchDebounced.value = val;
+}, 250);
 
-		return { search, t, searchDebounced, showSelectionOnly };
-	},
-});
+watch(search, setSearchDebounced);
+
+const searchDebounced = ref('');
 </script>
 
 <style scoped>

--- a/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
+++ b/app/src/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue
@@ -61,110 +61,77 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, toRefs, PropType, ref } from 'vue';
+<script setup lang="ts">
 import { useCustomSelectionMultiple } from '@cairncms/composables';
+import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Option = {
 	text: string;
 	value: string | number | boolean;
 };
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: Array as PropType<string[]>,
-			default: null,
-		},
-		choices: {
-			type: Array as PropType<Option[]>,
-			default: null,
-		},
-		allowOther: {
-			type: Boolean,
-			default: false,
-		},
-		width: {
-			type: String,
-			default: null,
-		},
-		iconOn: {
-			type: String,
-			default: 'check_box',
-		},
-		iconOff: {
-			type: String,
-			default: 'check_box_outline_blank',
-		},
-		color: {
-			type: String,
-			default: 'var(--primary)',
-		},
-		itemsShown: {
-			type: Number,
-			default: 8,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string[] | null;
+		disabled?: boolean;
+		choices: Option[];
+		allowOther?: boolean;
+		width?: string;
+		iconOn?: string;
+		iconOff?: string;
+		color?: string;
+		itemsShown?: number;
+	}>(),
+	{
+		iconOn: 'check_box',
+		iconOff: 'check_box_outline_blank',
+		color: 'var(--primary)',
+		itemsShown: 8,
+	}
+);
 
-		const { choices, value } = toRefs(props);
-		const showAll = ref(false);
+const emit = defineEmits(['input']);
 
-		const hideChoices = computed(() => props.choices.length > props.itemsShown);
+const { t } = useI18n();
 
-		const choicesDisplayed = computed(() => {
-			if (showAll.value || hideChoices.value === false) {
-				return props.choices;
-			}
+const { choices, value } = toRefs(props);
+const showAll = ref(false);
 
-			return props.choices.slice(0, props.itemsShown);
-		});
+const hideChoices = computed(() => props.choices!.length > props.itemsShown);
 
-		const hiddenCount = computed(() => props.choices.length - props.itemsShown);
+const choicesDisplayed = computed(() => {
+	if (showAll.value || hideChoices.value === false) {
+		return props.choices;
+	}
 
-		const gridClass = computed(() => {
-			if (choices.value === null) return null;
-
-			const widestOptionLength = choices.value.reduce((acc, val) => {
-				if (val.text.length > acc.length) acc = val.text;
-				return acc;
-			}, '').length;
-
-			if (props.width?.startsWith('half')) {
-				if (widestOptionLength <= 10) return 'grid-2';
-				return 'grid-1';
-			}
-
-			if (widestOptionLength <= 10) return 'grid-4';
-			if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
-			if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
-			return 'grid-1';
-		});
-
-		const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(value, choices, (value) =>
-			emit('input', value)
-		);
-
-		return {
-			t,
-			gridClass,
-			otherValues,
-			addOtherValue,
-			setOtherValue,
-			choicesDisplayed,
-			hideChoices,
-			showAll,
-			hiddenCount,
-		};
-	},
+	return props.choices!.slice(0, props.itemsShown);
 });
+
+const hiddenCount = computed(() => props.choices!.length - props.itemsShown);
+
+const gridClass = computed(() => {
+	if (choices?.value === undefined) return null;
+
+	const widestOptionLength = choices.value.reduce((acc, val) => {
+		if (val.text.length > acc.length) acc = val.text;
+		return acc;
+	}, '').length;
+
+	if (props.width?.startsWith('half')) {
+		if (widestOptionLength <= 10) return 'grid-2';
+		return 'grid-1';
+	}
+
+	if (widestOptionLength <= 10) return 'grid-4';
+	if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
+	if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
+	return 'grid-1';
+});
+
+const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(value, choices, (value) =>
+	emit('input', value)
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
+++ b/app/src/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue
@@ -21,65 +21,42 @@
 	</v-select>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
 import { sortBy } from 'lodash';
+import { useI18n } from 'vue-i18n';
 
 type Option = {
 	text: string;
 	value: string | number | boolean;
 };
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: Array as PropType<string[]>,
-			default: null,
-		},
-		choices: {
-			type: Array as PropType<Option[]>,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: null,
-		},
-		allowNone: {
-			type: Boolean,
-			default: false,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		allowOther: {
-			type: Boolean,
-			default: false,
-		},
-		previewThreshold: {
-			type: Number,
-			default: 3,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value?: string[];
+		disabled?: boolean;
+		choices?: Option[];
+		icon?: string;
 
-		return { t, updateValue };
+		allowNone?: boolean;
+		placeholder?: string;
+		allowOther?: boolean;
+		previewThreshold?: number;
+	}>(),
+	{
+		previewThreshold: 3,
+	}
+);
 
-		function updateValue(value: PropType<string[]>) {
-			const sortedValue = sortBy(value, (val) => {
-				const sortIndex = props.choices.findIndex((choice) => val === choice.value);
-				return sortIndex !== -1 ? sortIndex : value.length;
-			});
+const emit = defineEmits(['input']);
 
-			emit('input', sortedValue);
-		}
-	},
-});
+const { t } = useI18n();
+
+function updateValue(value: string[]) {
+	const sortedValue = sortBy(value, (val) => {
+		const sortIndex = props.choices!.findIndex((choice) => val === choice.value);
+		return sortIndex !== -1 ? sortIndex : value.length;
+	});
+
+	emit('input', sortedValue);
+}
 </script>

--- a/app/src/interfaces/select-radio/select-radio.vue
+++ b/app/src/interfaces/select-radio/select-radio.vue
@@ -37,86 +37,69 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, toRefs, PropType } from 'vue';
+<script setup lang="ts">
 import { useCustomSelection } from '@cairncms/composables';
+import { computed, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Option = {
 	text: string;
 	value: string | number | boolean;
 };
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: [String, Number],
-			default: null,
-		},
-		choices: {
-			type: Array as PropType<Option[]>,
-			default: null,
-		},
-		allowOther: {
-			type: Boolean,
-			default: false,
-		},
-		width: {
-			type: String,
-			default: null,
-		},
-		iconOn: {
-			type: String,
-			default: 'radio_button_checked',
-		},
-		iconOff: {
-			type: String,
-			default: 'radio_button_unchecked',
-		},
-		color: {
-			type: String,
-			default: 'var(--primary)',
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string | number | null;
+		disabled?: boolean;
+		choices?: Option[];
 
-		const { choices, value } = toRefs(props);
+		allowOther?: boolean;
+		width?: string;
 
-		const gridClass = computed(() => {
-			if (choices.value === null) return null;
+		iconOn?: string;
+		iconOff?: string;
+		color?: string;
+	}>(),
+	{
+		iconOn: 'radio_button_checked',
+		iconOff: 'radio_button_unchecked',
+		color: 'var(--primary)',
+	}
+);
 
-			const widestOptionLength = choices.value.reduce((acc, val) => {
-				if (val.text.length > acc.length) acc = val.text;
-				return acc;
-			}, '').length;
+const emit = defineEmits(['input']);
 
-			if (props.width?.startsWith('half')) {
-				if (widestOptionLength <= 10) return 'grid-2';
-				return 'grid-1';
-			}
+const { t } = useI18n();
 
-			if (widestOptionLength <= 10) return 'grid-4';
-			if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
-			if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
-			return 'grid-1';
-		});
+const { choices, value } = toRefs(props);
 
-		const { otherValue, usesOtherValue } = useCustomSelection(value, choices, (value) => emit('input', value));
+const gridClass = computed(() => {
+	if (choices?.value === undefined) return null;
 
-		const customIcon = computed(() => {
-			if (!otherValue.value) return 'add';
-			if (otherValue.value && usesOtherValue.value === true) return props.iconOn;
-			return props.iconOff;
-		});
+	const widestOptionLength = choices.value.reduce((acc, val) => {
+		if (val.text.length > acc.length) acc = val.text;
+		return acc;
+	}, '').length;
 
-		return { t, gridClass, otherValue, usesOtherValue, customIcon };
-	},
+	if (props.width?.startsWith('half')) {
+		if (widestOptionLength <= 10) return 'grid-2';
+		return 'grid-1';
+	}
+
+	if (widestOptionLength <= 10) return 'grid-4';
+	if (widestOptionLength > 10 && widestOptionLength <= 15) return 'grid-3';
+	if (widestOptionLength > 15 && widestOptionLength <= 25) return 'grid-2';
+	return 'grid-1';
+});
+
+const { otherValue, usesOtherValue } = useCustomSelection(value as any, choices as any, (value) =>
+	emit('input', value)
+);
+
+const customIcon = computed(() => {
+	if (!otherValue.value) return 'add';
+	if (otherValue.value && usesOtherValue.value === true) return props.iconOn;
+	return props.iconOff;
 });
 </script>
 

--- a/app/src/interfaces/slider/slider.vue
+++ b/app/src/interfaces/slider/slider.vue
@@ -12,38 +12,24 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+withDefaults(
+	defineProps<{
+		value: number | null;
+		disabled?: boolean;
+		minValue?: number;
+		maxValue?: number;
+		stepInterval?: number;
+		alwaysShowValue?: boolean;
+	}>(),
+	{
+		minValue: 0,
+		maxValue: 100,
+		stepInterval: 1,
+	}
+);
 
-export default defineComponent({
-	props: {
-		value: {
-			type: Number,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		minValue: {
-			type: Number,
-			default: 0,
-		},
-		maxValue: {
-			type: Number,
-			default: 100,
-		},
-		stepInterval: {
-			type: Number,
-			default: 1,
-		},
-		alwaysShowValue: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['input'],
-});
+defineEmits(['input']);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/tags/tags.vue
+++ b/app/src/interfaces/tags/tags.vue
@@ -46,151 +46,120 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed, watch } from 'vue';
+<script setup lang="ts">
 import formatTitle from '@cairncms/format-title';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		value: {
-			type: [Array, String] as PropType<string[] | string>,
-			default: null,
-		},
-		placeholder: {
-			type: String,
-			default: null,
-		},
-		whitespace: {
-			type: String,
-			default: null,
-		},
-		capitalization: {
-			type: String as PropType<'uppercase' | 'lowercase' | 'auto-format'>,
-			default: null,
-		},
-		alphabetize: {
-			type: Boolean,
-			default: false,
-		},
-		iconLeft: {
-			type: String,
-			default: null,
-		},
-		iconRight: {
-			type: String,
-			default: 'local_offer',
-		},
-		presets: {
-			type: Array as PropType<string[]>,
-			default: null,
-		},
-		allowCustom: {
-			type: Boolean,
-			default: true,
-		},
-		direction: {
-			type: String,
-			default: undefined,
-		},
-	},
-	emits: ['input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		value: string[] | string | null;
+		disabled?: boolean;
+		placeholder?: string;
+		whitespace?: string;
+		capitalization?: 'uppercase' | 'lowercase' | 'auto-format';
+		alphabetize?: boolean;
+		iconLeft?: string;
+		iconRight?: string;
+		presets?: string[];
+		allowCustom?: boolean;
+		direction?: string;
+	}>(),
+	{
+		iconRight: 'local_offer',
+		allowCustom: true,
+	}
+);
 
-		const presetVals = computed<string[]>(() => {
-			if (props.presets !== null) return processArray(props.presets);
-			return [];
-		});
+const emit = defineEmits(['input']);
 
-		const selectedValsLocal = ref<string[]>(Array.isArray(props.value) ? processArray(props.value) : []);
+const { t } = useI18n();
 
-		watch(
-			() => props.value,
-			(newVal) => {
-				if (Array.isArray(newVal)) {
-					selectedValsLocal.value = processArray(newVal);
-				}
-
-				if (newVal === null) selectedValsLocal.value = [];
-			}
-		);
-
-		const selectedVals = computed<string[]>(() => {
-			let vals = processArray(selectedValsLocal.value);
-
-			if (!props.allowCustom) {
-				vals = vals.filter((val) => presetVals.value.includes(val));
-			}
-
-			return vals;
-		});
-
-		const customVals = computed<string[]>(() => {
-			return selectedVals.value.filter((val) => !presetVals.value.includes(val));
-		});
-
-		function processArray(array: string[]): string[] {
-			array = array.map((val) => {
-				val = val.trim();
-				if (props.capitalization === 'uppercase') val = val.toUpperCase();
-				if (props.capitalization === 'lowercase') val = val.toLowerCase();
-
-				const whitespace = props.whitespace === null ? ' ' : props.whitespace;
-
-				if (props.capitalization === 'auto-format') val = formatTitle(val, new RegExp(whitespace));
-
-				val = val.replace(/ +/g, whitespace);
-
-				return val;
-			});
-
-			if (props.alphabetize) {
-				array = array.concat().sort();
-			}
-
-			array = [...new Set(array)];
-
-			return array;
-		}
-
-		return { t, onInput, addTag, removeTag, toggleTag, presetVals, customVals, selectedVals };
-
-		function onInput(event: KeyboardEvent) {
-			if (event.target && (event.key === 'Enter' || event.key === ',')) {
-				event.preventDefault();
-				addTag((event.target as HTMLInputElement).value);
-				(event.target as HTMLInputElement).value = '';
-			}
-		}
-
-		function toggleTag(tag: string) {
-			selectedVals.value.includes(tag) ? removeTag(tag) : addTag(tag);
-		}
-
-		function addTag(tag: string) {
-			if (!tag || tag === '') return;
-			// Remove any leading / trailing whitespace from the value
-			tag = tag.trim();
-			// Convert the tag to lowercase
-			selectedValsLocal.value.push(tag);
-			emitValue();
-		}
-
-		function removeTag(tag: string) {
-			selectedValsLocal.value = selectedValsLocal.value.filter((savedTag) => savedTag !== tag);
-			emitValue();
-		}
-
-		function emitValue() {
-			emit('input', selectedVals.value);
-		}
-	},
+const presetVals = computed<string[]>(() => {
+	if (props.presets !== undefined) return processArray(props.presets);
+	return [];
 });
+
+const selectedValsLocal = ref<string[]>(Array.isArray(props.value) ? processArray(props.value) : []);
+
+watch(
+	() => props.value,
+	(newVal) => {
+		if (Array.isArray(newVal)) {
+			selectedValsLocal.value = processArray(newVal);
+		}
+
+		if (newVal === null) selectedValsLocal.value = [];
+	}
+);
+
+const selectedVals = computed<string[]>(() => {
+	let vals = processArray(selectedValsLocal.value);
+
+	if (!props.allowCustom) {
+		vals = vals.filter((val) => presetVals.value.includes(val));
+	}
+
+	return vals;
+});
+
+const customVals = computed<string[]>(() => {
+	return selectedVals.value.filter((val) => !presetVals.value.includes(val));
+});
+
+function processArray(array: string[]): string[] {
+	array = array.map((val) => {
+		val = val.trim();
+		if (props.capitalization === 'uppercase') val = val.toUpperCase();
+		if (props.capitalization === 'lowercase') val = val.toLowerCase();
+
+		const whitespace = props.whitespace === undefined ? ' ' : props.whitespace;
+
+		if (props.capitalization === 'auto-format') val = formatTitle(val, new RegExp(whitespace));
+
+		val = val.replace(/ +/g, whitespace);
+
+		return val;
+	});
+
+	if (props.alphabetize) {
+		array = array.concat().sort();
+	}
+
+	array = [...new Set(array)];
+
+	return array;
+}
+
+function onInput(event: KeyboardEvent) {
+	if (event.target && (event.key === 'Enter' || event.key === ',')) {
+		event.preventDefault();
+		addTag((event.target as HTMLInputElement).value);
+		(event.target as HTMLInputElement).value = '';
+	}
+}
+
+function toggleTag(tag: string) {
+	selectedVals.value.includes(tag) ? removeTag(tag) : addTag(tag);
+}
+
+function addTag(tag: string) {
+	if (!tag || tag === '') return;
+	// Remove any leading / trailing whitespace from the value
+	tag = tag.trim();
+	// Convert the tag to lowercase
+	selectedValsLocal.value.push(tag);
+	emitValue();
+}
+
+function removeTag(tag: string) {
+	selectedValsLocal.value = selectedValsLocal.value.filter((savedTag) => savedTag !== tag);
+	emitValue();
+}
+
+function emitValue() {
+	emit('input', selectedVals.value);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/interfaces/translations/language-select.vue
+++ b/app/src/interfaces/translations/language-select.vue
@@ -9,7 +9,7 @@
 			</button>
 		</template>
 
-		<v-list>
+		<v-list v-if="items">
 			<v-list-item v-for="(item, index) in items" :key="index" @click="$emit('update:modelValue', item.value)">
 				<div class="start">
 					<div class="dot" :class="{ show: item.edited }"></div>
@@ -28,34 +28,25 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 
-export default defineComponent({
-	components: {},
-	props: {
-		modelValue: {
-			type: String,
-			default: null,
-		},
-		items: {
-			type: Array as PropType<Record<string, any>[]>,
-			default: () => [],
-		},
-		secondary: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props) {
-		const displayValue = computed(() => {
-			const item = props.items.find((item) => item.value === props.modelValue);
-			return item?.text ?? props.modelValue;
-		});
+const props = withDefaults(
+	defineProps<{
+		modelValue?: string;
+		items?: Record<string, any>[];
+		secondary?: boolean;
+	}>(),
+	{
+		items: () => [],
+	}
+);
 
-		return { displayValue };
-	},
+defineEmits(['update:modelValue']);
+
+const displayValue = computed(() => {
+	const item = props.items.find((item) => item.value === props.modelValue);
+	return item?.text ?? props.modelValue;
 });
 </script>
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -182,6 +182,7 @@ permissions_for_role: 'Items the {role} Role can {action}.'
 fields_for_role: 'Fields the {role} Role can {action}.'
 validation_for_role: 'Field {action} rules the {role} Role must obey.'
 presets_for_role: 'Field value defaults for the {role} Role.'
+presets_field_warning: 'Relational presets for field "{field}" should be configured with the "detailed" syntax.'
 presentation_and_aliases: Presentation & Aliases
 revision_post_create: Here is what this item looked like when it was created.
 revision_post_update: Here is what this item looked like after the update.

--- a/app/src/layouts/calendar/actions.vue
+++ b/app/src/layouts/calendar/actions.vue
@@ -7,21 +7,16 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
+export default {
 	inheritAttrs: false,
-	props: {
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		showingCount: {
-			type: String,
-			default: null,
-		},
-	},
-});
+};
+</script>
+
+<script setup lang="ts">
+defineProps<{
+	itemCount?: number;
+	showingCount?: string;
+}>();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/calendar/index.ts
+++ b/app/src/layouts/calendar/index.ts
@@ -9,13 +9,13 @@ import { unexpectedError } from '@/utils/unexpected-error';
 import { useCollection, useItems, useSync } from '@cairncms/composables';
 import { Field, Item } from '@cairncms/types';
 import { defineLayout, getEndpoint, getFieldsFromTemplate } from '@cairncms/utils';
-import { Calendar, CalendarOptions as FullCalendarOptions, EventInput } from '@fullcalendar/core';
+import { Calendar, EventInput, CalendarOptions as FullCalendarOptions } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import listPlugin from '@fullcalendar/list';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import { format, formatISO, isValid, parse } from 'date-fns';
-import { computed, ref, Ref, toRefs, watch } from 'vue';
+import { Ref, computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import CalendarActions from './actions.vue';
 import CalendarLayout from './calendar.vue';
@@ -316,7 +316,7 @@ export default defineLayout<LayoutOptions>({
 				id: primaryKey,
 				title:
 					renderDisplayStringTemplate(
-						collection.value,
+						collection.value!,
 						template.value || `{{ ${primaryKeyField.value.field} }}`,
 						item
 					) || item[primaryKeyField.value.field],

--- a/app/src/layouts/calendar/options.vue
+++ b/app/src/layouts/calendar/options.vue
@@ -28,58 +28,44 @@
 </template>
 
 <script lang="ts">
+export default {
+	inheritAttrs: false,
+};
+</script>
+
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
 import { Field } from '@cairncms/types';
 import { useSync } from '@cairncms/composables';
 import { localizedFormat } from '@/utils/localized-format';
 import { add, startOfWeek } from 'date-fns';
 
-export default defineComponent({
-	inheritAttrs: false,
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		template: {
-			type: String,
-			default: null,
-		},
-		dateFields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		startDateField: {
-			type: String,
-			default: null,
-		},
-		endDateField: {
-			type: String,
-			default: null,
-		},
-		firstDay: {
-			type: Number,
-			default: 0,
-		},
-	},
-	emits: ['update:template', 'update:startDateField', 'update:endDateField', 'update:firstDay'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		collection: string;
+		dateFields: Field[];
+		template?: string;
+		startDateField?: string;
+		endDateField?: string;
+		firstDay?: number;
+	}>(),
+	{
+		firstDay: 0,
+	}
+);
 
-		const templateWritable = useSync(props, 'template', emit);
-		const startDateFieldWritable = useSync(props, 'startDateField', emit);
-		const endDateFieldWritable = useSync(props, 'endDateField', emit);
-		const firstDayWritable = useSync(props, 'firstDay', emit);
+const emit = defineEmits(['update:template', 'update:startDateField', 'update:endDateField', 'update:firstDay']);
+const { t } = useI18n();
 
-		const firstDayOfWeekForDate = startOfWeek(new Date());
+const templateWritable = useSync(props, 'template', emit);
+const startDateFieldWritable = useSync(props, 'startDateField', emit);
+const endDateFieldWritable = useSync(props, 'endDateField', emit);
+const firstDayWritable = useSync(props, 'firstDay', emit);
 
-		const firstDayOptions: { text: string; value: number }[] = [...Array(7).keys()].map((_, i) => ({
-			text: localizedFormat(add(firstDayOfWeekForDate, { days: i }), 'EEEE'),
-			value: i,
-		}));
+const firstDayOfWeekForDate = startOfWeek(new Date());
 
-		return { t, templateWritable, startDateFieldWritable, endDateFieldWritable, firstDayWritable, firstDayOptions };
-	},
-});
+const firstDayOptions: { text: string; value: number }[] = [...Array(7).keys()].map((_, i) => ({
+	text: localizedFormat(add(firstDayOfWeekForDate, { days: i }), 'EEEE'),
+	value: i,
+}));
 </script>

--- a/app/src/layouts/cards/actions.vue
+++ b/app/src/layouts/cards/actions.vue
@@ -6,21 +6,18 @@
 	</transition>
 </template>
 
+<script lang="ts" setup>
+defineProps<{
+	itemCount?: number;
+	showingCount: string;
+}>();
+</script>
+
 <script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({
 	inheritAttrs: false,
-	props: {
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		showingCount: {
-			type: String,
-			required: true,
-		},
-	},
 });
 </script>
 

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -1,6 +1,6 @@
 <template>
 	<div ref="layoutElement" class="layout-cards" :style="{ '--size': size * 40 + 'px' }">
-		<template v-if="loading || itemCount > 0">
+		<template v-if="loading || itemCount! > 0">
 			<cards-header
 				v-model:size="sizeWritable"
 				v-model:selection="selectionWritable"
@@ -13,9 +13,9 @@
 			<div class="grid" :class="{ 'single-row': isSingleRow }">
 				<card
 					v-for="item in items"
-					:key="item[primaryKeyField.field]"
+					:key="item[primaryKeyField!.field]"
 					v-model="selectionWritable"
-					:item-key="primaryKeyField.field"
+					:item-key="primaryKeyField!.field"
 					:crop="imageFit === 'crop'"
 					:icon="icon"
 					:file="imageSource ? item[imageSource] : null"
@@ -75,167 +75,80 @@
 </template>
 
 <script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, watch, PropType, ref, inject, Ref } from 'vue';
+export default {
+	inheritAttrs: false,
+};
+</script>
 
+<script setup lang="ts">
+import { Collection } from '@/types/collections';
+import { useElementSize, useSync } from '@cairncms/composables';
+import { Field, Filter, Item, ShowSelect } from '@cairncms/types';
+import { Ref, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import Card from './components/card.vue';
 import CardsHeader from './components/header.vue';
-import { Field, Item } from '@cairncms/types';
-import { useSync, useElementSize } from '@cairncms/composables';
-import { Collection } from '@/types/collections';
-import { Filter, ShowSelect } from '@cairncms/types';
 
-export default defineComponent({
-	components: { Card, CardsHeader },
-	inheritAttrs: false,
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		selection: {
-			type: Array as PropType<Item[]>,
-			required: true,
-		},
-		showSelect: {
-			type: String as PropType<ShowSelect>,
-			default: 'multiple',
-		},
-		selectMode: {
-			type: Boolean,
-			required: true,
-		},
-		readonly: {
-			type: Boolean,
-			required: true,
-		},
-		items: {
-			type: Array as PropType<Item[]>,
-			required: true,
-		},
-		loading: {
-			type: Boolean,
-			required: true,
-		},
-		error: {
-			type: Object as PropType<any>,
-			default: null,
-		},
-		totalPages: {
-			type: Number,
-			required: true,
-		},
-		page: {
-			type: Number,
-			required: true,
-		},
-		toPage: {
-			type: Function as PropType<(newPage: number) => void>,
-			required: true,
-		},
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		fieldsInCollection: {
-			type: Array as PropType<Item[]>,
-			required: true,
-		},
-		limit: {
-			type: Number,
-			required: true,
-		},
-		size: {
-			type: Number,
-			required: true,
-		},
-		primaryKeyField: {
-			type: Object as PropType<Field>,
-			default: null,
-		},
-		icon: {
-			type: String,
-			required: true,
-		},
-		imageSource: {
-			type: String,
-			default: null,
-		},
-		title: {
-			type: String,
-			default: null,
-		},
-		subtitle: {
-			type: String,
-			default: null,
-		},
-		getLinkForItem: {
-			type: Function as PropType<(item: Record<string, any>) => string | undefined>,
-			required: true,
-		},
-		imageFit: {
-			type: String,
-			required: true,
-		},
-		sort: {
-			type: Array as PropType<string[]>,
-			required: true,
-		},
-		info: {
-			type: Object as PropType<Collection>,
-			default: null,
-		},
-		isSingleRow: {
-			type: Boolean,
-			required: true,
-		},
-		width: {
-			type: Number,
-			required: true,
-		},
-		selectAll: {
-			type: Function as PropType<() => void>,
-			required: true,
-		},
-		resetPresetAndRefresh: {
-			type: Function as PropType<() => Promise<void>>,
-			required: true,
-		},
-		filter: {
-			type: Object as PropType<Filter>,
-			default: null,
-		},
-		search: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['update:selection', 'update:limit', 'update:size', 'update:sort', 'update:width'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		collection: string;
+		items: Item[];
+		selection: (number | string)[];
+		selectMode: boolean;
+		readonly: boolean;
+		limit: number;
+		size: number;
+		icon: string;
+		imageFit: string;
+		isSingleRow: boolean;
+		width: number;
+		totalPages: number;
+		page: number;
+		toPage: (newPage: number) => void;
+		getLinkForItem: (item: Record<string, any>) => string | undefined;
+		fieldsInCollection: Field[];
+		selectAll: () => void;
+		resetPresetAndRefresh: () => Promise<void>;
+		sort: string[];
+		loading: boolean;
+		showSelect?: ShowSelect;
+		error?: any;
+		itemCount?: number;
+		primaryKeyField?: Field;
+		imageSource?: string;
+		title?: string;
+		subtitle?: string;
+		info?: Collection;
+		filter?: Filter;
+		search?: string;
+	}>(),
+	{
+		showSelect: 'multiple',
+	}
+);
 
-		const selectionWritable = useSync(props, 'selection', emit);
-		const limitWritable = useSync(props, 'limit', emit);
-		const sizeWritable = useSync(props, 'size', emit);
-		const sortWritable = useSync(props, 'sort', emit);
+const emit = defineEmits(['update:selection', 'update:limit', 'update:size', 'update:sort', 'update:width']);
 
-		const mainElement = inject<Ref<Element | undefined>>('main-element');
+const { t } = useI18n();
 
-		const layoutElement = ref<HTMLElement>();
+const selectionWritable = useSync(props, 'selection', emit);
+const limitWritable = useSync(props, 'limit', emit);
+const sizeWritable = useSync(props, 'size', emit);
+const sortWritable = useSync(props, 'sort', emit);
 
-		const { width } = useElementSize(layoutElement);
+const mainElement = inject<Ref<Element | undefined>>('main-element');
 
-		watch(
-			() => props.page,
-			() => mainElement.value?.scrollTo({ top: 0, behavior: 'smooth' })
-		);
+const layoutElement = ref<HTMLElement>();
 
-		watch(width, () => {
-			emit('update:width', width.value);
-		});
+const { width } = useElementSize(layoutElement);
 
-		return { t, selectionWritable, limitWritable, sizeWritable, sortWritable, layoutElement };
-	},
+watch(
+	() => props.page,
+	() => mainElement!.value?.scrollTo({ top: 0, behavior: 'smooth' })
+);
+
+watch(width, () => {
+	emit('update:width', width.value);
 });
 </script>
 

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -13,9 +13,9 @@
 				<template v-else>
 					<v-image
 						v-if="showThumbnail"
-						:class="imageInfo.fileType"
-						:src="imageInfo.source"
-						:alt="item.title"
+						:class="imageInfo?.fileType"
+						:src="imageInfo?.source"
+						:alt="item?.title"
 						role="presentation"
 					/>
 					<v-icon v-else large :name="icon" />
@@ -30,9 +30,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { readableMimeType } from '@/utils/readable-mime-type';
-import { computed, defineComponent, PropType, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 type File = {
@@ -42,115 +42,88 @@ type File = {
 	modified_on: Date;
 };
 
-export default defineComponent({
-	props: {
-		icon: {
-			type: String,
-			default: 'deployed_code',
-		},
-		file: {
-			type: Object as PropType<File>,
-			default: null,
-		},
-		crop: {
-			type: Boolean,
-			default: false,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		item: {
-			type: Object as PropType<Record<string, any>>,
-			default: null,
-		},
-		modelValue: {
-			type: Array as PropType<(string | number)[]>,
-			default: () => [],
-		},
-		selectMode: {
-			type: Boolean,
-			default: false,
-		},
-		to: {
-			type: String,
-			default: '',
-		},
-		readonly: {
-			type: Boolean,
-			default: false,
-		},
-		itemKey: {
-			type: String,
-			required: true,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const router = useRouter();
+const props = withDefaults(
+	defineProps<{
+		itemKey: string;
+		icon?: string;
+		file?: File;
+		crop?: boolean;
+		loading?: boolean;
+		item?: Record<string, any>;
+		modelValue?: (string | number)[];
+		selectMode?: boolean;
+		to?: string;
+		readonly?: boolean;
+	}>(),
+	{
+		icon: 'deployed_code',
+		modelValue: () => [],
+		to: '',
+	}
+);
 
-		const imgError = ref(false);
+const emit = defineEmits(['update:modelValue']);
 
-		const type = computed(() => {
-			if (!props.file || !props.file.type) return null;
-			if (!imgError.value && props.file.type.startsWith('image')) return null;
-			return readableMimeType(props.file.type, true);
-		});
+const router = useRouter();
 
-		const imageInfo = computed(() => {
-			let fileType = undefined;
-			if (!props.file || !props.file.type) return null;
-			if (props.file.type.startsWith('image') === true) fileType = 'image';
-			if (props.file.type.includes('svg')) fileType = 'svg';
+const imgError = ref(false);
 
-			// Show icon instead of thumbnail
-			if (!fileType) return { source: undefined, fileType };
-
-			let key = 'system-medium-cover';
-
-			if (props.crop === false) {
-				key = 'system-medium-contain';
-			}
-
-			const source = `/assets/${props.file.id}?key=${key}&modified=${props.file.modified_on}`;
-
-			return { source, fileType };
-		});
-
-		const showThumbnail = computed(() => {
-			return imageInfo.value && imageInfo.value.fileType;
-		});
-
-		const selectionIcon = computed(() => {
-			if (!props.item) return 'radio_button_unchecked';
-
-			return props.modelValue.includes(props.item[props.itemKey]) ? 'check_circle' : 'radio_button_unchecked';
-		});
-
-		return { imageInfo, type, showThumbnail, selectionIcon, toggleSelection, handleClick, imgError };
-
-		function toggleSelection() {
-			if (!props.item) return null;
-
-			if (props.modelValue.includes(props.item[props.itemKey])) {
-				emit(
-					'update:modelValue',
-					props.modelValue.filter((key) => key !== props.item[props.itemKey])
-				);
-			} else {
-				emit('update:modelValue', [...props.modelValue, props.item[props.itemKey]]);
-			}
-		}
-
-		function handleClick() {
-			if (props.selectMode === true) {
-				toggleSelection();
-			} else {
-				router.push(props.to);
-			}
-		}
-	},
+const type = computed(() => {
+	if (!props.file || !props.file.type) return null;
+	if (!imgError.value && props.file.type.startsWith('image')) return null;
+	return readableMimeType(props.file.type, true);
 });
+
+const imageInfo = computed(() => {
+	let fileType = undefined;
+	if (!props.file || !props.file.type) return null;
+	if (props.file.type.startsWith('image') === true) fileType = 'image';
+	if (props.file.type.includes('svg')) fileType = 'svg';
+
+	// Show icon instead of thumbnail
+	if (!fileType) return { source: undefined, fileType };
+
+	let key = 'system-medium-cover';
+
+	if (props.crop === false) {
+		key = 'system-medium-contain';
+	}
+
+	const source = `/assets/${props.file.id}?key=${key}&modified=${props.file.modified_on}`;
+
+	return { source, fileType };
+});
+
+const showThumbnail = computed(() => {
+	return imageInfo.value && imageInfo.value.fileType;
+});
+
+const selectionIcon = computed(() => {
+	if (!props.item) return 'radio_button_unchecked';
+
+	return props.modelValue.includes(props.item[props.itemKey]) ? 'check_circle' : 'radio_button_unchecked';
+});
+
+function toggleSelection() {
+	if (!props.item) return null;
+
+	if (props.modelValue.includes(props.item[props.itemKey])) {
+		emit(
+			'update:modelValue',
+			props.modelValue.filter((key) => key !== props.item?.[props.itemKey])
+		);
+	} else {
+		emit('update:modelValue', [...props.modelValue, props.item[props.itemKey]]);
+	}
+}
+
+function handleClick() {
+	if (props.selectMode === true) {
+		toggleSelection();
+	} else {
+		router.push(props.to);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/cards/components/header.vue
+++ b/app/src/layouts/cards/components/header.vue
@@ -51,91 +51,67 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Field, ShowSelect } from '@cairncms/types';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
+import { Field, ShowSelect } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		fields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		size: {
-			type: Number,
-			required: true,
-		},
-		sort: {
-			type: Array as PropType<string[]>,
-			required: true,
-		},
-		showSelect: {
-			type: String as PropType<ShowSelect>,
-			default: 'multiple',
-		},
-		selection: {
-			type: Array as PropType<Record<string, any>>,
-			default: () => [],
-		},
-	},
-	emits: ['select-all', 'update:size', 'update:sort', 'update:selection'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		fields: Field[];
+		size: number;
+		sort: string[];
+		showSelect?: ShowSelect;
+		selection?: (number | string)[];
+	}>(),
+	{
+		showSelect: 'multiple',
+		selection: () => [],
+	}
+);
 
-		const sizeSync = useSync(props, 'size', emit);
-		const sortSync = useSync(props, 'sort', emit);
-		const selectionSync = useSync(props, 'selection', emit);
+const emit = defineEmits(['select-all', 'update:size', 'update:sort', 'update:selection']);
 
-		const descending = computed(() => props.sort[0].startsWith('-'));
+const { t } = useI18n();
 
-		const sortKey = computed(() => (props.sort[0].startsWith('-') ? props.sort[0].substring(1) : props.sort[0]));
+const sizeSync = useSync(props, 'size', emit);
+const sortSync = useSync(props, 'sort', emit);
+const selectionSync = useSync(props, 'selection', emit);
 
-		const sortField = computed(() => {
-			return props.fields.find((field) => field.field === sortKey.value);
-		});
+const descending = computed(() => props.sort[0].startsWith('-'));
 
-		const fieldsWithoutFake = computed(() => {
-			return props.fields
-				.filter((field) => field.field.startsWith('$') === false)
-				.map((field) => ({
-					field: field.field,
-					name: field.name,
-					disabled: ['json', 'o2m', 'm2o', 'm2a', 'file', 'files', 'alias', 'presentation'].includes(field.type),
-				}));
-		});
+const sortKey = computed(() => (props.sort[0].startsWith('-') ? props.sort[0].substring(1) : props.sort[0]));
 
-		return {
-			t,
-			toggleSize,
-			descending,
-			toggleDescending,
-			sortField,
-			sizeSync,
-			sortSync,
-			selectionSync,
-			sortKey,
-			fieldsWithoutFake,
-		};
-
-		function toggleSize() {
-			if (props.size >= 2 && props.size < 5) {
-				sizeSync.value++;
-			} else {
-				sizeSync.value = 2;
-			}
-		}
-
-		function toggleDescending() {
-			if (descending.value === true) {
-				sortSync.value = [sortSync.value[0].substring(1)];
-			} else {
-				sortSync.value = ['-' + sortSync.value];
-			}
-		}
-	},
+const sortField = computed(() => {
+	return props.fields.find((field) => field.field === sortKey.value);
 });
+
+const fieldsWithoutFake = computed(() => {
+	return props.fields
+		.filter((field) => field.field.startsWith('$') === false)
+		.map((field) => ({
+			field: field.field,
+			name: field.name,
+			disabled: ['json', 'o2m', 'm2o', 'm2a', 'file', 'files', 'alias', 'presentation'].includes(field.type),
+		}));
+});
+
+function toggleSize() {
+	if (props.size >= 2 && props.size < 5) {
+		sizeSync.value++;
+	} else {
+		sizeSync.value = 2;
+	}
+}
+
+function toggleDescending() {
+	if (descending.value === true) {
+		sortSync.value = [sortSync.value[0].substring(1)];
+	} else {
+		sortSync.value = ['-' + sortSync.value];
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/cards/options.vue
+++ b/app/src/layouts/cards/options.vue
@@ -44,57 +44,44 @@
 	</v-detail>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
 
-import { Field } from '@cairncms/types';
 import { useSync } from '@cairncms/composables';
+import { Field } from '@cairncms/types';
+
+const props = defineProps<{
+	collection: string;
+	icon: string;
+	fileFields: Field[];
+	imageFit: string;
+	imageSource?: string | null;
+	title?: string;
+	subtitle?: string;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:icon', icon: string): void;
+	(e: 'update:imageSource', imageSource: string): void;
+	(e: 'update:title', title: string): void;
+	(e: 'update:subtitle', subtitle: string): void;
+	(e: 'update:imageFit', imageFit: string): void;
+}>();
+
+const { t } = useI18n();
+
+const iconWritable = useSync(props, 'icon', emit);
+const imageSourceWritable = useSync(props, 'imageSource', emit);
+const titleWritable = useSync(props, 'title', emit);
+const subtitleWritable = useSync(props, 'subtitle', emit);
+const imageFitWritable = useSync(props, 'imageFit', emit);
+</script>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
 	inheritAttrs: false,
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		icon: {
-			type: String,
-			required: true,
-		},
-		fileFields: {
-			type: Array as PropType<Field[]>,
-			required: true,
-		},
-		imageSource: {
-			type: String,
-			default: null,
-		},
-		title: {
-			type: String,
-			default: null,
-		},
-		subtitle: {
-			type: String,
-			default: null,
-		},
-		imageFit: {
-			type: String,
-			required: true,
-		},
-	},
-	emits: ['update:icon', 'update:imageSource', 'update:title', 'update:subtitle', 'update:imageFit'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const iconWritable = useSync(props, 'icon', emit);
-		const imageSourceWritable = useSync(props, 'imageSource', emit);
-		const titleWritable = useSync(props, 'title', emit);
-		const subtitleWritable = useSync(props, 'subtitle', emit);
-		const imageFitWritable = useSync(props, 'imageFit', emit);
-
-		return { t, iconWritable, imageSourceWritable, titleWritable, subtitleWritable, imageFitWritable };
-	},
 });
 </script>
 

--- a/app/src/layouts/map/actions.vue
+++ b/app/src/layouts/map/actions.vue
@@ -6,21 +6,18 @@
 	</transition>
 </template>
 
+<script lang="ts" setup>
+defineProps<{
+	itemCount?: number;
+	showingCount: string;
+}>();
+</script>
+
 <script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({
 	inheritAttrs: false,
-	props: {
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		showingCount: {
-			type: String,
-			required: true,
-		},
-	},
 });
 </script>
 

--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -6,364 +6,343 @@
 	></div>
 </template>
 
-<script lang="ts">
-import 'maplibre-gl/dist/maplibre-gl.css';
-import maplibre, {
-	MapboxGeoJSONFeature,
-	MapLayerMouseEvent,
-	NavigationControl,
-	GeolocateControl,
-	LngLatBoundsLike,
-	GeoJSONSource,
-	CameraOptions,
-	LngLatLike,
-	AnyLayer,
-	Map,
-	AttributionControl,
-} from 'maplibre-gl';
+<script setup lang="ts">
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
-import { ref, watch, PropType, onMounted, onUnmounted, defineComponent, toRefs, computed, WatchStopHandle } from 'vue';
+import maplibre, {
+	AnyLayer,
+	AttributionControl,
+	CameraOptions,
+	GeoJSONSource,
+	GeolocateControl,
+	LngLatBoundsLike,
+	LngLatLike,
+	Map,
+	MapLayerMouseEvent,
+	MapboxGeoJSONFeature,
+	NavigationControl,
+} from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { WatchStopHandle, computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ShowSelect } from '@cairncms/types';
 import { useAppStore } from '@/stores/app';
 import { useSettingsStore } from '@/stores/settings';
-import { BoxSelectControl, ButtonControl } from '@/utils/geometry/controls';
 import { getBasemapSources, getStyleFromBasemapSource } from '@/utils/geometry/basemap';
+import { BoxSelectControl, ButtonControl } from '@/utils/geometry/controls';
+import { ShowSelect } from '@cairncms/types';
 
-export default defineComponent({
-	components: {},
-	props: {
-		data: {
-			type: Object as PropType<GeoJSON.FeatureCollection>,
-			required: true,
-		},
-		source: {
-			type: Object as PropType<GeoJSONSource>,
-			required: true,
-		},
-		layers: {
-			type: Array as PropType<AnyLayer[]>,
-			default: () => [],
-		},
-		camera: {
-			type: Object as PropType<CameraOptions & { bbox: any }>,
-			default: () => ({} as any),
-		},
-		bounds: {
-			type: Array as unknown as PropType<GeoJSON.BBox>,
-			default: undefined,
-		},
-		featureId: {
-			type: String,
-			default: undefined,
-		},
-		selection: {
-			type: Array as PropType<Array<string | number>>,
-			default: () => [],
-		},
-		showSelect: {
-			type: String as PropType<ShowSelect>,
-			default: 'multiple',
-		},
-	},
-	emits: ['moveend', 'featureclick', 'featureselect', 'fitdata', 'updateitempopup'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-		const appStore = useAppStore();
-		const settingsStore = useSettingsStore();
-		let map: Map;
-		const hoveredFeature = ref<MapboxGeoJSONFeature>();
-		const hoveredCluster = ref<boolean>();
-		const selectMode = ref<boolean>();
-		const container = ref<HTMLElement>();
-		const unwatchers = [] as WatchStopHandle[];
-		const { sidebarOpen, basemap } = toRefs(appStore);
-		const mapboxKey = settingsStore.settings?.mapbox_key;
-		const basemaps = getBasemapSources();
+const props = withDefaults(
+	defineProps<{
+		data: GeoJSON.FeatureCollection;
+		source: GeoJSONSource;
+		layers?: AnyLayer[];
+		camera?: CameraOptions & { bbox: any };
+		bounds?: GeoJSON.BBox;
+		featureId?: string;
+		selection?: (string | number)[];
+		showSelect?: ShowSelect;
+	}>(),
+	{
+		layers: () => [],
+		camera: () => ({} as any),
+		selection: () => [],
+		showSelect: 'multiple',
+	}
+);
 
-		const style = computed(() => {
-			const source = basemaps.find((source) => source.name === basemap.value) ?? basemaps[0];
-			return getStyleFromBasemapSource(source);
-		});
+const emit = defineEmits(['moveend', 'featureclick', 'featureselect', 'fitdata', 'updateitempopup']);
 
-		const attributionControl = new AttributionControl();
+const { t } = useI18n();
+const appStore = useAppStore();
+const settingsStore = useSettingsStore();
+let map: Map;
+const hoveredFeature = ref<MapboxGeoJSONFeature>();
+const hoveredCluster = ref<boolean>();
+const selectMode = ref<boolean>();
+const container = ref<HTMLElement>();
+const unwatchers = [] as WatchStopHandle[];
+const { sidebarOpen, basemap } = toRefs(appStore);
+const mapboxKey = settingsStore.settings?.mapbox_key;
+const basemaps = getBasemapSources();
 
-		const navigationControl = new NavigationControl({
-			showCompass: false,
-		});
-
-		const geolocateControl = new GeolocateControl();
-
-		const fitDataControl = new ButtonControl('mapboxgl-ctrl-fitdata', () => {
-			emit('fitdata');
-		});
-
-		const boxSelectControl = new BoxSelectControl({
-			boxElementClass: 'map-selection-box',
-			selectButtonClass: 'mapboxgl-ctrl-select',
-			layers: ['__directus_polygons', '__directus_points', '__directus_lines'],
-		});
-
-		let geocoderControl: MapboxGeocoder | undefined;
-
-		if (mapboxKey) {
-			const marker = document.createElement('div');
-			marker.className = 'mapboxgl-user-location-dot mapboxgl-search-location-dot';
-
-			geocoderControl = new MapboxGeocoder({
-				accessToken: mapboxKey,
-				collapsed: true,
-				marker: { element: marker } as any,
-				flyTo: { speed: 1.4 },
-				mapboxgl: maplibre as any,
-				placeholder: t('layouts.map.find_location'),
-			});
-		}
-
-		onMounted(() => {
-			setupMap();
-		});
-
-		onUnmounted(() => {
-			map.remove();
-		});
-
-		return { container, hoveredFeature, hoveredCluster, selectMode };
-
-		function setupMap() {
-			map = new Map({
-				container: 'map-container',
-				style: style.value,
-				dragRotate: false,
-				attributionControl: false,
-				...props.camera,
-				...(mapboxKey ? { accessToken: mapboxKey } : {}),
-			});
-
-			if (geocoderControl) {
-				map.addControl(geocoderControl as any, 'top-right');
-			}
-
-			map.addControl(attributionControl, 'bottom-left');
-			map.addControl(navigationControl, 'top-left');
-			map.addControl(geolocateControl, 'top-left');
-			map.addControl(fitDataControl, 'top-left');
-			map.addControl(boxSelectControl, 'top-left');
-
-			map.on('load', () => {
-				watch(() => style.value, updateStyle);
-				watch(() => props.bounds, fitBounds);
-				const activeLayers = ['__directus_polygons', '__directus_points', '__directus_lines'];
-
-				for (const layer of activeLayers) {
-					map.on('click', layer, onFeatureClick);
-					map.on('mousemove', layer, updatePopup);
-					map.on('mouseleave', layer, updatePopup);
-				}
-
-				map.on('move', updatePopupLocation);
-				map.on('click', '__directus_clusters', expandCluster);
-				map.on('mousemove', '__directus_clusters', hoverCluster);
-				map.on('mouseleave', '__directus_clusters', hoverCluster);
-				map.on('select.enable', () => (selectMode.value = true));
-				map.on('select.disable', () => (selectMode.value = false));
-
-				map.on('select.end', (event: MapLayerMouseEvent) => {
-					const ids = event.features?.map((f) => f.id);
-					emit('featureselect', { ids, replace: !event.alt });
-				});
-
-				map.on('moveend', () => {
-					emit('moveend', {
-						center: map.getCenter(),
-						zoom: map.getZoom(),
-						bearing: map.getBearing(),
-						pitch: map.getPitch(),
-						bbox: map.getBounds().toArray().flat(),
-					});
-				});
-
-				startWatchers();
-			});
-
-			watch(
-				() => sidebarOpen.value,
-				(opened) => {
-					if (!opened) setTimeout(() => map.resize(), 300);
-				}
-			);
-
-			setTimeout(() => map.resize(), 300);
-		}
-
-		function fitBounds() {
-			const bbox = props.data.bbox;
-
-			if (map && bbox) {
-				map.fitBounds(bbox as LngLatBoundsLike, {
-					padding: 100,
-					speed: 1.3,
-					maxZoom: 14,
-				});
-			}
-		}
-
-		function updateStyle(style: any) {
-			unwatchers.forEach((unwatch) => unwatch());
-			unwatchers.length = 0;
-			map.setStyle(style, { diff: false });
-			map.once('styledata', startWatchers);
-		}
-
-		function startWatchers() {
-			unwatchers.push(
-				watch(() => props.source, updateSource, { immediate: true }),
-				watch(() => props.selection, updateSelection, { immediate: true }),
-				watch(() => props.layers, updateLayers),
-				watch(() => props.data, updateData)
-			);
-		}
-
-		function updateData(newData: any) {
-			const source = map.getSource('__directus');
-			(source as GeoJSONSource).setData(newData);
-			updateSelection(props.selection, undefined);
-		}
-
-		function updateSource(newSource: GeoJSONSource) {
-			const layersId = new Set(map.getStyle().layers?.map(({ id }) => id));
-
-			for (const layer of props.layers) {
-				if (layersId.has(layer.id)) {
-					map.removeLayer(layer.id);
-				}
-			}
-
-			if (props.featureId) {
-				(newSource as any).promoteId = props.featureId;
-			} else {
-				(newSource as any).generateId = true;
-			}
-
-			if (map.getStyle().sources?.['__directus']) {
-				map.removeSource('__directus');
-			}
-
-			map.addSource('__directus', { ...newSource, data: props.data });
-
-			map.once('sourcedata', () => {
-				setTimeout(() => props.layers.forEach((layer) => map.addLayer(layer)));
-			});
-		}
-
-		function updateLayers(newLayers?: AnyLayer[], previousLayers?: AnyLayer[]) {
-			const currentMapLayersId = new Set(map.getStyle().layers?.map(({ id }) => id));
-
-			previousLayers?.forEach((layer) => {
-				if (currentMapLayersId.has(layer.id)) map.removeLayer(layer.id);
-			});
-
-			newLayers?.forEach((layer) => {
-				map.addLayer(layer);
-			});
-		}
-
-		function updateSelection(newSelection?: (string | number)[], previousSelection?: (string | number)[]) {
-			previousSelection?.forEach((id) => {
-				map.setFeatureState({ id, source: '__directus' }, { selected: false });
-				map.removeFeatureState({ id, source: '__directus' });
-			});
-
-			newSelection?.forEach((id) => {
-				map.setFeatureState({ id, source: '__directus' }, { selected: true });
-			});
-		}
-
-		function onFeatureClick(event: MapLayerMouseEvent) {
-			const feature = event.features?.[0];
-			const replace = props.showSelect === 'multiple' ? false : !event.originalEvent.altKey;
-
-			if (feature && props.featureId) {
-				if (boxSelectControl.active()) {
-					emit('featureselect', { ids: [feature.id], replace });
-				} else {
-					emit('featureclick', { id: feature.id, replace });
-				}
-			}
-		}
-
-		function updatePopup(event: MapLayerMouseEvent) {
-			const feature = map.queryRenderedFeatures(event.point, {
-				layers: ['__directus_polygons', '__directus_points', '__directus_lines'],
-			})[0];
-
-			const previousId = hoveredFeature.value?.id;
-			const featureChanged = previousId !== feature?.id;
-
-			if (previousId && featureChanged) {
-				map.setFeatureState({ id: previousId, source: '__directus' }, { hovered: false });
-			}
-
-			if (feature && feature.properties) {
-				if (feature.geometry.type === 'Point') {
-					const { x, y } = map.project(feature.geometry.coordinates as LngLatLike);
-					const rect = map.getContainer().getBoundingClientRect();
-					emit('updateitempopup', { position: { x: rect.x + x, y: rect.y + y } });
-				} else {
-					const { clientX: x, clientY: y } = event.originalEvent;
-					emit('updateitempopup', { position: { x, y } });
-				}
-
-				if (featureChanged) {
-					map.setFeatureState({ id: feature.id, source: '__directus' }, { hovered: true });
-					hoveredFeature.value = feature;
-					emit('updateitempopup', { item: feature.id });
-				}
-			} else {
-				if (featureChanged) {
-					hoveredFeature.value = feature;
-					emit('updateitempopup', { item: null });
-				}
-			}
-		}
-
-		function updatePopupLocation(event: MapLayerMouseEvent) {
-			if (hoveredFeature.value && event.originalEvent) {
-				const { x, y } = event.originalEvent;
-				emit('updateitempopup', { position: { x, y } });
-			}
-		}
-
-		function expandCluster(event: MapLayerMouseEvent) {
-			const features = map.queryRenderedFeatures(event.point, {
-				layers: ['__directus_clusters'],
-			});
-
-			const clusterId = features[0]?.properties?.cluster_id;
-			const source = map.getSource('__directus') as GeoJSONSource;
-
-			source.getClusterExpansionZoom(clusterId, (err: any, zoom: number) => {
-				if (err) return;
-
-				map.flyTo({
-					center: (features[0].geometry as GeoJSON.Point).coordinates as LngLatLike,
-					zoom: zoom,
-					speed: 1.3,
-				});
-			});
-		}
-
-		function hoverCluster(event: MapLayerMouseEvent) {
-			if (event.type == 'mousemove') {
-				hoveredCluster.value = true;
-			} else {
-				hoveredCluster.value = false;
-			}
-		}
-	},
+const style = computed(() => {
+	const source = basemaps.find((source) => source.name === basemap.value) ?? basemaps[0];
+	return getStyleFromBasemapSource(source);
 });
+
+const attributionControl = new AttributionControl();
+
+const navigationControl = new NavigationControl({
+	showCompass: false,
+});
+
+const geolocateControl = new GeolocateControl();
+
+const fitDataControl = new ButtonControl('mapboxgl-ctrl-fitdata', () => {
+	emit('fitdata');
+});
+
+const boxSelectControl = new BoxSelectControl({
+	boxElementClass: 'map-selection-box',
+	selectButtonClass: 'mapboxgl-ctrl-select',
+	layers: ['__directus_polygons', '__directus_points', '__directus_lines'],
+});
+
+let geocoderControl: MapboxGeocoder | undefined;
+
+if (mapboxKey) {
+	const marker = document.createElement('div');
+	marker.className = 'mapboxgl-user-location-dot mapboxgl-search-location-dot';
+
+	geocoderControl = new MapboxGeocoder({
+		accessToken: mapboxKey,
+		collapsed: true,
+		marker: { element: marker } as any,
+		flyTo: { speed: 1.4 },
+		mapboxgl: maplibre as any,
+		placeholder: t('layouts.map.find_location'),
+	});
+}
+
+onMounted(() => {
+	setupMap();
+});
+
+onUnmounted(() => {
+	map.remove();
+});
+
+function setupMap() {
+	map = new Map({
+		container: 'map-container',
+		style: style.value,
+		dragRotate: false,
+		attributionControl: false,
+		...props.camera,
+		...(mapboxKey ? { accessToken: mapboxKey } : {}),
+	});
+
+	if (geocoderControl) {
+		map.addControl(geocoderControl as any, 'top-right');
+	}
+
+	map.addControl(attributionControl, 'bottom-left');
+	map.addControl(navigationControl, 'top-left');
+	map.addControl(geolocateControl, 'top-left');
+	map.addControl(fitDataControl, 'top-left');
+	map.addControl(boxSelectControl, 'top-left');
+
+	map.on('load', () => {
+		watch(() => style.value, updateStyle);
+		watch(() => props.bounds, fitBounds);
+		const activeLayers = ['__directus_polygons', '__directus_points', '__directus_lines'];
+
+		for (const layer of activeLayers) {
+			map.on('click', layer, onFeatureClick);
+			map.on('mousemove', layer, updatePopup);
+			map.on('mouseleave', layer, updatePopup);
+		}
+
+		map.on('move', updatePopupLocation);
+		map.on('click', '__directus_clusters', expandCluster);
+		map.on('mousemove', '__directus_clusters', hoverCluster);
+		map.on('mouseleave', '__directus_clusters', hoverCluster);
+		map.on('select.enable', () => (selectMode.value = true));
+		map.on('select.disable', () => (selectMode.value = false));
+
+		map.on('select.end', (event: MapLayerMouseEvent & { alt: unknown }) => {
+			const ids = event.features?.map((f) => f.id);
+			emit('featureselect', { ids, replace: !event.alt });
+		});
+
+		map.on('moveend', () => {
+			emit('moveend', {
+				center: map.getCenter(),
+				zoom: map.getZoom(),
+				bearing: map.getBearing(),
+				pitch: map.getPitch(),
+				bbox: map.getBounds().toArray().flat(),
+			});
+		});
+
+		startWatchers();
+	});
+
+	watch(
+		() => sidebarOpen.value,
+		(opened) => {
+			if (!opened) setTimeout(() => map.resize(), 300);
+		}
+	);
+
+	setTimeout(() => map.resize(), 300);
+}
+
+function fitBounds() {
+	const bbox = props.data.bbox;
+
+	if (map && bbox) {
+		map.fitBounds(bbox as LngLatBoundsLike, {
+			padding: 100,
+			speed: 1.3,
+			maxZoom: 14,
+		});
+	}
+}
+
+function updateStyle(style: any) {
+	unwatchers.forEach((unwatch) => unwatch());
+	unwatchers.length = 0;
+	map.setStyle(style, { diff: false });
+	map.once('styledata', startWatchers);
+}
+
+function startWatchers() {
+	unwatchers.push(
+		watch(() => props.source, updateSource, { immediate: true }),
+		watch(() => props.selection, updateSelection, { immediate: true }),
+		watch(() => props.layers, updateLayers),
+		watch(() => props.data, updateData)
+	);
+}
+
+function updateData(newData: any) {
+	const source = map.getSource('__directus');
+	(source as GeoJSONSource).setData(newData);
+	updateSelection(props.selection, undefined);
+}
+
+function updateSource(newSource: GeoJSONSource) {
+	const layersId = new Set(map.getStyle().layers?.map(({ id }) => id));
+
+	for (const layer of props.layers) {
+		if (layersId.has(layer.id)) {
+			map.removeLayer(layer.id);
+		}
+	}
+
+	if (props.featureId) {
+		(newSource as any).promoteId = props.featureId;
+	} else {
+		(newSource as any).generateId = true;
+	}
+
+	if (map.getStyle().sources?.['__directus']) {
+		map.removeSource('__directus');
+	}
+
+	map.addSource('__directus', { ...newSource, data: props.data });
+
+	map.once('sourcedata', () => {
+		setTimeout(() => props.layers.forEach((layer) => map.addLayer(layer)));
+	});
+}
+
+function updateLayers(newLayers?: AnyLayer[], previousLayers?: AnyLayer[]) {
+	const currentMapLayersId = new Set(map.getStyle().layers?.map(({ id }) => id));
+
+	previousLayers?.forEach((layer) => {
+		if (currentMapLayersId.has(layer.id)) map.removeLayer(layer.id);
+	});
+
+	newLayers?.forEach((layer) => {
+		map.addLayer(layer);
+	});
+}
+
+function updateSelection(newSelection?: (string | number)[], previousSelection?: (string | number)[]) {
+	previousSelection?.forEach((id) => {
+		map.setFeatureState({ id, source: '__directus' }, { selected: false });
+		map.removeFeatureState({ id, source: '__directus' });
+	});
+
+	newSelection?.forEach((id) => {
+		map.setFeatureState({ id, source: '__directus' }, { selected: true });
+	});
+}
+
+function onFeatureClick(event: MapLayerMouseEvent) {
+	const feature = event.features?.[0];
+	const replace = props.showSelect === 'multiple' ? false : !event.originalEvent.altKey;
+
+	if (feature && props.featureId) {
+		if (boxSelectControl.active()) {
+			emit('featureselect', { ids: [feature.id], replace });
+		} else {
+			emit('featureclick', { id: feature.id, replace });
+		}
+	}
+}
+
+function updatePopup(event: MapLayerMouseEvent) {
+	const feature = map.queryRenderedFeatures(event.point, {
+		layers: ['__directus_polygons', '__directus_points', '__directus_lines'],
+	})[0];
+
+	const previousId = hoveredFeature.value?.id;
+	const featureChanged = previousId !== feature?.id;
+
+	if (previousId && featureChanged) {
+		map.setFeatureState({ id: previousId, source: '__directus' }, { hovered: false });
+	}
+
+	if (feature && feature.properties) {
+		if (feature.geometry.type === 'Point') {
+			const { x, y } = map.project(feature.geometry.coordinates as LngLatLike);
+			const rect = map.getContainer().getBoundingClientRect();
+			emit('updateitempopup', { position: { x: rect.x + x, y: rect.y + y } });
+		} else {
+			const { clientX: x, clientY: y } = event.originalEvent;
+			emit('updateitempopup', { position: { x, y } });
+		}
+
+		if (featureChanged) {
+			map.setFeatureState({ id: feature.id, source: '__directus' }, { hovered: true });
+			hoveredFeature.value = feature;
+			emit('updateitempopup', { item: feature.id });
+		}
+	} else {
+		if (featureChanged) {
+			hoveredFeature.value = feature;
+			emit('updateitempopup', { item: null });
+		}
+	}
+}
+
+function updatePopupLocation(event: MapLayerMouseEvent) {
+	if (hoveredFeature.value && event.originalEvent) {
+		const { x, y } = event.originalEvent;
+		emit('updateitempopup', { position: { x, y } });
+	}
+}
+
+function expandCluster(event: MapLayerMouseEvent) {
+	const features = map.queryRenderedFeatures(event.point, {
+		layers: ['__directus_clusters'],
+	});
+
+	const clusterId = features[0]?.properties?.cluster_id;
+	const source = map.getSource('__directus') as GeoJSONSource;
+
+	source.getClusterExpansionZoom(clusterId, (err: any, zoom: number) => {
+		if (err) return;
+
+		map.flyTo({
+			center: (features[0].geometry as GeoJSON.Point).coordinates as LngLatLike,
+			zoom: zoom,
+			speed: 1.3,
+		});
+	});
+}
+
+function hoverCluster(event: MapLayerMouseEvent) {
+	if (event.type == 'mousemove') {
+		hoveredCluster.value = true;
+	} else {
+		hoveredCluster.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -1,7 +1,9 @@
+import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
 import { getGeometryFormatForType, toGeoJSON } from '@/utils/geometry';
+import { saveAsCSV } from '@/utils/save-as-csv';
 import { syncRefProperty } from '@/utils/sync-ref-property';
 import { useCollection, useItems, useSync } from '@cairncms/composables';
-import { Field, Filter, GeometryOptions, Item } from '@cairncms/types';
+import { Field, Filter, GeometryOptions } from '@cairncms/types';
 import { defineLayout, getFieldsFromTemplate } from '@cairncms/utils';
 import { cloneDeep, merge } from 'lodash';
 import { computed, ref, toRefs, watch } from 'vue';
@@ -11,8 +13,6 @@ import MapLayout from './map.vue';
 import MapOptions from './options.vue';
 import { getMapStyle } from './style';
 import { LayoutOptions, LayoutQuery } from './types';
-import { formatCollectionItemsCount } from '@/utils/format-collection-items-count';
-import { saveAsCSV } from '@/utils/save-as-csv';
 
 export default defineLayout<LayoutOptions, LayoutQuery>({
 	id: 'map',
@@ -211,20 +211,20 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			});
 		}
 
-		function setSelection(ids: Item[]) {
+		function setSelection(ids: (string | number)[]) {
 			selection.value = Array.from(new Set(ids));
 		}
 
-		function pushSelection(ids: Item[]) {
+		function pushSelection(ids: (string | number)[]) {
 			selection.value = Array.from(new Set(selection.value.concat(ids)));
 		}
 
-		function handleSelect({ ids, replace }: { ids: Item[]; replace: boolean }) {
+		function handleSelect({ ids, replace }: { ids: (string | number)[]; replace: boolean }) {
 			if (replace) setSelection(ids);
 			else pushSelection(ids);
 		}
 
-		function handleClick({ id, replace }: { id: Item; replace: boolean }) {
+		function handleClick({ id, replace }: { id: string | number; replace: boolean }) {
 			if (props.selectMode) {
 				handleSelect({ ids: [id], replace });
 			} else {

--- a/app/src/layouts/map/map.vue
+++ b/app/src/layouts/map/map.vue
@@ -20,11 +20,11 @@
 
 		<transition name="fade">
 			<div
-				v-if="itemPopup.item"
+				v-if="itemPopup!.item"
 				class="popup"
-				:style="{ top: itemPopup.position.y + 'px', left: itemPopup.position.x + 'px' }"
+				:style="{ top: itemPopup!.position!.y + 'px', left: itemPopup!.position!.x + 'px' }"
 			>
-				<render-template :template="template" :item="itemPopup.item" :collection="collection" />
+				<render-template :template="template" :item="itemPopup!.item" :collection="collection" />
 			</div>
 		</transition>
 
@@ -50,7 +50,7 @@
 			<v-progress-circular v-else-if="loading || geojsonLoading" indeterminate x-large class="center" />
 		</transition>
 
-		<template v-if="loading || itemCount > 0">
+		<template v-if="loading || itemCount! > 0">
 			<div class="footer">
 				<div v-if="totalPages > 1" class="pagination">
 					<v-pagination
@@ -93,132 +93,57 @@
 </template>
 
 <script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
-
-import MapComponent from './components/map.vue';
-import { useSync } from '@cairncms/composables';
-import { GeometryOptions, Item } from '@cairncms/types';
-
-export default defineComponent({
-	components: { MapComponent },
+export default {
 	inheritAttrs: false,
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		selection: {
-			type: Array as PropType<Item[]>,
-			default: () => [],
-		},
-		loading: {
-			type: Boolean,
-			required: true,
-		},
-		error: {
-			type: Object as PropType<any>,
-			default: null,
-		},
-		geojsonError: {
-			type: String,
-			default: null,
-		},
-		geometryOptions: {
-			type: Object as PropType<GeometryOptions>,
-			default: undefined,
-		},
-		geojson: {
-			type: Object as PropType<any>,
-			required: true,
-		},
-		featureId: {
-			type: String,
-			default: null,
-		},
-		geojsonBounds: {
-			type: Object as PropType<any>,
-			default: undefined,
-		},
-		directusSource: {
-			type: Object as PropType<any>,
-			required: true,
-		},
-		directusLayers: {
-			type: Array as PropType<any[]>,
-			required: true,
-		},
-		handleClick: {
-			type: Function as PropType<(event: { id: string | number; replace: boolean }) => void>,
-			required: true,
-		},
-		handleSelect: {
-			type: Function as PropType<(event: { ids: Array<string | number>; replace: boolean }) => void>,
-			required: true,
-		},
-		cameraOptions: {
-			type: Object as PropType<any>,
-			default: undefined,
-		},
-		resetPresetAndRefresh: {
-			type: Function as PropType<() => Promise<void>>,
-			required: true,
-		},
-		geojsonLoading: {
-			type: Boolean,
-			required: true,
-		},
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		totalPages: {
-			type: Number,
-			required: true,
-		},
-		page: {
-			type: Number,
-			required: true,
-		},
-		toPage: {
-			type: Function as PropType<(newPage: number) => void>,
-			required: true,
-		},
-		limit: {
-			type: Number,
-			required: true,
-		},
-		autoLocationFilter: {
-			type: Boolean,
-			default: undefined,
-		},
-		fitDataBounds: {
-			type: Function as PropType<() => void>,
-			required: true,
-		},
-		template: {
-			type: String,
-			default: () => undefined,
-		},
-		itemPopup: {
-			type: Object as PropType<{ item?: any; position?: { x: number; y: number } }>,
-			default: () => undefined,
-		},
-		updateItemPopup: {
-			type: Function,
-			required: true,
-		},
-	},
-	emits: ['update:cameraOptions', 'update:limit'],
-	setup(props, { emit }) {
-		const { t, n } = useI18n();
+};
+</script>
 
-		const cameraOptionsWritable = useSync(props, 'cameraOptions', emit);
-		const limitWritable = useSync(props, 'limit', emit);
+<script setup lang="ts">
+import { useSync } from '@cairncms/composables';
+import { GeometryOptions } from '@cairncms/types';
+import { useI18n } from 'vue-i18n';
+import MapComponent from './components/map.vue';
 
-		return { t, n, cameraOptionsWritable, limitWritable };
-	},
-});
+const props = withDefaults(
+	defineProps<{
+		collection: string;
+		geojson: any;
+		directusSource: any;
+		directusLayers: any[];
+		handleClick: (event: { id: string | number; replace: boolean }) => void;
+		handleSelect: (event: { ids: Array<string | number>; replace: boolean }) => void;
+		resetPresetAndRefresh: () => Promise<void>;
+		fitDataBounds: () => void;
+		updateItemPopup: () => void;
+		geojsonLoading: boolean;
+		loading: boolean;
+		totalPages: number;
+		page: number;
+		toPage: (newPage: number) => void;
+		limit: number;
+		selection?: (string | number)[];
+		error?: any;
+		geojsonError?: string;
+		geometryOptions?: GeometryOptions;
+		featureId?: string;
+		geojsonBounds?: any;
+		cameraOptions?: any;
+		itemCount?: number;
+		autoLocationFilter?: boolean;
+		template?: string;
+		itemPopup?: { item?: any; position?: { x: number; y: number } };
+	}>(),
+	{
+		selection: () => [],
+	}
+);
+
+const emit = defineEmits(['update:cameraOptions', 'update:limit']);
+
+const { t, n } = useI18n();
+
+const cameraOptionsWritable = useSync(props, 'cameraOptions', emit);
+const limitWritable = useSync(props, 'limit', emit);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/map/options.vue
+++ b/app/src/layouts/map/options.vue
@@ -37,64 +37,37 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, toRefs } from 'vue';
-
+<script lang="ts" setup>
 import { useAppStore } from '@/stores/app';
 import { getBasemapSources } from '@/utils/geometry/basemap';
-import { GeometryOptions, Item } from '@cairncms/types';
 import { useSync } from '@cairncms/composables';
+import { GeometryOptions, Item } from '@cairncms/types';
+import { toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	inheritAttrs: false,
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		geometryFields: {
-			type: Array as PropType<Item[]>,
-			required: true,
-		},
-		geometryField: {
-			type: String,
-			default: undefined,
-		},
-		geometryOptions: {
-			type: Object as PropType<GeometryOptions>,
-			default: undefined,
-		},
-		clusterData: {
-			type: Boolean,
-			default: undefined,
-		},
-		displayTemplate: {
-			type: String as string | undefined,
-			default: undefined,
-		},
-	},
-	emits: ['update:geometryField', 'update:autoLocationFilter', 'update:clusterData'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: string;
+	geometryFields: Item[];
+	geometryField?: string;
+	geometryOptions?: GeometryOptions;
+	clusterData?: boolean;
+	displayTemplate?: string;
+}>();
 
-		const appStore = useAppStore();
+const emit = defineEmits<{
+	(e: 'update:geometryField', geometryField: string): void;
+	(e: 'update:clusterData', clusterData: boolean): void;
+	(e: 'update:displayTemplate', displayTemplate: string): void;
+}>();
 
-		const geometryFieldWritable = useSync(props, 'geometryField', emit);
-		const clusterDataWritable = useSync(props, 'clusterData', emit);
-		const displayTemplateWritable = useSync(props, 'displayTemplate', emit);
+const { t } = useI18n();
 
-		const basemaps = getBasemapSources();
-		const { basemap } = toRefs(appStore);
+const appStore = useAppStore();
 
-		return {
-			t,
-			geometryFieldWritable,
-			clusterDataWritable,
-			displayTemplateWritable,
-			basemaps,
-			basemap,
-		};
-	},
-});
+const geometryFieldWritable = useSync(props, 'geometryField', emit);
+const clusterDataWritable = useSync(props, 'clusterData', emit);
+const displayTemplateWritable = useSync(props, 'displayTemplate', emit);
+
+const basemaps = getBasemapSources();
+const { basemap } = toRefs(appStore);
 </script>

--- a/app/src/layouts/tabular/actions.vue
+++ b/app/src/layouts/tabular/actions.vue
@@ -6,21 +6,18 @@
 	</transition>
 </template>
 
+<script lang="ts" setup>
+defineProps<{
+	itemCount?: number;
+	showingCount: string;
+}>();
+</script>
+
 <script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({
 	inheritAttrs: false,
-	props: {
-		itemCount: {
-			type: Number,
-			default: null,
-		},
-		showingCount: {
-			type: String,
-			required: true,
-		},
-	},
 });
 </script>
 

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -25,7 +25,7 @@
 		>
 			<template v-for="header in tableHeaders" :key="header.value" #[`item.${header.value}`]="{ item }">
 				<render-display
-					:value="getDisplayValue(item, header.value)"
+					:value="getFromAliasedItem(item, header.value)"
 					:display="header.field.display"
 					:options="header.field.displayOptions"
 					:interface="header.field.interface"
@@ -178,17 +178,16 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import { HeaderRaw } from '@/components/v-table/types';
+import { AliasFields, useAliasFields } from '@/composables/use-alias-fields';
 import { useShortcut } from '@/composables/use-shortcut';
+import { usePermissionsStore } from '@/stores/permissions';
+import { useUserStore } from '@/stores/user';
 import { Collection } from '@/types/collections';
 import { useSync } from '@cairncms/composables';
 import { Field, Filter, Item, ShowSelect } from '@cairncms/types';
-import { ComponentPublicInstance, inject, ref, Ref, watch, computed, toRefs } from 'vue';
+import { ComponentPublicInstance, Ref, computed, inject, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { get } from '@cairncms/utils';
-import { AliasFields } from '@/composables/use-alias-fields';
-import { usePermissionsStore } from '@/stores/permissions';
-import { useUserStore } from '@/stores/user';
-import { HeaderRaw } from '@/components/v-table/types';
 
 interface Props {
 	collection: string;
@@ -239,7 +238,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['update:selection', 'update:tableHeaders', 'update:limit', 'update:fields']);
 
 const { t } = useI18n();
-const { collection, aliasedFields, aliasedKeys } = toRefs(props);
+const { collection } = toRefs(props);
 
 const selectionWritable = useSync(props, 'selection', emit);
 const tableHeadersWritable = useSync(props, 'tableHeaders', emit);
@@ -276,33 +275,16 @@ const showManualSort = computed(() => {
 
 	if (!permission) return false;
 
-	if (Array.isArray(permission.fields) && permission.fields.length > 0)
+	if (Array.isArray(permission.fields) && permission.fields.length > 0) {
 		return permission.fields.includes(props.sortField) || permission.fields.includes('*');
+	}
+
 	return true;
 });
 
 const fieldsWritable = useSync(props, 'fields', emit);
 
-function getDisplayValue(item: Item, key: string) {
-	const aliasInfo = Object.values(aliasedFields.value).find((field) => field.key === key);
-
-	if (!aliasInfo) return get(item, key);
-
-	const dealiasedItem = Object.keys(item).reduce<Item>((result, itemKey) => {
-		if (aliasedKeys.value.includes(itemKey)) {
-			if (itemKey !== aliasInfo.fieldAlias) return result;
-			const name = aliasedFields.value[itemKey].fieldName;
-			result[name] = item[itemKey];
-		} else {
-			// Don't overwrite already dealiased keys
-			if (itemKey in result === false) result[itemKey] = item[itemKey];
-		}
-
-		return result;
-	}, {});
-
-	return get(dealiasedItem, key);
-}
+const { getFromAliasedItem } = useAliasFields(fieldsWritable, collection);
 
 function addField(fieldKey: string) {
 	fieldsWritable.value = [...fieldsWritable.value, fieldKey];

--- a/app/src/modules/activity/components/navigation.vue
+++ b/app/src/modules/activity/components/navigation.vue
@@ -91,44 +91,37 @@
 	</v-list>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, PropType } from 'vue';
+<script setup lang="ts">
 import { useUserStore } from '@/stores/user';
 import { Filter } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		filter: {
-			type: Object as PropType<Filter>,
-			default: null,
+const props = defineProps<{
+	filter?: Filter;
+}>();
+
+const emit = defineEmits(['update:filter']);
+
+const { t } = useI18n();
+
+const userStore = useUserStore();
+const currentUserID = computed(() => userStore.currentUser?.id);
+
+const filterField = computed(() => Object.keys(props.filter ?? {})[0] ?? null);
+const filterValue = computed(() => Object.values(props.filter ?? {})[0]?._eq ?? null);
+
+function setNavFilter(key: string, value: any) {
+	emit('update:filter', {
+		[key]: {
+			_eq: value,
 		},
-	},
-	emits: ['update:filter'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+	});
+}
 
-		const userStore = useUserStore();
-		const currentUserID = computed(() => userStore.currentUser?.id);
-
-		const filterField = computed(() => Object.keys(props.filter ?? {})[0] ?? null);
-		const filterValue = computed(() => Object.values(props.filter ?? {})[0]?._eq ?? null);
-
-		return { t, currentUserID, setNavFilter, clearNavFilter, filterField, filterValue };
-
-		function setNavFilter(key: string, value: any) {
-			emit('update:filter', {
-				[key]: {
-					_eq: value,
-				},
-			});
-		}
-
-		function clearNavFilter() {
-			emit('update:filter', null);
-		}
-	},
-});
+function clearNavFilter() {
+	emit('update:filter', null);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/activity/routes/collection.vue
+++ b/app/src/modules/activity/routes/collection.vue
@@ -63,7 +63,7 @@
 	</component>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useExtension } from '@/composables/use-extension';
 import { usePreset } from '@/composables/use-preset';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
@@ -71,59 +71,23 @@ import SearchInput from '@/views/private/components/search-input.vue';
 import { useLayout } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
 import { mergeFilters } from '@cairncms/utils';
-import { computed, defineComponent, ref } from 'vue';
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ActivityNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	name: 'ActivityCollection',
-	components: { ActivityNavigation, LayoutSidebarDetail, SearchInput },
-	props: {
-		primaryKey: {
-			type: String,
-			default: null,
-		},
-	},
-	setup() {
-		const { t } = useI18n();
+defineProps<{
+	primaryKey?: string;
+}>();
 
-		const { layout, layoutOptions, layoutQuery, filter, search } = usePreset(ref('directus_activity'));
-		const { breadcrumb } = useBreadcrumb();
+const { t } = useI18n();
 
-		const { layoutWrapper } = useLayout(layout);
+const { layout, layoutOptions, layoutQuery, filter, search } = usePreset(ref('directus_activity'));
 
-		const currentLayout = useExtension('layout', layout);
+const { layoutWrapper } = useLayout(layout);
 
-		const roleFilter = ref<Filter | null>(null);
+const currentLayout = useExtension('layout', layout);
 
-		return {
-			t,
-			breadcrumb,
-			layout,
-			layoutWrapper,
-			layoutOptions,
-			layoutQuery,
-			search,
-			filter,
-			roleFilter,
-			mergeFilters,
-			currentLayout,
-		};
-
-		function useBreadcrumb() {
-			const breadcrumb = computed(() => {
-				return [
-					{
-						name: t('collection', 2),
-						to: `/content`,
-					},
-				];
-			});
-
-			return { breadcrumb };
-		}
-	},
-});
+const roleFilter = ref<Filter | null>(null);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/content/components/navigation-item-content.vue
+++ b/app/src/modules/content/components/navigation-item-content.vue
@@ -7,29 +7,18 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-	props: {
-		icon: {
-			type: String,
-			default: null,
-		},
-		name: {
-			type: String,
-			required: true,
-		},
-		search: {
-			type: String,
-			default: null,
-		},
-		depth: {
-			type: Number,
-			default: 0,
-		},
-	},
-});
+<script setup lang="ts">
+withDefaults(
+	defineProps<{
+		name: string;
+		search?: string;
+		icon?: string;
+		depth?: number;
+	}>(),
+	{
+		depth: 0,
+	}
+);
 </script>
 
 <style scoped>

--- a/app/src/modules/content/components/navigation-item.vue
+++ b/app/src/modules/content/components/navigation-item.vue
@@ -53,8 +53,8 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 import { Collection } from '@/types/collections';
 import { Preset } from '@cairncms/types';
 import { useUserStore } from '@/stores/user';
@@ -65,99 +65,76 @@ import NavigationBookmark from './navigation-bookmark.vue';
 import { useI18n } from 'vue-i18n';
 import { orderBy } from 'lodash';
 
-export default defineComponent({
-	name: 'NavigationItem',
-	components: { NavigationItemContent, NavigationBookmark },
-	props: {
-		collection: {
-			type: Object as PropType<Collection>,
-			required: true,
-		},
-		showHidden: {
-			type: Boolean,
-			default: false,
-		},
-		search: {
-			type: String,
-			default: null,
-		},
-		depth: {
-			type: Number,
-			default: 0,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		collection: Collection;
+		showHidden?: boolean;
+		search?: string;
+		depth?: number;
+	}>(),
+	{
+		depth: 0,
+	}
+);
 
-		const { isAdmin } = useUserStore();
-		const collectionsStore = useCollectionsStore();
-		const presetsStore = usePresetsStore();
+const { t } = useI18n();
 
-		const childCollections = computed(() => getChildCollections(props.collection));
+const { isAdmin } = useUserStore();
+const collectionsStore = useCollectionsStore();
+const presetsStore = usePresetsStore();
 
-		const childBookmarks = computed(() => getChildBookmarks(props.collection));
+const childCollections = computed(() => getChildCollections(props.collection));
 
-		const isGroup = computed(() => childCollections.value.length > 0 || childBookmarks.value.length > 0);
+const childBookmarks = computed(() => getChildBookmarks(props.collection));
 
-		const to = computed(() => (props.collection.schema ? `/content/${props.collection.collection}` : ''));
+const isGroup = computed(() => childCollections.value.length > 0 || childBookmarks.value.length > 0);
 
-		const matchesSearch = computed(() => {
-			if (!props.search || props.search.length < 3) return true;
+const to = computed(() => (props.collection.schema ? `/content/${props.collection.collection}` : ''));
 
-			const searchQuery = props.search.toLowerCase();
+const matchesSearch = computed(() => {
+	if (!props.search || props.search.length < 3) return true;
 
-			return matchesSearch(props.collection) || childrenMatchSearch(childCollections.value, childBookmarks.value);
+	const searchQuery = props.search.toLowerCase();
 
-			function childrenMatchSearch(collections: Collection[], bookmarks: Preset[]): boolean {
-				return (
-					collections.some((collection) => {
-						const childCollections = getChildCollections(collection);
-						const childBookmarks = getChildBookmarks(collection);
+	return matchesSearch(props.collection) || childrenMatchSearch(childCollections.value, childBookmarks.value);
 
-						return matchesSearch(collection) || childrenMatchSearch(childCollections, childBookmarks);
-					}) || bookmarks.some((bookmark) => bookmarkMatchesSearch(bookmark))
-				);
-			}
+	function childrenMatchSearch(collections: Collection[], bookmarks: Preset[]): boolean {
+		return (
+			collections.some((collection) => {
+				const childCollections = getChildCollections(collection);
+				const childBookmarks = getChildBookmarks(collection);
 
-			function matchesSearch(collection: Collection) {
-				return collection.collection.includes(searchQuery) || collection.name.toLowerCase().includes(searchQuery);
-			}
+				return matchesSearch(collection) || childrenMatchSearch(childCollections, childBookmarks);
+			}) || bookmarks.some((bookmark) => bookmarkMatchesSearch(bookmark))
+		);
+	}
 
-			function bookmarkMatchesSearch(bookmark: Preset) {
-				return bookmark.bookmark?.toLowerCase().includes(searchQuery);
-			}
-		});
+	function matchesSearch(collection: Collection) {
+		return collection.collection.includes(searchQuery) || collection.name.toLowerCase().includes(searchQuery);
+	}
 
-		const hasContextMenu = computed(() => isAdmin && props.collection.type === 'table');
-
-		return {
-			childCollections,
-			childBookmarks,
-			isGroup,
-			to,
-			matchesSearch,
-			isAdmin,
-			t,
-			hasContextMenu,
-		};
-
-		function getChildCollections(collection: Collection) {
-			let collections = collectionsStore.collections.filter(
-				(childCollection) => childCollection.meta?.group === collection.collection
-			);
-
-			if (props.showHidden === false) {
-				collections = collections.filter((collection) => collection.meta?.hidden !== true);
-			}
-
-			return orderBy(collections, ['meta.sort', 'collection']);
-		}
-
-		function getChildBookmarks(collection: Collection) {
-			return presetsStore.bookmarks.filter((bookmark) => bookmark.collection === collection.collection);
-		}
-	},
+	function bookmarkMatchesSearch(bookmark: Preset) {
+		return bookmark.bookmark?.toLowerCase().includes(searchQuery);
+	}
 });
+
+const hasContextMenu = computed(() => isAdmin && props.collection.type === 'table');
+
+function getChildCollections(collection: Collection) {
+	let collections = collectionsStore.collections.filter(
+		(childCollection) => childCollection.meta?.group === collection.collection
+	);
+
+	if (props.showHidden === false) {
+		collections = collections.filter((collection) => collection.meta?.hidden !== true);
+	}
+
+	return orderBy(collections, ['meta.sort', 'collection']);
+}
+
+function getChildBookmarks(collection: Collection) {
+	return presetsStore.bookmarks.filter((bookmark) => bookmark.collection === collection.collection);
+}
 </script>
 
 <style scoped>

--- a/app/src/modules/content/components/navigation.vue
+++ b/app/src/modules/content/components/navigation.vue
@@ -36,60 +36,42 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref, toRefs } from 'vue';
-import { useNavigation } from '../composables/use-navigation';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
-import { orderBy, isNil } from 'lodash';
+import { isNil, orderBy } from 'lodash';
+import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useNavigation } from '../composables/use-navigation';
 import NavigationItem from './navigation-item.vue';
 
-export default defineComponent({
-	components: { NavigationItem },
-	props: {
-		currentCollection: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
-		const { currentCollection } = toRefs(props);
-		const { activeGroups, showHidden } = useNavigation(currentCollection);
+const props = defineProps<{
+	currentCollection?: string;
+}>();
 
-		const search = ref('');
+const { t } = useI18n();
+const { currentCollection } = toRefs(props);
+const { activeGroups, showHidden } = useNavigation(currentCollection);
 
-		const collectionsStore = useCollectionsStore();
+const search = ref('');
 
-		const rootItems = computed(() => {
-			const shownCollections = showHidden.value ? collectionsStore.allCollections : collectionsStore.visibleCollections;
-			return orderBy(
-				shownCollections.filter((collection) => {
-					return isNil(collection?.meta?.group);
-				}),
-				['meta.sort', 'collection']
-			);
-		});
+const collectionsStore = useCollectionsStore();
 
-		const dense = computed(() => collectionsStore.visibleCollections.length > 5);
-		const showSearch = computed(() => collectionsStore.visibleCollections.length > 20);
-
-		const hasHiddenCollections = computed(
-			() => collectionsStore.allCollections.length > collectionsStore.visibleCollections.length
-		);
-
-		return {
-			t,
-			activeGroups,
-			showHidden,
-			rootItems,
-			dense,
-			search,
-			showSearch,
-			hasHiddenCollections,
-		};
-	},
+const rootItems = computed(() => {
+	const shownCollections = showHidden.value ? collectionsStore.allCollections : collectionsStore.visibleCollections;
+	return orderBy(
+		shownCollections.filter((collection) => {
+			return isNil(collection?.meta?.group);
+		}),
+		['meta.sort', 'collection']
+	);
 });
+
+const dense = computed(() => collectionsStore.visibleCollections.length > 5);
+const showSearch = computed(() => collectionsStore.visibleCollections.length > 20);
+
+const hasHiddenCollections = computed(
+	() => collectionsStore.allCollections.length > collectionsStore.visibleCollections.length
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/content/routes/collection-or-item.vue
+++ b/app/src/modules/content/routes/collection-or-item.vue
@@ -1,6 +1,6 @@
 <template>
 	<component
-		:is="isSingleton ? 'item-route' : 'collection-route'"
+		:is="isSingleton ? ItemRoute : CollectionRoute"
 		:collection="collection"
 		:bookmark="bookmark"
 		:archive="archive"
@@ -8,56 +8,38 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, watch } from 'vue';
+<script setup lang="ts">
+import { computed, watch } from 'vue';
 import CollectionRoute from './collection.vue';
 import ItemRoute from './item.vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useRoute } from 'vue-router';
 import { useLocalStorage } from '@/composables/use-local-storage';
 
-export default defineComponent({
-	components: {
-		CollectionRoute,
-		ItemRoute,
-	},
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		bookmark: {
-			type: String,
-			default: null,
-		},
-		archive: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const route = useRoute();
+const props = defineProps<{
+	collection: string;
+	bookmark?: string;
+	archive?: string;
+}>();
 
-		const { data } = useLocalStorage('last-accessed-collection');
+const route = useRoute();
 
-		const collectionsStore = useCollectionsStore();
+const { data } = useLocalStorage('last-accessed-collection');
 
-		const isSingleton = computed(() => {
-			const collectionInfo = collectionsStore.getCollection(props.collection);
-			return !!collectionInfo?.meta?.singleton === true;
-		});
+const collectionsStore = useCollectionsStore();
 
-		watch(
-			() => route.params,
-			(newParams) => {
-				if (newParams.collection && data.value !== newParams.collection) {
-					data.value = newParams.collection;
-				}
-			},
-			{ immediate: true }
-		);
-
-		return { isSingleton };
-	},
+const isSingleton = computed(() => {
+	const collectionInfo = collectionsStore.getCollection(props.collection);
+	return !!collectionInfo?.meta?.singleton === true;
 });
+
+watch(
+	() => route.params,
+	(newParams) => {
+		if (newParams.collection && data.value !== newParams.collection) {
+			data.value = newParams.collection;
+		}
+	},
+	{ immediate: true }
+);
 </script>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -270,410 +270,337 @@
 	</component>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref, watch, toRefs } from 'vue';
-import ContentNavigation from '../components/navigation.vue';
+<script setup lang="ts">
 import api from '@/api';
-import ContentNotFound from './not-found.vue';
-import { useCollection, useLayout } from '@cairncms/composables';
+import { useExtension } from '@/composables/use-extension';
 import { usePreset } from '@/composables/use-preset';
-import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
-import ArchiveSidebarDetail from '@/views/private/components/archive-sidebar-detail.vue';
-import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
-import ExportSidebarDetail from '@/views/private/components/export-sidebar-detail.vue';
-import FlowSidebarDetail from '@/views/private/components/flow-sidebar-detail.vue';
-import SearchInput from '@/views/private/components/search-input.vue';
-import BookmarkAdd from '@/views/private/components/bookmark-add.vue';
-import { useRouter } from 'vue-router';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useUserStore } from '@/stores/user';
-import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { mergeFilters } from '@cairncms/utils';
+import ArchiveSidebarDetail from '@/views/private/components/archive-sidebar-detail.vue';
+import BookmarkAdd from '@/views/private/components/bookmark-add.vue';
+import DrawerBatch from '@/views/private/components/drawer-batch.vue';
+import ExportSidebarDetail from '@/views/private/components/export-sidebar-detail.vue';
+import FlowSidebarDetail from '@/views/private/components/flow-sidebar-detail.vue';
+import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
+import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
+import SearchInput from '@/views/private/components/search-input.vue';
+import { useCollection, useLayout } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
-import { useExtension } from '@/composables/use-extension';
+import { mergeFilters } from '@cairncms/utils';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import ContentNavigation from '../components/navigation.vue';
+import ContentNotFound from './not-found.vue';
 
 type Item = {
 	[field: string]: any;
 };
 
-export default defineComponent({
-	name: 'ContentCollection',
-	components: {
-		ContentNavigation,
-		ContentNotFound,
-		LayoutSidebarDetail,
-		SearchInput,
-		BookmarkAdd,
-		DrawerBatch,
-		ArchiveSidebarDetail,
-		RefreshSidebarDetail,
-		ExportSidebarDetail,
-		FlowSidebarDetail,
+const props = defineProps<{
+	collection: string;
+	bookmark?: string;
+	archive?: string;
+}>();
+
+const { t } = useI18n();
+
+const router = useRouter();
+
+const userStore = useUserStore();
+const permissionsStore = usePermissionsStore();
+const layoutRef = ref();
+
+const { collection } = toRefs(props);
+const bookmarkID = computed(() => (props.bookmark ? +props.bookmark : null));
+
+const { selection } = useSelection();
+const { info: currentCollection } = useCollection(collection);
+const { addNewLink, currentCollectionLink } = useLinks();
+const { breadcrumb } = useBreadcrumb();
+
+const {
+	layout,
+	layoutOptions,
+	layoutQuery,
+	filter,
+	search,
+	savePreset,
+	bookmarkExists,
+	saveCurrentAsBookmark,
+	bookmarkTitle,
+	resetPreset,
+	bookmarkSaved,
+	bookmarkIsMine,
+	refreshInterval,
+	busy: bookmarkSaving,
+	clearLocalSave,
+} = usePreset(collection, bookmarkID);
+
+const { layoutWrapper } = useLayout(layout);
+
+const {
+	confirmDelete,
+	deleting,
+	batchDelete,
+	confirmArchive,
+	archiveItems,
+	archiving,
+	error: deleteError,
+	batchEditActive,
+} = useBatch();
+
+const { bookmarkDialogActive, creatingBookmark, createBookmark } = useBookmarks();
+
+const currentLayout = useExtension('layout', layout);
+
+watch(
+	collection,
+	() => {
+		if (layout.value === null) {
+			layout.value = 'tabular';
+		}
 	},
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		bookmark: {
-			type: String,
-			default: null,
-		},
-		archive: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+	{ immediate: true }
+);
 
-		const router = useRouter();
+const { batchEditAllowed, batchArchiveAllowed, batchDeleteAllowed, createAllowed } = usePermissions();
 
-		const userStore = useUserStore();
-		const permissionsStore = usePermissionsStore();
-		const layoutRef = ref();
+const hasArchive = computed(
+	() =>
+		currentCollection.value &&
+		currentCollection.value.meta?.archive_field &&
+		currentCollection.value.meta?.archive_app_filter
+);
 
-		const { collection } = toRefs(props);
-		const bookmarkID = computed(() => (props.bookmark ? +props.bookmark : null));
+const archiveFilter = computed<Filter | null>(() => {
+	if (!currentCollection.value?.meta) return null;
+	if (!currentCollection.value?.meta?.archive_app_filter) return null;
 
-		const { selection } = useSelection();
-		const { info: currentCollection } = useCollection(collection);
-		const { addNewLink, currentCollectionLink } = useLinks();
-		const { breadcrumb } = useBreadcrumb();
+	const field = currentCollection.value.meta.archive_field;
 
-		const {
-			layout,
-			layoutOptions,
-			layoutQuery,
-			filter,
-			search,
-			savePreset,
-			bookmarkExists,
-			saveCurrentAsBookmark,
-			bookmarkTitle,
-			resetPreset,
-			bookmarkSaved,
-			bookmarkIsMine,
-			refreshInterval,
-			busy: bookmarkSaving,
-			clearLocalSave,
-		} = usePreset(collection, bookmarkID);
+	if (!field) return null;
 
-		const { layoutWrapper } = useLayout(layout);
+	let archiveValue: any = currentCollection.value.meta.archive_value;
+	if (archiveValue === 'true') archiveValue = true;
+	if (archiveValue === 'false') archiveValue = false;
 
-		const {
-			confirmDelete,
-			deleting,
-			batchDelete,
-			confirmArchive,
-			archiveItems,
-			archiving,
-			error: deleteError,
-			batchEditActive,
-		} = useBatch();
-
-		const { bookmarkDialogActive, creatingBookmark, createBookmark } = useBookmarks();
-
-		const currentLayout = useExtension('layout', layout);
-
-		watch(
-			collection,
-			() => {
-				if (layout.value === null) {
-					layout.value = 'tabular';
-				}
-			},
-			{ immediate: true }
-		);
-
-		const { batchEditAllowed, batchArchiveAllowed, batchDeleteAllowed, createAllowed } = usePermissions();
-
-		const hasArchive = computed(
-			() =>
-				currentCollection.value &&
-				currentCollection.value.meta?.archive_field &&
-				currentCollection.value.meta?.archive_app_filter
-		);
-
-		const archiveFilter = computed<Filter | null>(() => {
-			if (!currentCollection.value?.meta) return null;
-			if (!currentCollection.value?.meta?.archive_app_filter) return null;
-
-			const field = currentCollection.value.meta.archive_field;
-
-			if (!field) return null;
-
-			let archiveValue: any = currentCollection.value.meta.archive_value;
-			if (archiveValue === 'true') archiveValue = true;
-			if (archiveValue === 'false') archiveValue = false;
-
-			if (props.archive === 'all') {
-				return null;
-			} else if (props.archive === 'archived') {
-				return {
-					[field]: {
-						_eq: archiveValue,
-					},
-				};
-			} else {
-				return {
-					[field]: {
-						_neq: archiveValue,
-					},
-				};
-			}
-		});
-
+	if (props.archive === 'all') {
+		return null;
+	} else if (props.archive === 'archived') {
 		return {
-			t,
-			addNewLink,
-			batchDelete,
-			batchEditActive,
-			confirmDelete,
-			currentCollection,
-			deleting,
-			filter,
-			layoutRef,
-			layoutWrapper,
-			selection,
-			layoutOptions,
-			layoutQuery,
-			layout,
-			search,
-			savePreset,
-			bookmarkExists,
-			currentCollectionLink,
-			bookmarkDialogActive,
-			creatingBookmark,
-			createBookmark,
-			bookmarkTitle,
-			breadcrumb,
-			clearFilters,
-			confirmArchive,
-			archiveItems,
-			archiving,
-			batchEditAllowed,
-			batchArchiveAllowed,
-			batchDeleteAllowed,
-			deleteError,
-			createAllowed,
-			resetPreset,
-			bookmarkSaved,
-			bookmarkIsMine,
-			bookmarkSaving,
-			clearLocalSave,
-			batchRefresh,
-			refresh,
-			refreshInterval,
-			currentLayout,
-			hasArchive,
-			archiveFilter,
-			mergeFilters,
-			download,
+			[field]: {
+				_eq: archiveValue,
+			},
 		};
+	} else {
+		return {
+			[field]: {
+				_neq: archiveValue,
+			},
+		};
+	}
+});
 
-		async function refresh() {
-			await layoutRef.value?.state?.refresh?.();
-		}
+async function refresh() {
+	await layoutRef.value?.state?.refresh?.();
+}
 
-		async function download() {
-			await layoutRef.value?.state?.download?.();
-		}
+async function download() {
+	await layoutRef.value?.state?.download?.();
+}
 
-		async function batchRefresh() {
+async function batchRefresh() {
+	selection.value = [];
+	await refresh();
+}
+
+function useBreadcrumb() {
+	const breadcrumb = computed(() => [
+		{
+			name: currentCollection.value?.name,
+			to: `/content/${props.collection}`,
+		},
+	]);
+
+	return { breadcrumb };
+}
+
+function useSelection() {
+	const selection = ref<Item[]>([]);
+
+	// Whenever the collection we're working on changes, we have to clear the selection
+	watch(
+		() => props.collection,
+		() => (selection.value = [])
+	);
+
+	return { selection };
+}
+
+function useBatch() {
+	const confirmDelete = ref(false);
+	const deleting = ref(false);
+
+	const batchEditActive = ref(false);
+
+	const confirmArchive = ref(false);
+	const archiving = ref(false);
+
+	const error = ref<any>(null);
+
+	return { batchEditActive, confirmDelete, deleting, batchDelete, confirmArchive, archiving, archiveItems, error };
+
+	async function batchDelete() {
+		deleting.value = true;
+
+		const batchPrimaryKeys = selection.value;
+
+		try {
+			await api.delete(`/items/${props.collection}`, {
+				data: batchPrimaryKeys,
+			});
+
 			selection.value = [];
 			await refresh();
-		}
 
-		function useBreadcrumb() {
-			const breadcrumb = computed(() => [
-				{
-					name: currentCollection.value?.name,
-					to: `/content/${props.collection}`,
+			confirmDelete.value = false;
+		} catch (err: any) {
+			error.value = err;
+		} finally {
+			deleting.value = false;
+		}
+	}
+
+	async function archiveItems() {
+		if (!currentCollection.value?.meta?.archive_field) return;
+
+		archiving.value = true;
+
+		let archiveValue: any = currentCollection.value.meta.archive_value;
+		if (archiveValue === 'true') archiveValue = true;
+		if (archiveValue === 'false') archiveValue = false;
+
+		try {
+			await api.patch(`/items/${props.collection}`, {
+				keys: selection.value,
+				data: {
+					[currentCollection.value.meta.archive_field]: archiveValue,
 				},
-			]);
-
-			return { breadcrumb };
-		}
-
-		function useSelection() {
-			const selection = ref<Item[]>([]);
-
-			// Whenever the collection we're working on changes, we have to clear the selection
-			watch(
-				() => props.collection,
-				() => (selection.value = [])
-			);
-
-			return { selection };
-		}
-
-		function useBatch() {
-			const confirmDelete = ref(false);
-			const deleting = ref(false);
-
-			const batchEditActive = ref(false);
-
-			const confirmArchive = ref(false);
-			const archiving = ref(false);
-
-			const error = ref<any>(null);
-
-			return { batchEditActive, confirmDelete, deleting, batchDelete, confirmArchive, archiving, archiveItems, error };
-
-			async function batchDelete() {
-				deleting.value = true;
-
-				const batchPrimaryKeys = selection.value;
-
-				try {
-					await api.delete(`/items/${props.collection}`, {
-						data: batchPrimaryKeys,
-					});
-
-					selection.value = [];
-					await refresh();
-
-					confirmDelete.value = false;
-				} catch (err: any) {
-					error.value = err;
-				} finally {
-					deleting.value = false;
-				}
-			}
-
-			async function archiveItems() {
-				if (!currentCollection.value?.meta?.archive_field) return;
-
-				archiving.value = true;
-
-				let archiveValue: any = currentCollection.value.meta.archive_value;
-				if (archiveValue === 'true') archiveValue = true;
-				if (archiveValue === 'false') archiveValue = false;
-
-				try {
-					await api.patch(`/items/${props.collection}`, {
-						keys: selection.value,
-						data: {
-							[currentCollection.value.meta.archive_field]: archiveValue,
-						},
-					});
-
-					selection.value = [];
-					await refresh();
-
-					confirmArchive.value = false;
-				} catch (err: any) {
-					error.value = err;
-				} finally {
-					archiving.value = false;
-				}
-			}
-		}
-
-		function useLinks() {
-			const addNewLink = computed<string>(() => {
-				return `/content/${props.collection}/+`;
 			});
 
-			const currentCollectionLink = computed<string>(() => {
-				return `/content/${props.collection}`;
-			});
+			selection.value = [];
+			await refresh();
 
-			return { addNewLink, currentCollectionLink };
+			confirmArchive.value = false;
+		} catch (err: any) {
+			error.value = err;
+		} finally {
+			archiving.value = false;
 		}
+	}
+}
 
-		function useBookmarks() {
-			const bookmarkDialogActive = ref(false);
-			const creatingBookmark = ref(false);
+function useLinks() {
+	const addNewLink = computed<string>(() => {
+		return `/content/${props.collection}/+`;
+	});
 
-			return {
-				bookmarkDialogActive,
-				creatingBookmark,
-				createBookmark,
-			};
+	const currentCollectionLink = computed<string>(() => {
+		return `/content/${props.collection}`;
+	});
 
-			async function createBookmark(bookmark: any) {
-				creatingBookmark.value = true;
+	return { addNewLink, currentCollectionLink };
+}
 
-				try {
-					const newBookmark = await saveCurrentAsBookmark({
-						bookmark: bookmark.name,
-						icon: bookmark.icon,
-						color: bookmark.color,
-					});
+function useBookmarks() {
+	const bookmarkDialogActive = ref(false);
+	const creatingBookmark = ref(false);
 
-					router.push(`/content/${newBookmark.collection}?bookmark=${newBookmark.id}`);
+	return {
+		bookmarkDialogActive,
+		creatingBookmark,
+		createBookmark,
+	};
 
-					bookmarkDialogActive.value = false;
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					creatingBookmark.value = false;
-				}
-			}
+	async function createBookmark(bookmark: any) {
+		creatingBookmark.value = true;
+
+		try {
+			const newBookmark = await saveCurrentAsBookmark({
+				bookmark: bookmark.name,
+				icon: bookmark.icon,
+				color: bookmark.color,
+			});
+
+			router.push(`/content/${newBookmark.collection}?bookmark=${newBookmark.id}`);
+
+			bookmarkDialogActive.value = false;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			creatingBookmark.value = false;
 		}
+	}
+}
 
-		function clearFilters() {
-			filter.value = null;
-			search.value = null;
-		}
+function clearFilters() {
+	filter.value = null;
+	search.value = null;
+}
 
-		function usePermissions() {
-			const batchEditAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
+function usePermissions() {
+	const batchEditAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-				const updatePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'update' && permission.collection === collection.value
-				);
+		const updatePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'update' && permission.collection === collection.value
+		);
 
-				return !!updatePermissions;
-			});
+		return !!updatePermissions;
+	});
 
-			const batchArchiveAllowed = computed(() => {
-				if (!currentCollection.value?.meta?.archive_field) return false;
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
+	const batchArchiveAllowed = computed(() => {
+		if (!currentCollection.value?.meta?.archive_field) return false;
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-				const updatePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'update' && permission.collection === collection.value
-				);
+		const updatePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'update' && permission.collection === collection.value
+		);
 
-				if (!updatePermissions) return false;
-				if (!updatePermissions.fields) return false;
-				if (updatePermissions.fields.includes('*')) return true;
-				return updatePermissions.fields.includes(currentCollection.value.meta.archive_field);
-			});
+		if (!updatePermissions) return false;
+		if (!updatePermissions.fields) return false;
+		if (updatePermissions.fields.includes('*')) return true;
+		return updatePermissions.fields.includes(currentCollection.value.meta.archive_field);
+	});
 
-			const batchDeleteAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
+	const batchDeleteAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-				const deletePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'delete' && permission.collection === collection.value
-				);
+		const deletePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'delete' && permission.collection === collection.value
+		);
 
-				return !!deletePermissions;
-			});
+		return !!deletePermissions;
+	});
 
-			const createAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
+	const createAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-				const createPermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'create' && permission.collection === collection.value
-				);
+		const createPermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'create' && permission.collection === collection.value
+		);
 
-				return !!createPermissions;
-			});
+		return !!createPermissions;
+	});
 
-			return { batchEditAllowed, batchArchiveAllowed, batchDeleteAllowed, createAllowed };
-		}
-	},
-});
+	return { batchEditAllowed, batchArchiveAllowed, batchDeleteAllowed, createAllowed };
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/content/routes/no-collections.vue
+++ b/app/src/modules/content/routes/no-collections.vue
@@ -32,28 +32,17 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import ContentNavigation from '../components/navigation.vue';
+<script setup lang="ts">
 import { useUserStore } from '@/stores/user';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ContentNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	name: 'ContentOverview',
-	components: {
-		ContentNavigation,
-	},
-	props: {},
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const userStore = useUserStore();
+const userStore = useUserStore();
 
-		const isAdmin = computed(() => userStore.currentUser?.role.admin_access === true);
-
-		return { t, isAdmin };
-	},
-});
+const isAdmin = computed(() => userStore.currentUser?.role.admin_access === true);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/content/routes/not-found.vue
+++ b/app/src/modules/content/routes/not-found.vue
@@ -12,18 +12,11 @@
 	</private-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import ContentNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	components: { ContentNavigation },
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/files/components/add-folder.vue
+++ b/app/src/modules/files/components/add-folder.vue
@@ -28,59 +28,48 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref } from 'vue';
+import { ref } from 'vue';
 import { useFolders } from '@/composables/use-folders';
 import api from '@/api';
 import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
 
-export default defineComponent({
-	props: {
-		parent: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	parent?: string;
+	disabled?: boolean;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const dialogActive = ref(false);
-		const saving = ref(false);
-		const newFolderName = ref(null);
+const router = useRouter();
 
-		const { fetchFolders } = useFolders();
+const dialogActive = ref(false);
+const saving = ref(false);
+const newFolderName = ref(null);
 
-		return { t, addFolder, dialogActive, newFolderName, saving };
+const { fetchFolders } = useFolders();
 
-		async function addFolder() {
-			saving.value = true;
+async function addFolder() {
+	saving.value = true;
 
-			try {
-				const newFolder = await api.post(`/folders`, {
-					name: newFolderName.value,
-					parent: props.parent === 'root' ? null : props.parent,
-				});
+	try {
+		const newFolder = await api.post(`/folders`, {
+			name: newFolderName.value,
+			parent: props.parent === 'root' ? null : props.parent,
+		});
 
-				await fetchFolders();
+		await fetchFolders();
 
-				dialogActive.value = false;
-				newFolderName.value = null;
+		dialogActive.value = false;
+		newFolderName.value = null;
 
-				router.push({ path: `/files/folders/${newFolder.data.data.id}` });
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				saving.value = false;
-			}
-		}
-	},
-});
+		router.push({ path: `/files/folders/${newFolder.data.data.id}` });
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		saving.value = false;
+	}
+}
 </script>

--- a/app/src/modules/files/components/file-info-sidebar-detail.vue
+++ b/app/src/modules/files/components/file-info-sidebar-detail.vue
@@ -23,12 +23,12 @@
 
 			<div v-if="file.charset">
 				<dt>{{ t('charset') }}</dt>
-				<dd>{{ charset }}</dd>
+				<dd>{{ file.charset }}</dd>
 			</div>
 
 			<div v-if="file.embed">
 				<dt>{{ t('embed') }}</dt>
-				<dd>{{ embed }}</dd>
+				<dd>{{ file.embed }}</dd>
 			</div>
 
 			<div v-if="creationDate">
@@ -125,188 +125,166 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref, watch } from 'vue';
-import { readableMimeType } from '@/utils/readable-mime-type';
-import { formatFilesize } from '@/utils/format-filesize';
-import { localizedFormat } from '@/utils/localized-format';
+<script setup lang="ts">
 import api from '@/api';
+import { formatFilesize } from '@/utils/format-filesize';
 import { getRootPath } from '@/utils/get-root-path';
+import { localizedFormat } from '@/utils/localized-format';
+import { readableMimeType } from '@/utils/readable-mime-type';
 import { userName } from '@/utils/user-name';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		file: {
-			type: Object,
-			default: () => ({}),
-		},
-		isNew: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t, n } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		file?: Record<string, any>;
+		isNew?: boolean;
+	}>(),
+	{
+		file: () => ({}),
+	}
+);
 
-		const size = computed(() => {
-			if (props.isNew) return null;
+const { t, n } = useI18n();
+
+const size = computed(() => {
+	if (props.isNew) return null;
+	if (!props.file) return null;
+	if (!props.file.filesize) return null;
+
+	return formatFilesize(props.file.filesize); // { locale: locale.value.split('-')[0] }
+});
+
+const { creationDate, modificationDate } = useDates();
+const { userCreated, userModified } = useUser();
+const { folder, folderLink } = useFolder();
+
+const fileLink = computed(() => {
+	return `${getRootPath()}assets/${props.file.id}`;
+});
+
+function useDates() {
+	const creationDate = ref<string | null>(null);
+	const modificationDate = ref<string | null>(null);
+
+	watch(
+		() => props.file,
+		async () => {
 			if (!props.file) return null;
-			if (!props.file.filesize) return null;
 
-			return formatFilesize(props.file.filesize); // { locale: locale.value.split('-')[0] }
-		});
+			creationDate.value = localizedFormat(new Date(props.file.uploaded_on), String(t('date-fns_date_short')));
 
-		const { creationDate, modificationDate } = useDates();
-		const { userCreated, userModified } = useUser();
-		const { folder, folderLink } = useFolder();
-
-		const fileLink = computed(() => {
-			return `${getRootPath()}assets/${props.file.id}`;
-		});
-
-		return {
-			t,
-			n,
-			readableMimeType,
-			size,
-			creationDate,
-			modificationDate,
-			userCreated,
-			userModified,
-			folder,
-			folderLink,
-			getRootPath,
-			fileLink,
-		};
-
-		function useDates() {
-			const creationDate = ref<string | null>(null);
-			const modificationDate = ref<string | null>(null);
-
-			watch(
-				() => props.file,
-				async () => {
-					if (!props.file) return null;
-
-					creationDate.value = localizedFormat(new Date(props.file.uploaded_on), String(t('date-fns_date_short')));
-
-					if (props.file.modified_on) {
-						modificationDate.value = localizedFormat(
-							new Date(props.file.modified_on),
-							String(t('date-fns_date_short'))
-						);
-					}
-				},
-				{ immediate: true }
-			);
-
-			return { creationDate, modificationDate };
-		}
-
-		function useUser() {
-			type User = {
-				id: number;
-				name: string;
-				link: string;
-			};
-
-			const loading = ref(false);
-			const userCreated = ref<User | null>(null);
-			const userModified = ref<User | null>(null);
-
-			watch(() => props.file, fetchUser, { immediate: true });
-
-			return { userCreated, userModified };
-
-			async function fetchUser() {
-				if (!props.file) return null;
-				if (!props.file.uploaded_by) return null;
-
-				loading.value = true;
-
-				try {
-					const response = await api.get(`/users/${props.file.uploaded_by}`, {
-						params: {
-							fields: ['id', 'email', 'first_name', 'last_name', 'role'],
-						},
-					});
-
-					const user = response.data.data;
-
-					userCreated.value = {
-						id: props.file.uploaded_by,
-						name: userName(user),
-						link: `/users/${user.id}`,
-					};
-
-					if (props.file.modified_by) {
-						const response = await api.get(`/users/${props.file.modified_by}`, {
-							params: {
-								fields: ['id', 'email', 'first_name', 'last_name', 'role'],
-							},
-						});
-
-						const user = response.data.data;
-
-						userModified.value = {
-							id: props.file.modified_by,
-							name: userName(user),
-							link: `/users/${user.id}`,
-						};
-					}
-				} finally {
-					loading.value = false;
-				}
+			if (props.file.modified_on) {
+				modificationDate.value = localizedFormat(new Date(props.file.modified_on), String(t('date-fns_date_short')));
 			}
-		}
+		},
+		{ immediate: true }
+	);
 
-		function useFolder() {
-			type Folder = {
-				id: string;
-				name: string;
-			};
+	return { creationDate, modificationDate };
+}
 
-			const loading = ref(false);
-			const folder = ref<Folder | null>(null);
+function useUser() {
+	type User = {
+		id: number;
+		name: string;
+		link: string;
+	};
 
-			const folderLink = computed(() => {
-				if (folder.value === null) {
-					return `/files`;
-				}
+	const loading = ref(false);
+	const userCreated = ref<User | null>(null);
+	const userModified = ref<User | null>(null);
 
-				return `/files/folders/${folder.value.id}`;
+	watch(() => props.file, fetchUser, { immediate: true });
+
+	return { userCreated, userModified };
+
+	async function fetchUser() {
+		if (!props.file) return null;
+		if (!props.file.uploaded_by) return null;
+
+		loading.value = true;
+
+		try {
+			const response = await api.get(`/users/${props.file.uploaded_by}`, {
+				params: {
+					fields: ['id', 'email', 'first_name', 'last_name', 'role'],
+				},
 			});
 
-			watch(() => props.file, fetchFolder, { immediate: true });
+			const user = response.data.data;
 
-			return { folder, folderLink };
+			userCreated.value = {
+				id: props.file.uploaded_by,
+				name: userName(user),
+				link: `/users/${user.id}`,
+			};
 
-			async function fetchFolder() {
-				if (!props.file) return null;
-				if (!props.file.folder) return;
-				loading.value = true;
+			if (props.file.modified_by) {
+				const response = await api.get(`/users/${props.file.modified_by}`, {
+					params: {
+						fields: ['id', 'email', 'first_name', 'last_name', 'role'],
+					},
+				});
 
-				try {
-					const response = await api.get(`/folders/${props.file.folder}`, {
-						params: {
-							fields: ['id', 'name'],
-						},
-					});
+				const user = response.data.data;
 
-					const { name } = response.data.data;
-
-					folder.value = {
-						id: props.file.folder,
-						name: name,
-					};
-				} finally {
-					loading.value = false;
-				}
+				userModified.value = {
+					id: props.file.modified_by,
+					name: userName(user),
+					link: `/users/${user.id}`,
+				};
 			}
+		} finally {
+			loading.value = false;
 		}
-	},
-});
+	}
+}
+
+function useFolder() {
+	type Folder = {
+		id: string;
+		name: string;
+	};
+
+	const loading = ref(false);
+	const folder = ref<Folder | null>(null);
+
+	const folderLink = computed(() => {
+		if (folder.value === null) {
+			return `/files`;
+		}
+
+		return `/files/folders/${folder.value.id}`;
+	});
+
+	watch(() => props.file, fetchFolder, { immediate: true });
+
+	return { folder, folderLink };
+
+	async function fetchFolder() {
+		if (!props.file) return null;
+		if (!props.file.folder) return;
+		loading.value = true;
+
+		try {
+			const response = await api.get(`/folders/${props.file.folder}`, {
+				params: {
+					fields: ['id', 'name'],
+				},
+			});
+
+			const { name } = response.data.data;
+
+			folder.value = {
+				id: props.file.folder,
+				name: name,
+			};
+		} finally {
+			loading.value = false;
+		}
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/files/components/navigation-folder.vue
+++ b/app/src/modules/files/components/navigation-folder.vue
@@ -118,196 +118,170 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref } from 'vue';
+import { ref } from 'vue';
 import { useFolders, Folder } from '@/composables/use-folders';
 import api from '@/api';
 import FolderPicker from '@/views/private/components/folder-picker.vue';
 import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
 
-export default defineComponent({
-	name: 'NavigationFolder',
-	components: { FolderPicker },
-	props: {
-		folder: {
-			type: Object as PropType<Folder>,
-			required: true,
-		},
-		currentFolder: {
-			type: String,
-			default: null,
-		},
-		clickHandler: {
-			type: Function,
-			default: () => undefined,
-		},
-		depth: {
-			type: Number,
-			default: 0,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		folder: Folder;
+		currentFolder?: string;
+		clickHandler?: () => void;
+		depth?: number;
+	}>(),
+	{
+		clickHandler: () => undefined,
+		depth: 0,
+	}
+);
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const { renameActive, renameValue, renameSave, renameSaving } = useRenameFolder();
-		const { moveActive, moveValue, moveSave, moveSaving } = useMoveFolder();
-		const { deleteActive, deleteSave, deleteSaving } = useDeleteFolder();
+const router = useRouter();
 
-		const { fetchFolders } = useFolders();
+const { renameActive, renameValue, renameSave, renameSaving } = useRenameFolder();
+const { moveActive, moveValue, moveSave, moveSaving } = useMoveFolder();
+const { deleteActive, deleteSave, deleteSaving } = useDeleteFolder();
 
-		return {
-			t,
-			renameActive,
-			renameValue,
-			renameSave,
-			renameSaving,
-			moveActive,
-			moveValue,
-			moveSave,
-			moveSaving,
-			deleteActive,
-			deleteSave,
-			deleteSaving,
-		};
+const { fetchFolders } = useFolders();
 
-		function useRenameFolder() {
-			const renameActive = ref(false);
-			const renameValue = ref(props.folder.name);
-			const renameSaving = ref(false);
+function useRenameFolder() {
+	const renameActive = ref(false);
+	const renameValue = ref(props.folder.name);
+	const renameSaving = ref(false);
 
-			return { renameActive, renameValue, renameSave, renameSaving };
+	return { renameActive, renameValue, renameSave, renameSaving };
 
-			async function renameSave() {
-				renameSaving.value = true;
+	async function renameSave() {
+		renameSaving.value = true;
 
-				try {
-					await api.patch(`/folders/${props.folder.id}`, {
-						name: renameValue.value,
-					});
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					renameSaving.value = false;
-					await fetchFolders();
-					renameActive.value = false;
-				}
-			}
+		try {
+			await api.patch(`/folders/${props.folder.id}`, {
+				name: renameValue.value,
+			});
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			renameSaving.value = false;
+			await fetchFolders();
+			renameActive.value = false;
 		}
+	}
+}
 
-		function useMoveFolder() {
-			const moveActive = ref(false);
-			const moveValue = ref(props.folder.parent);
-			const moveSaving = ref(false);
+function useMoveFolder() {
+	const moveActive = ref(false);
+	const moveValue = ref(props.folder.parent);
+	const moveSaving = ref(false);
 
-			return { moveActive, moveValue, moveSave, moveSaving };
+	return { moveActive, moveValue, moveSave, moveSaving };
 
-			async function moveSave() {
-				moveSaving.value = true;
+	async function moveSave() {
+		moveSaving.value = true;
 
-				try {
-					await api.patch(`/folders/${props.folder.id}`, {
-						parent: moveValue.value,
-					});
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					moveSaving.value = false;
-					await fetchFolders();
-					moveActive.value = false;
-				}
-			}
+		try {
+			await api.patch(`/folders/${props.folder.id}`, {
+				parent: moveValue.value,
+			});
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			moveSaving.value = false;
+			await fetchFolders();
+			moveActive.value = false;
 		}
+	}
+}
 
-		function useDeleteFolder() {
-			const deleteActive = ref(false);
-			const deleteSaving = ref(false);
+function useDeleteFolder() {
+	const deleteActive = ref(false);
+	const deleteSaving = ref(false);
 
-			return { deleteActive, deleteSave, deleteSaving };
+	return { deleteActive, deleteSave, deleteSaving };
 
-			async function deleteSave() {
-				deleteSaving.value = true;
+	async function deleteSave() {
+		deleteSaving.value = true;
 
-				try {
-					const foldersToUpdate = await api.get('/folders', {
-						params: {
-							filter: {
-								parent: {
-									_eq: props.folder.id,
-								},
-							},
-							fields: ['id'],
+		try {
+			const foldersToUpdate = await api.get('/folders', {
+				params: {
+					filter: {
+						parent: {
+							_eq: props.folder.id,
 						},
-					});
+					},
+					fields: ['id'],
+				},
+			});
 
-					const filesToUpdate = await api.get('/files', {
-						params: {
-							filter: {
-								folder: {
-									_eq: props.folder.id,
-								},
-							},
-							fields: ['id'],
+			const filesToUpdate = await api.get('/files', {
+				params: {
+					filter: {
+						folder: {
+							_eq: props.folder.id,
 						},
-					});
+					},
+					fields: ['id'],
+				},
+			});
 
-					const newParent = props.folder.parent || null;
+			const newParent = props.folder.parent || null;
 
-					const folderKeys = foldersToUpdate.data.data.map((folder: { id: string }) => folder.id);
-					const fileKeys = filesToUpdate.data.data.map((file: { id: string }) => file.id);
+			const folderKeys = foldersToUpdate.data.data.map((folder: { id: string }) => folder.id);
+			const fileKeys = filesToUpdate.data.data.map((file: { id: string }) => file.id);
 
-					await api.delete(`/folders/${props.folder.id}`);
+			await api.delete(`/folders/${props.folder.id}`);
 
-					if (folderKeys.length > 0) {
-						await api.patch(`/folders`, {
-							keys: folderKeys,
-							data: {
-								parent: newParent,
-							},
-						});
-					}
-
-					if (fileKeys.length > 0) {
-						await api.patch(`/files`, {
-							keys: fileKeys,
-							data: {
-								folder: newParent,
-							},
-						});
-					}
-
-					if (newParent) {
-						router.replace(`/files/folders/${newParent}`);
-					} else {
-						router.replace('/files');
-					}
-
-					deleteActive.value = false;
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					await fetchFolders();
-					deleteSaving.value = false;
-				}
+			if (folderKeys.length > 0) {
+				await api.patch(`/folders`, {
+					keys: folderKeys,
+					data: {
+						parent: newParent,
+					},
+				});
 			}
+
+			if (fileKeys.length > 0) {
+				await api.patch(`/files`, {
+					keys: fileKeys,
+					data: {
+						folder: newParent,
+					},
+				});
+			}
+
+			if (newParent) {
+				router.replace(`/files/folders/${newParent}`);
+			} else {
+				router.replace('/files');
+			}
+
+			deleteActive.value = false;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			await fetchFolders();
+			deleteSaving.value = false;
 		}
-	},
-});
+	}
+}
 </script>
 
 <style scoped>
-.content-inner {
-	display: flex;
-	align-items: center;
-	width: 100%;
-}
-
 .v-list-item.danger {
 	--v-list-item-color: var(--danger);
 	--v-list-item-color-hover: var(--danger);
 	--v-list-item-icon-color: var(--danger);
+}
+
+.content-inner {
+	display: flex;
+	align-items: center;
+	width: 100%;
 }
 </style>

--- a/app/src/modules/files/components/navigation.vue
+++ b/app/src/modules/files/components/navigation.vue
@@ -62,80 +62,60 @@
 	</v-list>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, watch } from 'vue';
-import { useFolders, Folder } from '@/composables/use-folders';
-import NavigationFolder from './navigation-folder.vue';
+<script setup lang="ts">
+import { Folder, useFolders } from '@/composables/use-folders';
 import { isEqual } from 'lodash';
+import { watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import NavigationFolder from './navigation-folder.vue';
 
-export default defineComponent({
-	components: { NavigationFolder },
-	props: {
-		currentFolder: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	currentFolder?: string;
+}>();
 
-		const { nestedFolders, folders, error, loading, openFolders } = useFolders();
+const { t } = useI18n();
 
-		setOpenFolders();
+const { nestedFolders, folders, loading, openFolders } = useFolders();
 
-		watch(() => props.currentFolder, setOpenFolders);
+setOpenFolders();
 
-		return { t, folders, nestedFolders, error, loading, openFolders };
+watch(() => props.currentFolder, setOpenFolders);
 
-		function setOpenFolders() {
-			if (!folders.value) return [];
-			if (!openFolders?.value) return [];
+function setOpenFolders() {
+	if (!folders.value) return [];
+	if (!openFolders?.value) return [];
 
-			const shouldBeOpen: string[] = [];
-			const folder = folders.value.find((folder: Folder) => folder.id === props.currentFolder);
+	const shouldBeOpen: string[] = [];
+	const folder = folders.value.find((folder: Folder) => folder.id === props.currentFolder);
 
-			if (folder && folder.parent) parseFolder(folder.parent);
+	if (folder && folder.parent) parseFolder(folder.parent);
 
-			const newOpenFolders = [...openFolders.value];
+	const newOpenFolders = [...openFolders.value];
 
-			for (const folderID of shouldBeOpen) {
-				if (newOpenFolders.includes(folderID) === false) {
-					newOpenFolders.push(folderID);
-				}
-			}
-
-			if (newOpenFolders.length !== 1 && isEqual(newOpenFolders, openFolders.value) === false) {
-				openFolders.value = newOpenFolders;
-			}
-
-			function parseFolder(id: string) {
-				if (!folders.value) return;
-				shouldBeOpen.push(id);
-
-				const folder = folders.value.find((folder: Folder) => folder.id === id);
-
-				if (folder && folder.parent) {
-					parseFolder(folder.parent);
-				}
-			}
+	for (const folderID of shouldBeOpen) {
+		if (newOpenFolders.includes(folderID) === false) {
+			newOpenFolders.push(folderID);
 		}
-	},
-});
+	}
+
+	if (newOpenFolders.length !== 1 && isEqual(newOpenFolders, openFolders.value) === false) {
+		openFolders.value = newOpenFolders;
+	}
+
+	function parseFolder(id: string) {
+		if (!folders.value) return;
+		shouldBeOpen.push(id);
+
+		const folder = folders.value.find((folder: Folder) => folder.id === id);
+
+		if (folder && folder.parent) {
+			parseFolder(folder.parent);
+		}
+	}
+}
 </script>
 
 <style lang="scss" scoped>
-.files-navigation {
-	--v-list-item-active-rule-width: 2px;
-	--v-list-item-active-rule-color: var(--primary);
-	--v-list-item-border-radius-nav: 0;
-	--v-list-group-items-padding-left: 0;
-
-	:deep(.v-list-item.active) {
-		--v-list-item-icon-color: var(--primary);
-	}
-}
-
 .v-skeleton-loader {
 	--v-skeleton-loader-background-color: var(--background-normal-alt);
 }
@@ -148,6 +128,17 @@ export default defineComponent({
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+	}
+}
+
+.files-navigation {
+	--v-list-item-active-rule-width: 2px;
+	--v-list-item-active-rule-color: var(--primary);
+	--v-list-item-border-radius-nav: 0;
+	--v-list-group-items-padding-left: 0;
+
+	:deep(.v-list-item.active) {
+		--v-list-item-icon-color: var(--primary);
 	}
 }
 </style>

--- a/app/src/modules/files/routes/add-new.vue
+++ b/app/src/modules/files/routes/add-new.vue
@@ -3,7 +3,7 @@
 		<v-card>
 			<v-card-title>{{ t('add_file') }}</v-card-title>
 			<v-card-text>
-				<v-upload :preset="{ folder }" multiple from-url @input="close" />
+				<v-upload :preset="props.folder ? { folder: props.folder } : undefined" multiple from-url @input="close" />
 			</v-card-text>
 			<v-card-actions>
 				<v-button secondary @click="close">{{ t('done') }}</v-button>
@@ -12,31 +12,22 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
-import { useRouter } from 'vue-router';
+<script setup lang="ts">
 import { useDialogRoute } from '@/composables/use-dialog-route';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
-export default defineComponent({
-	props: {
-		folder: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	folder?: string;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const isOpen = useDialogRoute();
+const router = useRouter();
 
-		return { t, isOpen, close };
+const isOpen = useDialogRoute();
 
-		function close() {
-			router.push(props.folder ? { path: `/files/folders/${props.folder}` } : { path: '/files' });
-		}
-	},
-});
+function close() {
+	router.push(props.folder ? { path: `/files/folders/${props.folder}` } : { path: '/files' });
+}
 </script>

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -189,7 +189,7 @@
 	</component>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import api from '@/api';
 import { useEventListener } from '@/composables/use-event-listener';
 import { useExtension } from '@/composables/use-extension';
@@ -209,7 +209,7 @@ import { useLayout } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
 import { mergeFilters } from '@cairncms/utils';
 import { subDays } from 'date-fns';
-import { PropType, computed, defineComponent, nextTick, onMounted, onUnmounted, ref } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRouter } from 'vue-router';
 import AddFolder from '../components/add-folder.vue';
@@ -219,458 +219,402 @@ type Item = {
 	[field: string]: any;
 };
 
-export default defineComponent({
-	name: 'FilesCollection',
-	components: {
-		FilesNavigation,
-		LayoutSidebarDetail,
-		AddFolder,
-		SearchInput,
-		FolderPicker,
-		DrawerBatch,
-	},
-	props: {
-		folder: {
-			type: String,
-			default: null,
-		},
-		special: {
-			type: String as PropType<'all' | 'recent' | 'mine'>,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	folder?: string;
+	special?: 'all' | 'recent' | 'mine';
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const notificationsStore = useNotificationsStore();
-		const permissionsStore = usePermissionsStore();
-		const { folders } = useFolders();
+const router = useRouter();
 
-		const layoutRef = ref();
-		const selection = ref<Item[]>([]);
+const notificationsStore = useNotificationsStore();
+const permissionsStore = usePermissionsStore();
+const { folders } = useFolders();
 
-		const userStore = useUserStore();
+const layoutRef = ref();
+const selection = ref<Item[]>([]);
 
-		const { layout, layoutOptions, layoutQuery, filter, search, resetPreset } = usePreset(ref('directus_files'));
+const userStore = useUserStore();
 
-		const currentLayout = useExtension('layout', layout);
+const { layout, layoutOptions, layoutQuery, filter, search, resetPreset } = usePreset(ref('directus_files'));
 
-		const { confirmDelete, deleting, batchDelete, error: deleteError, batchEditActive } = useBatch();
+const currentLayout = useExtension('layout', layout);
 
-		const { breadcrumb, title } = useBreadcrumb();
+const { confirmDelete, deleting, batchDelete, batchEditActive } = useBatch();
 
-		const folderTypeFilter = computed(() => {
-			const filterParsed: Filter = {
-				_and: [
-					{
-						type: {
-							_nnull: true,
-						},
-					},
-				],
-			};
+const { breadcrumb, title } = useBreadcrumb();
 
-			if (props.special === null) {
-				if (props.folder !== null) {
-					filterParsed._and.push({
-						folder: {
-							_eq: props.folder,
-						},
-					});
-				} else {
-					filterParsed._and.push({
-						folder: {
-							_null: true,
-						},
-					});
-				}
-			}
+const folderTypeFilter = computed(() => {
+	const filterParsed: Filter = {
+		_and: [
+			{
+				type: {
+					_nnull: true,
+				},
+			},
+		],
+	};
 
-			if (props.special === 'mine' && userStore.currentUser) {
-				filterParsed._and.push({
-					uploaded_by: {
-						_eq: userStore.currentUser.id,
-					},
-				});
-			}
+	if (props.special === null) {
+		if (props.folder !== null) {
+			filterParsed._and.push({
+				folder: {
+					_eq: props.folder,
+				},
+			});
+		} else {
+			filterParsed._and.push({
+				folder: {
+					_null: true,
+				},
+			});
+		}
+	}
 
-			if (props.special === 'recent') {
-				filterParsed._and.push({
-					uploaded_on: {
-						_gt: subDays(new Date(), 5).toISOString(),
-					},
-				});
-			}
-
-			return filterParsed;
+	if (props.special === 'mine' && userStore.currentUser) {
+		filterParsed._and.push({
+			uploaded_by: {
+				_eq: userStore.currentUser.id,
+			},
 		});
+	}
 
-		const { layoutWrapper } = useLayout(layout);
+	if (props.special === 'recent') {
+		filterParsed._and.push({
+			uploaded_on: {
+				_gt: subDays(new Date(), 5).toISOString(),
+			},
+		});
+	}
 
-		const { moveToDialogActive, moveToFolder, moving, selectedFolder } = useMovetoFolder();
+	return filterParsed;
+});
 
-		onMounted(() => emitter.on(Events.upload, refresh));
-		onUnmounted(() => emitter.off(Events.upload, refresh));
+const { layoutWrapper } = useLayout(layout);
 
-		onBeforeRouteLeave(() => {
+const { moveToDialogActive, moveToFolder, moving, selectedFolder } = useMovetoFolder();
+
+onMounted(() => emitter.on(Events.upload, refresh));
+onUnmounted(() => emitter.off(Events.upload, refresh));
+
+onBeforeRouteLeave(() => {
+	selection.value = [];
+});
+
+onBeforeRouteUpdate(() => {
+	selection.value = [];
+});
+
+const { onDragEnter, onDragLeave, onDrop, onDragOver, showDropEffect, dragging } = useFileUpload();
+
+useEventListener(window, 'dragenter', onDragEnter);
+useEventListener(window, 'dragover', onDragOver);
+useEventListener(window, 'dragleave', onDragLeave);
+useEventListener(window, 'drop', onDrop);
+
+const { batchEditAllowed, batchDeleteAllowed, createAllowed, createFolderAllowed } = usePermissions();
+
+function useBatch() {
+	const confirmDelete = ref(false);
+	const deleting = ref(false);
+
+	const batchEditActive = ref(false);
+
+	const error = ref<any>();
+
+	return { batchEditActive, confirmDelete, deleting, batchDelete, error };
+
+	async function batchDelete() {
+		deleting.value = true;
+
+		const batchPrimaryKeys = selection.value;
+
+		try {
+			await api.delete('/files', {
+				data: batchPrimaryKeys,
+			});
+
+			await refresh();
+
 			selection.value = [];
-		});
+		} catch (err: any) {
+			unexpectedError(err);
+			error.value = err;
+		} finally {
+			confirmDelete.value = false;
+			deleting.value = false;
+		}
+	}
+}
 
-		onBeforeRouteUpdate(() => {
+function useBreadcrumb() {
+	const title = computed(() => {
+		if (props.special === 'all') {
+			return t('all_files');
+		}
+
+		if (props.special === 'mine') {
+			return t('my_files');
+		}
+
+		if (props.special === 'recent') {
+			return t('recent_files');
+		}
+
+		if (props.folder) {
+			const folder = folders.value?.find((folder: Folder) => folder.id === props.folder);
+
+			if (folder) {
+				return folder.name;
+			}
+		}
+
+		return t('file_library');
+	});
+
+	const breadcrumb = computed(() => {
+		if (title.value !== t('file_library')) {
+			return [
+				{
+					name: t('file_library'),
+					to: `/files`,
+				},
+			];
+		}
+
+		return null;
+	});
+
+	return { breadcrumb, title };
+}
+
+function useMovetoFolder() {
+	const moveToDialogActive = ref(false);
+	const moving = ref(false);
+	const selectedFolder = ref<number | null>();
+
+	return { moveToDialogActive, moving, moveToFolder, selectedFolder };
+
+	async function moveToFolder() {
+		moving.value = true;
+
+		try {
+			await api.patch(`/files`, {
+				keys: selection.value,
+				data: {
+					folder: selectedFolder.value,
+				},
+			});
+
 			selection.value = [];
+
+			if (selectedFolder.value) {
+				router.push(`/files/folders/${selectedFolder.value}`);
+			}
+
+			await nextTick();
+			await refresh();
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			moveToDialogActive.value = false;
+			moving.value = false;
+		}
+	}
+}
+
+async function refresh() {
+	await layoutRef.value?.state?.refresh?.();
+}
+
+function clearFilters() {
+	filter.value = null;
+	search.value = null;
+}
+
+function usePermissions() {
+	const batchEditAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
+
+		const updatePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'update' && permission.collection === 'directus_files'
+		);
+
+		return !!updatePermissions;
+	});
+
+	const batchDeleteAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
+
+		const deletePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'delete' && permission.collection === 'directus_files'
+		);
+
+		return !!deletePermissions;
+	});
+
+	const createAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
+
+		const createPermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'create' && permission.collection === 'directus_files'
+		);
+
+		return !!createPermissions;
+	});
+
+	const createFolderAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
+
+		const createPermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'create' && permission.collection === 'directus_folders'
+		);
+
+		return !!createPermissions;
+	});
+
+	return { batchEditAllowed, batchDeleteAllowed, createAllowed, createFolderAllowed };
+}
+
+function useFileUpload() {
+	const showDropEffect = ref(false);
+
+	let dragNotificationID: string;
+	let fileUploadNotificationID: string;
+
+	const dragCounter = ref(0);
+
+	const dragging = computed(() => dragCounter.value > 0);
+
+	return { onDragEnter, onDragLeave, onDrop, onDragOver, showDropEffect, dragging };
+
+	function enableDropEffect() {
+		showDropEffect.value = true;
+
+		dragNotificationID = notificationsStore.add({
+			title: t('drop_to_upload'),
+			icon: 'cloud_upload',
+			type: 'info',
+			persist: true,
+			closeable: false,
+		});
+	}
+
+	function disableDropEffect() {
+		showDropEffect.value = false;
+
+		if (dragNotificationID) {
+			notificationsStore.remove(dragNotificationID);
+		}
+	}
+
+	function onDragEnter(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		if (event.dataTransfer?.types.indexOf('Files') === -1) return;
+
+		event.preventDefault();
+		dragCounter.value++;
+
+		const isDropzone = event.target && (event.target as HTMLElement).getAttribute?.('data-dropzone') === '';
+
+		if (dragCounter.value === 1 && showDropEffect.value === false && isDropzone === false) {
+			enableDropEffect();
+		}
+
+		if (isDropzone) {
+			disableDropEffect();
+			dragCounter.value = 0;
+		}
+	}
+
+	function onDragOver(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		if (event.dataTransfer?.types.indexOf('Files') === -1) return;
+
+		event.preventDefault();
+	}
+
+	function onDragLeave(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		if (event.dataTransfer?.types.indexOf('Files') === -1) return;
+
+		event.preventDefault();
+		dragCounter.value--;
+
+		if (dragCounter.value === 0) {
+			disableDropEffect();
+		}
+
+		if (event.target && (event.target as HTMLElement).getAttribute?.('data-dropzone') === '') {
+			enableDropEffect();
+			dragCounter.value = 1;
+		}
+	}
+
+	async function onDrop(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		if (event.dataTransfer?.types.indexOf('Files') === -1) return;
+
+		event.preventDefault();
+		showDropEffect.value = false;
+
+		dragCounter.value = 0;
+
+		if (dragNotificationID) {
+			notificationsStore.remove(dragNotificationID);
+		}
+
+		const files = [...(event.dataTransfer.files as any)];
+
+		fileUploadNotificationID = notificationsStore.add({
+			title: t(
+				'upload_files_indeterminate',
+				{
+					done: 0,
+					total: files.length,
+				},
+				files.length
+			),
+			type: 'info',
+			persist: true,
+			closeable: false,
+			loading: true,
 		});
 
-		const { onDragEnter, onDragLeave, onDrop, onDragOver, showDropEffect, dragging } = useFileUpload();
+		const preset = props.folder ? { folder: props.folder } : undefined;
 
-		useEventListener(window, 'dragenter', onDragEnter);
-		useEventListener(window, 'dragover', onDragOver);
-		useEventListener(window, 'dragleave', onDragLeave);
-		useEventListener(window, 'drop', onDrop);
+		await uploadFiles(files, {
+			preset,
+			onProgressChange: (progress) => {
+				const percentageDone = progress.reduce((val, cur) => (val += cur)) / progress.length;
 
-		const { batchEditAllowed, batchDeleteAllowed, createAllowed, createFolderAllowed } = usePermissions();
+				const total = files.length;
+				const done = progress.filter((p) => p === 100).length;
 
-		return {
-			t,
-			breadcrumb,
-			title,
-			layoutRef,
-			layoutWrapper,
-			selection,
-			layoutOptions,
-			layoutQuery,
-			layout,
-			folderTypeFilter,
-			search,
-			moveToDialogActive,
-			moveToFolder,
-			moving,
-			selectedFolder,
-			refresh,
-			clearFilters,
-			onDragEnter,
-			onDragLeave,
-			showDropEffect,
-			onDrop,
-			dragging,
-			batchEditAllowed,
-			batchDeleteAllowed,
-			createAllowed,
-			createFolderAllowed,
-			resetPreset,
-			confirmDelete,
-			deleting,
-			batchDelete,
-			deleteError,
-			batchEditActive,
-			filter,
-			mergeFilters,
-			currentLayout,
-		};
-
-		function useBatch() {
-			const confirmDelete = ref(false);
-			const deleting = ref(false);
-
-			const batchEditActive = ref(false);
-
-			const error = ref<any>();
-
-			return { batchEditActive, confirmDelete, deleting, batchDelete, error };
-
-			async function batchDelete() {
-				deleting.value = true;
-
-				const batchPrimaryKeys = selection.value;
-
-				try {
-					await api.delete('/files', {
-						data: batchPrimaryKeys,
-					});
-
-					await refresh();
-
-					selection.value = [];
-				} catch (err: any) {
-					unexpectedError(err);
-					error.value = err;
-				} finally {
-					confirmDelete.value = false;
-					deleting.value = false;
-				}
-			}
-		}
-
-		function useBreadcrumb() {
-			const title = computed(() => {
-				if (props.special === 'all') {
-					return t('all_files');
-				}
-
-				if (props.special === 'mine') {
-					return t('my_files');
-				}
-
-				if (props.special === 'recent') {
-					return t('recent_files');
-				}
-
-				if (props.folder) {
-					const folder = folders.value?.find((folder: Folder) => folder.id === props.folder);
-
-					if (folder) {
-						return folder.name;
-					}
-				}
-
-				return t('file_library');
-			});
-
-			const breadcrumb = computed(() => {
-				if (title.value !== t('file_library')) {
-					return [
-						{
-							name: t('file_library'),
-							to: `/files`,
-						},
-					];
-				}
-
-				return null;
-			});
-
-			return { breadcrumb, title };
-		}
-
-		function useMovetoFolder() {
-			const moveToDialogActive = ref(false);
-			const moving = ref(false);
-			const selectedFolder = ref<number | null>();
-
-			return { moveToDialogActive, moving, moveToFolder, selectedFolder };
-
-			async function moveToFolder() {
-				moving.value = true;
-
-				try {
-					await api.patch(`/files`, {
-						keys: selection.value,
-						data: {
-							folder: selectedFolder.value,
-						},
-					});
-
-					selection.value = [];
-
-					if (selectedFolder.value) {
-						router.push(`/files/folders/${selectedFolder.value}`);
-					}
-
-					await nextTick();
-					await refresh();
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					moveToDialogActive.value = false;
-					moving.value = false;
-				}
-			}
-		}
-
-		async function refresh() {
-			await layoutRef.value?.state?.refresh?.();
-		}
-
-		function clearFilters() {
-			filter.value = null;
-			search.value = null;
-		}
-
-		function usePermissions() {
-			const batchEditAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const updatePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'update' && permission.collection === 'directus_files'
-				);
-
-				return !!updatePermissions;
-			});
-
-			const batchDeleteAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const deletePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'delete' && permission.collection === 'directus_files'
-				);
-
-				return !!deletePermissions;
-			});
-
-			const createAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const createPermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'create' && permission.collection === 'directus_files'
-				);
-
-				return !!createPermissions;
-			});
-
-			const createFolderAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const createPermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'create' && permission.collection === 'directus_folders'
-				);
-
-				return !!createPermissions;
-			});
-
-			return { batchEditAllowed, batchDeleteAllowed, createAllowed, createFolderAllowed };
-		}
-
-		function useFileUpload() {
-			const showDropEffect = ref(false);
-
-			let dragNotificationID: string;
-			let fileUploadNotificationID: string;
-
-			const dragCounter = ref(0);
-
-			const dragging = computed(() => dragCounter.value > 0);
-
-			return { onDragEnter, onDragLeave, onDrop, onDragOver, showDropEffect, dragging };
-
-			function enableDropEffect() {
-				showDropEffect.value = true;
-
-				dragNotificationID = notificationsStore.add({
-					title: t('drop_to_upload'),
-					icon: 'cloud_upload',
-					type: 'info',
-					persist: true,
-					closeable: false,
-				});
-			}
-
-			function disableDropEffect() {
-				showDropEffect.value = false;
-
-				if (dragNotificationID) {
-					notificationsStore.remove(dragNotificationID);
-				}
-			}
-
-			function onDragEnter(event: DragEvent) {
-				if (!event.dataTransfer) return;
-				if (event.dataTransfer?.types.indexOf('Files') === -1) return;
-
-				event.preventDefault();
-				dragCounter.value++;
-
-				const isDropzone = event.target && (event.target as HTMLElement).getAttribute?.('data-dropzone') === '';
-
-				if (dragCounter.value === 1 && showDropEffect.value === false && isDropzone === false) {
-					enableDropEffect();
-				}
-
-				if (isDropzone) {
-					disableDropEffect();
-					dragCounter.value = 0;
-				}
-			}
-
-			function onDragOver(event: DragEvent) {
-				if (!event.dataTransfer) return;
-				if (event.dataTransfer?.types.indexOf('Files') === -1) return;
-
-				event.preventDefault();
-			}
-
-			function onDragLeave(event: DragEvent) {
-				if (!event.dataTransfer) return;
-				if (event.dataTransfer?.types.indexOf('Files') === -1) return;
-
-				event.preventDefault();
-				dragCounter.value--;
-
-				if (dragCounter.value === 0) {
-					disableDropEffect();
-				}
-
-				if (event.target && (event.target as HTMLElement).getAttribute?.('data-dropzone') === '') {
-					enableDropEffect();
-					dragCounter.value = 1;
-				}
-			}
-
-			async function onDrop(event: DragEvent) {
-				if (!event.dataTransfer) return;
-				if (event.dataTransfer?.types.indexOf('Files') === -1) return;
-
-				event.preventDefault();
-				showDropEffect.value = false;
-
-				dragCounter.value = 0;
-
-				if (dragNotificationID) {
-					notificationsStore.remove(dragNotificationID);
-				}
-
-				const files = [...(event.dataTransfer.files as any)];
-
-				fileUploadNotificationID = notificationsStore.add({
+				notificationsStore.update(fileUploadNotificationID, {
 					title: t(
 						'upload_files_indeterminate',
 						{
-							done: 0,
-							total: files.length,
+							done,
+							total,
 						},
 						files.length
 					),
-					type: 'info',
-					persist: true,
-					closeable: false,
-					loading: true,
+					loading: false,
+					progress: percentageDone,
 				});
+			},
+		});
 
-				await uploadFiles(files, {
-					preset: {
-						folder: props.folder,
-					},
-					onProgressChange: (progress) => {
-						const percentageDone = progress.reduce((val, cur) => (val += cur)) / progress.length;
-
-						const total = files.length;
-						const done = progress.filter((p) => p === 100).length;
-
-						notificationsStore.update(fileUploadNotificationID, {
-							title: t(
-								'upload_files_indeterminate',
-								{
-									done,
-									total,
-								},
-								files.length
-							),
-							loading: false,
-							progress: percentageDone,
-						});
-					},
-				});
-
-				notificationsStore.remove(fileUploadNotificationID);
-				emitter.emit(Events.upload);
-			}
-		}
-	},
-});
+		notificationsStore.remove(fileUploadNotificationID);
+		emitter.emit(Events.upload);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/files/routes/not-found.vue
+++ b/app/src/modules/files/routes/not-found.vue
@@ -12,18 +12,11 @@
 	</private-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import FilesNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	components: { FilesNavigation },
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/insights/components/navigation.vue
+++ b/app/src/modules/insights/components/navigation.vue
@@ -13,33 +13,25 @@
 	</v-list>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, ref } from 'vue';
+<script setup lang="ts">
 import { useInsightsStore } from '@/stores/insights';
 import { Dashboard } from '@/types/insights';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	name: 'InsightsNavigation',
-	emits: ['create'],
-	setup() {
-		const { t } = useI18n();
-		const insightsStore = useInsightsStore();
+defineEmits(['create']);
 
-		const createDialogActive = ref(false);
+const { t } = useI18n();
+const insightsStore = useInsightsStore();
 
-		const navItems = computed(() =>
-			insightsStore.dashboards.map((dashboard: Dashboard) => ({
-				icon: dashboard.icon,
-				color: dashboard.color,
-				name: dashboard.name,
-				to: `/insights/${dashboard.id}`,
-			}))
-		);
-
-		return { navItems, createDialogActive, t };
-	},
-});
+const navItems = computed(() =>
+	insightsStore.dashboards.map((dashboard: Dashboard) => ({
+		icon: dashboard.icon,
+		color: dashboard.color,
+		name: dashboard.name,
+		to: `/insights/${dashboard.id}`,
+	}))
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/insights/routes/not-found.vue
+++ b/app/src/modules/insights/routes/not-found.vue
@@ -12,19 +12,11 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-import InsightsNavigation from '../components/navigation.vue';
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import InsightsNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	components: { InsightsNavigation },
-	setup() {
-		const { t } = useI18n();
-
-		return { t };
-	},
-});
+const { t } = useI18n();
 </script>
 
 <style scoped>

--- a/app/src/modules/insights/routes/overview.vue
+++ b/app/src/modules/insights/routes/overview.vue
@@ -100,8 +100,8 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, ref } from 'vue';
+<script setup lang="ts">
+import { computed, ref } from 'vue';
 import { useInsightsStore } from '@/stores/insights';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useI18n } from 'vue-i18n';
@@ -112,101 +112,78 @@ import InsightsNavigation from '../components/navigation.vue';
 import DashboardDialog from '../components/dashboard-dialog.vue';
 import api from '@/api';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { md } from '@/utils/md';
 
-export default defineComponent({
-	name: 'InsightsOverview',
-	components: { InsightsNavigation, DashboardDialog },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const insightsStore = useInsightsStore();
-		const permissionsStore = usePermissionsStore();
+const insightsStore = useInsightsStore();
+const permissionsStore = usePermissionsStore();
 
-		const confirmDelete = ref<string | null>(null);
-		const deletingDashboard = ref(false);
-		const editDashboard = ref<Dashboard | null>(null);
+const confirmDelete = ref<string | null>(null);
+const deletingDashboard = ref(false);
+const editDashboard = ref<Dashboard | null>(null);
 
-		const createDialogActive = ref(false);
+const createDialogActive = ref(false);
 
-		const createAllowed = computed<boolean>(() => {
-			return permissionsStore.hasPermission('directus_dashboards', 'create');
-		});
-
-		const updateAllowed = computed<boolean>(() => {
-			return permissionsStore.hasPermission('directus_dashboards', 'update');
-		});
-
-		const deleteAllowed = computed<boolean>(() => {
-			return permissionsStore.hasPermission('directus_dashboards', 'delete');
-		});
-
-		const tableHeaders = ref<Header[]>([
-			{
-				text: '',
-				value: 'icon',
-				width: 42,
-				sortable: false,
-				align: 'left',
-				description: null,
-			},
-			{
-				text: t('name'),
-				value: 'name',
-				width: 240,
-				sortable: true,
-				align: 'left',
-				description: null,
-			},
-			{
-				text: t('note'),
-				value: 'note',
-				width: 360,
-				sortable: false,
-				align: 'left',
-				description: null,
-			},
-		]);
-
-		const dashboards = computed(() => insightsStore.dashboards);
-
-		return {
-			dashboards,
-			createAllowed,
-			updateAllowed,
-			deleteAllowed,
-			tableHeaders,
-			navigateToDashboard,
-			createDialogActive,
-			confirmDelete,
-			deletingDashboard,
-			deleteDashboard,
-			editDashboard,
-			t,
-			md,
-		};
-
-		function navigateToDashboard({ item: dashboard }: { item: Dashboard }) {
-			router.push(`/insights/${dashboard.id}`);
-		}
-
-		async function deleteDashboard() {
-			if (!confirmDelete.value) return;
-
-			deletingDashboard.value = true;
-
-			try {
-				await api.delete(`/dashboards/${confirmDelete.value}`);
-				await insightsStore.hydrate();
-				confirmDelete.value = null;
-			} catch (err) {
-				unexpectedError(err);
-			} finally {
-				deletingDashboard.value = false;
-			}
-		}
-	},
+const createAllowed = computed<boolean>(() => {
+	return permissionsStore.hasPermission('directus_dashboards', 'create');
 });
+
+const updateAllowed = computed<boolean>(() => {
+	return permissionsStore.hasPermission('directus_dashboards', 'update');
+});
+
+const deleteAllowed = computed<boolean>(() => {
+	return permissionsStore.hasPermission('directus_dashboards', 'delete');
+});
+
+const tableHeaders = ref<Header[]>([
+	{
+		text: '',
+		value: 'icon',
+		width: 42,
+		sortable: false,
+		align: 'left',
+		description: null,
+	},
+	{
+		text: t('name'),
+		value: 'name',
+		width: 240,
+		sortable: true,
+		align: 'left',
+		description: null,
+	},
+	{
+		text: t('note'),
+		value: 'note',
+		width: 360,
+		sortable: false,
+		align: 'left',
+		description: null,
+	},
+]);
+
+const dashboards = computed(() => insightsStore.dashboards);
+
+function navigateToDashboard({ item: dashboard }: { item: Dashboard }) {
+	router.push(`/insights/${dashboard.id}`);
+}
+
+async function deleteDashboard() {
+	if (!confirmDelete.value) return;
+
+	deletingDashboard.value = true;
+
+	try {
+		await api.delete(`/dashboards/${confirmDelete.value}`);
+		await insightsStore.hydrate();
+		confirmDelete.value = null;
+	} catch (err) {
+		unexpectedError(err);
+	} finally {
+		deletingDashboard.value = false;
+	}
+}
 </script>
 
 <style scoped>

--- a/app/src/modules/settings/components/navigation.test.ts
+++ b/app/src/modules/settings/components/navigation.test.ts
@@ -61,3 +61,28 @@ describe('Settings Navigation — version display', () => {
 		expect(wrapper.html()).not.toContain('github.com/CairnCMS/cairncms/releases');
 	});
 });
+
+describe('Settings Navigation - support links', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: true,
+			})
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('links to the generic issue and discussion pages without a preselected template or category', () => {
+		const wrapper = mountNavigation();
+		const hrefs = wrapper.findAll('a.v-list-item-stub').map((anchor) => anchor.attributes('href'));
+
+		expect(hrefs).toContain('https://github.com/CairnCMS/cairncms/issues/new');
+		expect(hrefs).toContain('https://github.com/CairnCMS/cairncms/discussions/new');
+		expect(hrefs.some((href) => href?.includes('?template='))).toBe(false);
+		expect(hrefs.some((href) => href?.includes('?category='))).toBe(false);
+	});
+});

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -75,12 +75,12 @@ export default defineComponent({
 				{
 					icon: 'bug_report',
 					name: t('report_bug'),
-					href: 'https://github.com/CairnCMS/cairncms/issues/new?template=bug_report.yml',
+					href: 'https://github.com/CairnCMS/cairncms/issues/new',
 				},
 				{
 					icon: 'new_releases',
 					name: t('request_feature'),
-					href: 'https://github.com/CairnCMS/cairncms/discussions/new?category=feature-requests',
+					href: 'https://github.com/CairnCMS/cairncms/discussions/new',
 				},
 			];
 		});

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -25,68 +25,62 @@
 	</v-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useServerStore } from '@/stores/server';
-import { computed, defineComponent } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const serverStore = useServerStore();
-		const version = computed(() => serverStore.info.cairncms?.version);
+const serverStore = useServerStore();
+const version = computed(() => serverStore.info.cairncms?.version);
 
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const navItems = [
-			{
-				icon: 'public',
-				name: t('settings_project'),
-				to: `/settings/project`,
-			},
-			{
-				icon: 'list_alt',
-				name: t('settings_data_model'),
-				to: `/settings/data-model`,
-			},
-			{
-				icon: 'admin_panel_settings',
-				name: t('settings_permissions'),
-				to: `/settings/roles`,
-			},
-			{
-				icon: 'bookmark',
-				name: t('settings_presets'),
-				to: `/settings/presets`,
-			},
-			{
-				icon: 'translate',
-				name: t('settings_translation_strings'),
-				to: `/settings/translation-strings`,
-			},
-			{
-				icon: 'bolt',
-				name: t('settings_flows'),
-				to: `/settings/flows`,
-			},
-		];
-
-		const externalItems = computed(() => {
-			return [
-				{
-					icon: 'bug_report',
-					name: t('report_bug'),
-					href: 'https://github.com/CairnCMS/cairncms/issues/new',
-				},
-				{
-					icon: 'new_releases',
-					name: t('request_feature'),
-					href: 'https://github.com/CairnCMS/cairncms/discussions/new',
-				},
-			];
-		});
-
-		return { version, navItems, externalItems };
+const navItems = [
+	{
+		icon: 'public',
+		name: t('settings_project'),
+		to: `/settings/project`,
 	},
+	{
+		icon: 'list_alt',
+		name: t('settings_data_model'),
+		to: `/settings/data-model`,
+	},
+	{
+		icon: 'admin_panel_settings',
+		name: t('settings_permissions'),
+		to: `/settings/roles`,
+	},
+	{
+		icon: 'bookmark',
+		name: t('settings_presets'),
+		to: `/settings/presets`,
+	},
+	{
+		icon: 'translate',
+		name: t('settings_translation_strings'),
+		to: `/settings/translation-strings`,
+	},
+	{
+		icon: 'bolt',
+		name: t('settings_flows'),
+		to: `/settings/flows`,
+	},
+];
+
+const externalItems = computed(() => {
+	return [
+		{
+			icon: 'bug_report',
+			name: t('report_bug'),
+			href: 'https://github.com/CairnCMS/cairncms/issues/new',
+		},
+		{
+			icon: 'new_releases',
+			name: t('request_feature'),
+			href: 'https://github.com/CairnCMS/cairncms/discussions/new',
+		},
+	];
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
@@ -70,83 +70,72 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import api from '@/api';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { defineComponent, ref, reactive, PropType, watch } from 'vue';
+import { ref, reactive, watch } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useI18n } from 'vue-i18n';
 import { isEqual } from 'lodash';
 import { Collection } from '@/types/collections';
 
-export default defineComponent({
-	name: 'CollectionDialog',
-	props: {
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
-		collection: {
-			type: Object as PropType<Collection>,
-			default: null,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	modelValue?: boolean;
+	collection?: Collection;
+}>();
 
-		const collectionsStore = useCollectionsStore();
+const emit = defineEmits(['update:modelValue']);
 
-		const values = reactive({
-			collection: props.collection?.collection ?? null,
-			icon: props.collection?.icon ?? 'folder',
-			note: props.collection?.meta?.note ?? null,
-			color: props.collection?.color ?? null,
-			translations: props.collection?.meta?.translations ?? null,
-		});
+const { t } = useI18n();
 
-		watch(
-			() => props.modelValue,
-			(newValue, oldValue) => {
-				if (isEqual(newValue, oldValue) === false) {
-					values.collection = props.collection?.collection ?? null;
-					values.icon = props.collection?.icon ?? 'folder';
-					values.note = props.collection?.meta?.note ?? null;
-					values.color = props.collection?.color ?? null;
-					values.translations = props.collection?.meta?.translations ?? null;
-				}
-			}
-		);
+const collectionsStore = useCollectionsStore();
 
-		const saving = ref(false);
-
-		return { values, cancel, saving, save, t };
-
-		function cancel() {
-			emit('update:modelValue', false);
-		}
-
-		async function save() {
-			saving.value = true;
-
-			try {
-				if (props.collection) {
-					await api.patch(`/collections/${props.collection.collection}`, { meta: values });
-					await collectionsStore.hydrate();
-				} else {
-					await api.post<any>('/collections', { collection: values.collection, meta: values });
-					await collectionsStore.hydrate();
-				}
-
-				emit('update:modelValue', false);
-			} catch (err) {
-				unexpectedError(err);
-			} finally {
-				saving.value = false;
-			}
-		}
-	},
+const values = reactive({
+	collection: props.collection?.collection ?? null,
+	icon: props.collection?.icon ?? 'folder',
+	note: props.collection?.meta?.note ?? null,
+	color: props.collection?.color ?? null,
+	translations: props.collection?.meta?.translations ?? null,
 });
+
+watch(
+	() => props.modelValue,
+	(newValue, oldValue) => {
+		if (isEqual(newValue, oldValue) === false) {
+			values.collection = props.collection?.collection ?? null;
+			values.icon = props.collection?.icon ?? 'folder';
+			values.note = props.collection?.meta?.note ?? null;
+			values.color = props.collection?.color ?? null;
+			values.translations = props.collection?.meta?.translations ?? null;
+		}
+	}
+);
+
+const saving = ref(false);
+
+function cancel() {
+	emit('update:modelValue', false);
+}
+
+async function save() {
+	saving.value = true;
+
+	try {
+		if (props.collection) {
+			await api.patch(`/collections/${props.collection.collection}`, { meta: values });
+			await collectionsStore.hydrate();
+		} else {
+			await api.post<any>('/collections', { collection: values.collection, meta: values });
+			await collectionsStore.hydrate();
+		}
+
+		emit('update:modelValue', false);
+	} catch (err) {
+		unexpectedError(err);
+	} finally {
+		saving.value = false;
+	}
+}
 </script>
 
 <style scoped>

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -58,8 +58,8 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed, ref } from 'vue';
+<script setup lang="ts">
+import { computed, ref } from 'vue';
 import CollectionOptions from './collection-options.vue';
 import { Collection } from '@/types/collections';
 import Draggable from 'vuedraggable';
@@ -68,108 +68,85 @@ import { DeepPartial } from '@cairncms/types';
 import { useI18n } from 'vue-i18n';
 import { unexpectedError } from '@/utils/unexpected-error';
 
-export default defineComponent({
-	name: 'CollectionItem',
-	components: { CollectionOptions, Draggable },
-	props: {
-		collection: {
-			type: Object as PropType<Collection>,
-			required: true,
-		},
-		collections: {
-			type: Array as PropType<Collection[]>,
-			required: true,
-		},
-		disableDrag: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['setNestedSort', 'editCollection'],
-	setup(props, { emit }) {
-		const collectionsStore = useCollectionsStore();
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: Collection;
+	collections: Collection[];
+	disableDrag?: boolean;
+}>();
 
-		const nestedCollections = computed(() =>
-			props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
-		);
+const emit = defineEmits(['setNestedSort', 'editCollection']);
 
-		const collapseIcon = computed(() => {
-			switch (props.collection.meta?.collapse) {
-				case 'open':
-					return 'folder_open';
-				case 'closed':
-					return 'folder';
-				case 'locked':
-					return 'folder_lock';
-			}
+const collectionsStore = useCollectionsStore();
+const { t } = useI18n();
 
-			return undefined;
-		});
+const nestedCollections = computed(() =>
+	props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
+);
 
-		const collapseTooltip = computed(() => {
-			switch (props.collection.meta?.collapse) {
-				case 'open':
-					return t('start_open');
-				case 'closed':
-					return t('start_collapsed');
-				case 'locked':
-					return t('always_open');
-			}
+const collapseIcon = computed(() => {
+	switch (props.collection.meta?.collapse) {
+		case 'open':
+			return 'folder_open';
+		case 'closed':
+			return 'folder';
+		case 'locked':
+			return 'folder_lock';
+	}
 
-			return undefined;
-		});
-
-		const collapseLoading = ref(false);
-
-		return {
-			collapseIcon,
-			onGroupSortChange,
-			nestedCollections,
-			update,
-			toggleCollapse,
-			collapseTooltip,
-			collapseLoading,
-		};
-
-		async function toggleCollapse() {
-			if (collapseLoading.value === true) return;
-
-			collapseLoading.value = true;
-
-			let newCollapse: 'open' | 'closed' | 'locked' = 'open';
-
-			if (props.collection.meta?.collapse === 'open') {
-				newCollapse = 'closed';
-			} else if (props.collection.meta?.collapse === 'closed') {
-				newCollapse = 'locked';
-			}
-
-			try {
-				await update({ meta: { collapse: newCollapse } });
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				collapseLoading.value = false;
-			}
-		}
-
-		async function update(updates: DeepPartial<Collection>) {
-			await collectionsStore.updateCollection(props.collection.collection, updates);
-		}
-
-		function onGroupSortChange(collections: Collection[]) {
-			const updates = collections.map((collection) => ({
-				collection: collection.collection,
-				meta: {
-					group: props.collection.collection,
-				},
-			}));
-
-			emit('setNestedSort', updates);
-		}
-	},
+	return undefined;
 });
+
+const collapseTooltip = computed(() => {
+	switch (props.collection.meta?.collapse) {
+		case 'open':
+			return t('start_open');
+		case 'closed':
+			return t('start_collapsed');
+		case 'locked':
+			return t('always_open');
+	}
+
+	return undefined;
+});
+
+const collapseLoading = ref(false);
+
+async function toggleCollapse() {
+	if (collapseLoading.value === true) return;
+
+	collapseLoading.value = true;
+
+	let newCollapse: 'open' | 'closed' | 'locked' = 'open';
+
+	if (props.collection.meta?.collapse === 'open') {
+		newCollapse = 'closed';
+	} else if (props.collection.meta?.collapse === 'closed') {
+		newCollapse = 'locked';
+	}
+
+	try {
+		await update({ meta: { collapse: newCollapse } });
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		collapseLoading.value = false;
+	}
+}
+
+async function update(updates: DeepPartial<Collection>) {
+	await collectionsStore.updateCollection(props.collection.collection, updates);
+}
+
+function onGroupSortChange(collections: Collection[]) {
+	const updates = collections.map((collection) => ({
+		collection: collection.collection,
+		meta: {
+			group: props.collection.collection,
+		},
+	}));
+
+	emit('setNestedSort', updates);
+}
 </script>
 
 <style scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-actions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-actions.vue
@@ -11,21 +11,15 @@
 	</v-button>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-import { useFieldDetailStore } from '../store';
+<script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
+import { useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	emits: ['save'],
-	setup() {
-		const fieldDetailStore = useFieldDetailStore();
-		const { saving, readyToSave } = storeToRefs(fieldDetailStore);
+defineEmits(['save']);
 
-		const { t } = useI18n();
+const fieldDetailStore = useFieldDetailStore();
+const { saving, readyToSave } = storeToRefs(fieldDetailStore);
 
-		return { saving, t, readyToSave };
-	},
-});
+const { t } = useI18n();
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-display.vue
@@ -22,95 +22,89 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { clone } from 'lodash';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
-import { storeToRefs } from 'pinia';
-import ExtensionOptions from '../shared/extension-options.vue';
+<script setup lang="ts">
+import { FancySelectItem } from '@/components/v-fancy-select.vue';
 import { useExtension } from '@/composables/use-extension';
+import { clone } from 'lodash';
+import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ExtensionOptions from '../shared/extension-options.vue';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	components: { ExtensionOptions },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
+const fieldDetailStore = useFieldDetailStore();
 
-		const { loading, field, displaysForType } = storeToRefs(fieldDetailStore);
+const { loading, field, displaysForType } = storeToRefs(fieldDetailStore);
 
-		const interfaceId = computed(() => field.value.meta?.interface ?? null);
-		const display = syncFieldDetailStoreProperty('field.meta.display');
+const interfaceId = computed(() => field.value.meta?.interface ?? null);
+const display = syncFieldDetailStoreProperty('field.meta.display');
 
-		const selectedInterface = useExtension('interface', interfaceId);
-		const selectedDisplay = useExtension('display', display);
+const selectedInterface = useExtension('interface', interfaceId);
+const selectedDisplay = useExtension('display', display);
 
-		const selectItems = computed(() => {
-			let recommended = clone(selectedInterface.value?.recommendedDisplays) || [];
+const selectItems = computed(() => {
+	let recommended = clone(selectedInterface.value?.recommendedDisplays) || [];
 
-			recommended.push('raw', 'formatted-value');
-			recommended = [...new Set(recommended)];
+	recommended.push('raw', 'formatted-value');
+	recommended = [...new Set(recommended)];
 
-			const displayItems: FancySelectItem[] = displaysForType.value.map((display) => {
-				const item: FancySelectItem = {
-					text: display.name,
-					description: display.description,
-					value: display.id,
-					icon: display.icon,
-				};
+	const displayItems: FancySelectItem[] = displaysForType.value.map((display) => {
+		const item: FancySelectItem = {
+			text: display.name,
+			description: display.description,
+			value: display.id,
+			icon: display.icon,
+		};
 
-				if (recommended.includes(item.value as string)) {
-					item.iconRight = 'star';
-				}
+		if (recommended.includes(item.value as string)) {
+			item.iconRight = 'star';
+		}
 
-				return item;
-			});
+		return item;
+	});
 
-			const recommendedItems: (FancySelectItem | { divider: boolean } | undefined)[] = [];
+	const recommendedItems: (FancySelectItem | { divider: boolean } | undefined)[] = [];
 
-			const recommendedList = recommended.map((key: any) => displayItems.find((item) => item.value === key));
+	const recommendedList = recommended.map((key: any) => displayItems.find((item) => item.value === key));
 
-			if (recommendedList !== undefined) {
-				recommendedItems.push(...recommendedList.filter((i: any) => i));
-			}
+	if (recommendedList !== undefined) {
+		recommendedItems.push(...recommendedList.filter((i: any) => i));
+	}
 
-			if (displayItems.length >= 5 && recommended.length > 0) {
-				recommendedItems.push({ divider: true });
-			}
+	if (displayItems.length >= 5 && recommended.length > 0) {
+		recommendedItems.push({ divider: true });
+	}
 
-			const displayList = displayItems.filter((item) => recommended.includes(item.value as string) === false);
+	const displayList = displayItems.filter((item) => recommended.includes(item.value as string) === false);
 
-			if (displayList !== undefined) {
-				recommendedItems.push(...displayList.filter((i) => i));
-			}
+	if (displayList !== undefined) {
+		recommendedItems.push(...displayList.filter((i) => i));
+	}
 
-			return recommendedItems;
+	return recommendedItems;
+});
+
+const customOptionsFields = computed(() => {
+	if (typeof selectedDisplay.value?.options === 'function') {
+		return selectedDisplay.value?.options(fieldDetailStore);
+	}
+
+	return null;
+});
+
+const options = computed({
+	get() {
+		return fieldDetailStore.field.meta?.display_options ?? {};
+	},
+	set(newOptions: Record<string, any>) {
+		fieldDetailStore.$patch((state) => {
+			state.field.meta = {
+				...(state.field.meta ?? {}),
+				display_options: newOptions,
+			};
 		});
-
-		const customOptionsFields = computed(() => {
-			if (typeof selectedDisplay.value?.options === 'function') {
-				return selectedDisplay.value?.options(fieldDetailStore);
-			}
-
-			return null;
-		});
-
-		const options = computed({
-			get() {
-				return fieldDetailStore.field.meta?.display_options ?? {};
-			},
-			set(newOptions: Record<string, any>) {
-				fieldDetailStore.$patch((state) => {
-					state.field.meta = {
-						...(state.field.meta ?? {}),
-						display_options: newOptions,
-					};
-				});
-			},
-		});
-
-		return { t, loading, selectItems, selectedDisplay, display, options, customOptionsFields };
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -71,27 +71,22 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
+<script setup lang="ts">
 import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
-		const fieldDetailStore = useFieldDetailStore();
-		const readonly = syncFieldDetailStoreProperty('field.meta.readonly', false);
-		const hidden = syncFieldDetailStoreProperty('field.meta.hidden', false);
-		const required = syncFieldDetailStoreProperty('field.meta.required', false);
-		const note = syncFieldDetailStoreProperty('field.meta.note');
-		const translations = syncFieldDetailStoreProperty('field.meta.translations');
-		const { loading, field } = storeToRefs(fieldDetailStore);
-		const type = computed(() => field.value.type);
-		const isGenerated = computed(() => field.value.schema?.is_generated);
-		return { t, loading, readonly, hidden, required, note, translations, type, isGenerated };
-	},
-});
+const { t } = useI18n();
+const fieldDetailStore = useFieldDetailStore();
+const readonly = syncFieldDetailStoreProperty('field.meta.readonly', false);
+const hidden = syncFieldDetailStoreProperty('field.meta.hidden', false);
+const required = syncFieldDetailStoreProperty('field.meta.required', false);
+const note = syncFieldDetailStoreProperty('field.meta.note');
+const translations = syncFieldDetailStoreProperty('field.meta.translations');
+const { loading, field } = storeToRefs(fieldDetailStore);
+const type = computed(() => field.value.type);
+const isGenerated = computed(() => field.value.schema?.is_generated);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-interface.vue
@@ -23,107 +23,101 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store/';
-import { storeToRefs } from 'pinia';
-import ExtensionOptions from '../shared/extension-options.vue';
+<script setup lang="ts">
+import { FancySelectItem } from '@/components/v-fancy-select.vue';
 import { useExtension } from '@/composables/use-extension';
+import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ExtensionOptions from '../shared/extension-options.vue';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store/';
 
-export default defineComponent({
-	components: { ExtensionOptions },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
+const fieldDetailStore = useFieldDetailStore();
 
-		const interfaceId = syncFieldDetailStoreProperty('field.meta.interface');
+const interfaceId = syncFieldDetailStoreProperty('field.meta.interface');
 
-		const { loading, field, interfacesForType } = storeToRefs(fieldDetailStore);
-		const type = computed(() => field.value.type);
+const { loading, field, interfacesForType } = storeToRefs(fieldDetailStore);
+const type = computed(() => field.value.type);
 
-		const selectItems = computed(() => {
-			const recommendedInterfacesPerType: { [type: string]: string[] } = {
-				string: ['input', 'select-dropdown'],
-				text: ['input-rich-text-html'],
-				boolean: ['boolean'],
-				integer: ['input'],
-				bigInteger: ['input'],
-				float: ['input'],
-				decimal: ['input'],
-				timestamp: ['datetime'],
-				datetime: ['datetime'],
-				date: ['datetime'],
-				time: ['datetime'],
-				json: ['select-multiple-checkbox', 'tags'],
-				uuid: ['input'],
-				csv: ['tags'],
+const selectItems = computed(() => {
+	const recommendedInterfacesPerType: { [type: string]: string[] } = {
+		string: ['input', 'select-dropdown'],
+		text: ['input-rich-text-html'],
+		boolean: ['boolean'],
+		integer: ['input'],
+		bigInteger: ['input'],
+		float: ['input'],
+		decimal: ['input'],
+		timestamp: ['datetime'],
+		datetime: ['datetime'],
+		date: ['datetime'],
+		time: ['datetime'],
+		json: ['select-multiple-checkbox', 'tags'],
+		uuid: ['input'],
+		csv: ['tags'],
+	};
+
+	const recommended = recommendedInterfacesPerType[type.value ?? 'alias'] || [];
+
+	const interfaceItems: FancySelectItem[] = interfacesForType.value.map((inter) => {
+		const item: FancySelectItem = {
+			text: inter.name,
+			description: inter.description,
+			value: inter.id,
+			icon: inter.icon,
+		};
+
+		if (recommended.includes(item.value as string)) {
+			item.iconRight = 'star';
+		}
+
+		return item;
+	});
+
+	const recommendedItems: (FancySelectItem | { divider: boolean } | undefined)[] = [];
+
+	const recommendedList = recommended.map((key) => interfaceItems.find((item) => item.value === key));
+
+	if (recommendedList !== undefined) {
+		recommendedItems.push(...recommendedList.filter((i) => i));
+	}
+
+	if (interfaceItems.length >= 5 && recommended.length > 0) {
+		recommendedItems.push({ divider: true });
+	}
+
+	const interfaceList = interfaceItems.filter((item) => recommended.includes(item.value as string) === false);
+
+	if (interfaceList !== undefined) {
+		recommendedItems.push(...interfaceList.filter((i) => i));
+	}
+
+	return recommendedItems;
+});
+
+const selectedInterface = useExtension('interface', interfaceId);
+
+const customOptionsFields = computed(() => {
+	if (typeof selectedInterface.value?.options === 'function') {
+		return selectedInterface.value?.options(fieldDetailStore);
+	}
+
+	return null;
+});
+
+const options = computed({
+	get() {
+		return fieldDetailStore.field.meta?.options ?? {};
+	},
+	set(newOptions: Record<string, any>) {
+		fieldDetailStore.$patch((state) => {
+			state.field.meta = {
+				...(state.field.meta ?? {}),
+				options: newOptions,
 			};
-
-			const recommended = recommendedInterfacesPerType[type.value ?? 'alias'] || [];
-
-			const interfaceItems: FancySelectItem[] = interfacesForType.value.map((inter) => {
-				const item: FancySelectItem = {
-					text: inter.name,
-					description: inter.description,
-					value: inter.id,
-					icon: inter.icon,
-				};
-
-				if (recommended.includes(item.value as string)) {
-					item.iconRight = 'star';
-				}
-
-				return item;
-			});
-
-			const recommendedItems: (FancySelectItem | { divider: boolean } | undefined)[] = [];
-
-			const recommendedList = recommended.map((key) => interfaceItems.find((item) => item.value === key));
-
-			if (recommendedList !== undefined) {
-				recommendedItems.push(...recommendedList.filter((i) => i));
-			}
-
-			if (interfaceItems.length >= 5 && recommended.length > 0) {
-				recommendedItems.push({ divider: true });
-			}
-
-			const interfaceList = interfaceItems.filter((item) => recommended.includes(item.value as string) === false);
-
-			if (interfaceList !== undefined) {
-				recommendedItems.push(...interfaceList.filter((i) => i));
-			}
-
-			return recommendedItems;
 		});
-
-		const selectedInterface = useExtension('interface', interfaceId);
-
-		const customOptionsFields = computed(() => {
-			if (typeof selectedInterface.value?.options === 'function') {
-				return selectedInterface.value?.options(fieldDetailStore);
-			}
-
-			return null;
-		});
-
-		const options = computed({
-			get() {
-				return fieldDetailStore.field.meta?.options ?? {};
-			},
-			set(newOptions: Record<string, any>) {
-				fieldDetailStore.$patch((state) => {
-					state.field.meta = {
-						...(state.field.meta ?? {}),
-						options: newOptions,
-					};
-				});
-			},
-		});
-
-		return { t, loading, selectItems, selectedInterface, interfaceId, customOptionsFields, options };
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -153,91 +153,67 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
-import { storeToRefs } from 'pinia';
-import RelatedCollectionSelect from '../shared/related-collection-select.vue';
-import RelatedFieldSelect from '../shared/related-field-select.vue';
-import { useFieldsStore } from '@/stores/fields';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { orderBy } from 'lodash';
+import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import RelatedCollectionSelect from '../shared/related-collection-select.vue';
+import RelatedFieldSelect from '../shared/related-field-select.vue';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect, RelatedFieldSelect },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
-		const collectionsStore = useCollectionsStore();
-		const relationsStore = useRelationsStore();
-		const fieldsStore = useFieldsStore();
+const fieldDetailStore = useFieldDetailStore();
+const collectionsStore = useCollectionsStore();
+const relationsStore = useRelationsStore();
+const fieldsStore = useFieldsStore();
 
-		const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
+const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
 
-		const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
-		const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
-		const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
-		const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
-		const oneCollectionField = syncFieldDetailStoreProperty('relations.m2o.meta.one_collection_field');
-		const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_collections', []);
-		const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
-		const onDelete = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
-		const onDeselect = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
+const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
+const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
+const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
+const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
+const oneCollectionField = syncFieldDetailStoreProperty('relations.m2o.meta.one_collection_field');
+const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_collections', []);
+const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
+const onDelete = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
+const onDeselect = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
 
-		const isExisting = computed(() => editing.value !== '+');
-		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
+const isExisting = computed(() => editing.value !== '+');
+const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
-		const availableCollections = computed(() => {
-			return orderBy(
-				[
-					...collectionsStore.databaseCollections,
-					{
-						divider: true,
-					},
-					{
-						name: t('system'),
-						selectable: false,
-						children: collectionsStore.crudSafeSystemCollections,
-					},
-				],
-				['collection'],
-				['asc']
-			);
-		});
+const availableCollections = computed(() => {
+	return orderBy(
+		[
+			...collectionsStore.databaseCollections,
+			{
+				divider: true,
+			},
+			{
+				name: t('system'),
+				selectable: false,
+				children: collectionsStore.crudSafeSystemCollections,
+			},
+		],
+		['collection'],
+		['asc']
+	);
+});
 
-		const unsortableJunctionFields = computed(() => {
-			let fields = ['item', 'collection'];
+const unsortableJunctionFields = computed(() => {
+	let fields = ['item', 'collection'];
 
-			if (junctionCollection.value) {
-				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
-				fields.push(...relations.map((field) => field.field));
-			}
+	if (junctionCollection.value) {
+		const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
+		fields.push(...relations.map((field) => field.field));
+	}
 
-			return fields;
-		});
-
-		return {
-			t,
-			availableCollections,
-			generationInfo,
-			collection,
-			isExisting,
-			autoGenerateJunctionRelation,
-			junctionCollection,
-			oneAllowedCollections,
-			currentPrimaryKey,
-			junctionFieldCurrent,
-			junctionFieldRelated,
-			oneCollectionField,
-			sortField,
-			onDelete,
-			onDeselect,
-			unsortableJunctionFields,
-		};
-	},
+	return fields;
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2m.vue
@@ -198,110 +198,82 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
-import { storeToRefs } from 'pinia';
-import RelatedCollectionSelect from '../shared/related-collection-select.vue';
-import RelatedFieldSelect from '../shared/related-field-select.vue';
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
+import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import RelatedCollectionSelect from '../shared/related-collection-select.vue';
+import RelatedFieldSelect from '../shared/related-field-select.vue';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect, RelatedFieldSelect },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
-		const relationsStore = useRelationsStore();
-		const fieldsStore = useFieldsStore();
+const fieldDetailStore = useFieldDetailStore();
+const relationsStore = useRelationsStore();
+const fieldsStore = useFieldsStore();
 
-		const { collection, editing, generationInfo, localType } = storeToRefs(fieldDetailStore);
+const { collection, editing, generationInfo, localType } = storeToRefs(fieldDetailStore);
 
-		const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
-		const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
-		const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
-		const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
-		const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
-		const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
-		const onDeleteCurrent = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
-		const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
-		const deselectAction = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
-		const correspondingField = syncFieldDetailStoreProperty('fields.corresponding');
-		const correspondingFieldKey = syncFieldDetailStoreProperty('fields.corresponding.field');
+const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
+const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
+const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
+const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
+const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
+const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
+const onDeleteCurrent = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
+const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
+const deselectAction = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
+const correspondingField = syncFieldDetailStoreProperty('fields.corresponding');
+const correspondingFieldKey = syncFieldDetailStoreProperty('fields.corresponding.field');
 
-		const isExisting = computed(() => editing.value !== '+');
+const isExisting = computed(() => editing.value !== '+');
 
-		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
+const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
-		const relatedPrimaryKey = computed(
-			() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
-		);
+const relatedPrimaryKey = computed(
+	() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
+);
 
-		const hasCorresponding = computed({
-			get() {
-				return !!correspondingField.value;
-			},
-			set(enabled: boolean) {
-				if (enabled) {
-					correspondingField.value = {
-						field: collection.value,
-						collection: relatedCollection.value,
-						type: 'alias',
-						meta: {
-							special: ['m2m'],
-							interface: 'list-m2m',
-						},
-					};
-				} else {
-					correspondingField.value = null;
-				}
-			},
-		});
-
-		const correspondingLabel = computed(() => {
-			if (junctionCollection.value) {
-				return t('add_m2m_to_collection', { collection: relatedCollection.value });
-			}
-
-			return t('add_field_related');
-		});
-
-		const unsortableJunctionFields = computed(() => {
-			let fields = [];
-
-			if (junctionCollection.value) {
-				const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
-				fields.push(...relations.map((field) => field.field));
-			}
-
-			return fields;
-		});
-
-		return {
-			t,
-			autoGenerateJunctionRelation,
-			collection,
-			localType,
-			isExisting,
-			junctionCollection,
-			junctionFieldCurrent,
-			relatedCollection,
-			sortField,
-			currentPrimaryKey,
-			junctionFieldRelated,
-			relatedPrimaryKey,
-			onDeleteCurrent,
-			onDeleteRelated,
-			deselectAction,
-			hasCorresponding,
-			correspondingLabel,
-			correspondingFieldKey,
-			generationInfo,
-			unsortableJunctionFields,
-		};
+const hasCorresponding = computed({
+	get() {
+		return !!correspondingField.value;
 	},
+	set(enabled: boolean) {
+		if (enabled) {
+			correspondingField.value = {
+				field: collection.value,
+				collection: relatedCollection.value,
+				type: 'alias',
+				meta: {
+					special: ['m2m'],
+					interface: 'list-m2m',
+				},
+			};
+		} else {
+			correspondingField.value = null;
+		}
+	},
+});
+
+const correspondingLabel = computed(() => {
+	if (junctionCollection.value) {
+		return t('add_m2m_to_collection', { collection: relatedCollection.value });
+	}
+
+	return t('add_field_related');
+});
+
+const unsortableJunctionFields = computed(() => {
+	let fields = [];
+
+	if (junctionCollection.value) {
+		const relations = relationsStore.getRelationsForCollection(junctionCollection.value);
+		fields.push(...relations.map((field) => field.field));
+	}
+
+	return fields;
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2o.vue
@@ -70,106 +70,86 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
+import { computed } from 'vue';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import { useFieldsStore } from '@/stores/fields';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
-		const fieldsStore = useFieldsStore();
+const fieldDetailStore = useFieldDetailStore();
+const fieldsStore = useFieldsStore();
 
-		const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
-		const correspondingField = syncFieldDetailStoreProperty('fields.corresponding');
-		const correspondingFieldKey = syncFieldDetailStoreProperty('fields.corresponding.field');
-		const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
+const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
+const correspondingField = syncFieldDetailStoreProperty('fields.corresponding');
+const correspondingFieldKey = syncFieldDetailStoreProperty('fields.corresponding.field');
+const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
 
-		const { field, collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
+const { field, collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
 
-		const isExisting = computed(() => editing.value !== '+');
+const isExisting = computed(() => editing.value !== '+');
 
-		const relatedPrimaryKey = computed(
-			() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
-		);
+const relatedPrimaryKey = computed(
+	() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
+);
 
-		const currentField = computed(() => field.value.field);
+const currentField = computed(() => field.value.field);
 
-		const hasCorresponding = computed({
-			get() {
-				return !!correspondingField.value;
-			},
-			set(enabled: boolean) {
-				if (enabled) {
-					correspondingField.value = {
-						field: collection.value,
-						collection: relatedCollection.value,
-						type: 'alias',
-						meta: {
-							special: ['o2m'],
-							interface: 'list-o2m',
-						},
-					};
-				} else {
-					correspondingField.value = null;
-				}
-			},
-		});
-
-		const correspondingLabel = computed(() => {
-			if (relatedCollection.value) {
-				return t('add_o2m_to_collection', { collection: relatedCollection.value });
-			}
-
-			return t('add_field_related');
-		});
-
-		const onDeleteOptions = computed(() =>
-			[
-				{
-					text: t('referential_action_set_null', { field: currentField.value }),
-					value: 'SET NULL',
+const hasCorresponding = computed({
+	get() {
+		return !!correspondingField.value;
+	},
+	set(enabled: boolean) {
+		if (enabled) {
+			correspondingField.value = {
+				field: collection.value,
+				collection: relatedCollection.value,
+				type: 'alias',
+				meta: {
+					special: ['o2m'],
+					interface: 'list-o2m',
 				},
-				{
-					text: t('referential_action_set_default', { field: currentField.value }),
-					value: 'SET DEFAULT',
-				},
-				{
-					text: t('referential_action_cascade', {
-						collection: collection.value,
-						field: currentField.value,
-					}),
-					value: 'CASCADE',
-				},
-				{
-					text: t('referential_action_no_action', { field: currentField.value }),
-					value: 'NO ACTION',
-				},
-			].filter((o) => !(o.value === 'SET NULL' && field.value.schema?.is_nullable === false))
-		);
-
-		return {
-			t,
-			collection,
-			relatedCollection,
-			isExisting,
-			relatedPrimaryKey,
-			currentField,
-			hasCorresponding,
-			correspondingLabel,
-			correspondingFieldKey,
-			generationInfo,
-			onDeleteRelated,
-			onDeleteOptions,
-		};
+			};
+		} else {
+			correspondingField.value = null;
+		}
 	},
 });
+
+const correspondingLabel = computed(() => {
+	if (relatedCollection.value) {
+		return t('add_o2m_to_collection', { collection: relatedCollection.value });
+	}
+
+	return t('add_field_related');
+});
+
+const onDeleteOptions = computed(() =>
+	[
+		{
+			text: t('referential_action_set_null', { field: currentField.value }),
+			value: 'SET NULL',
+		},
+		{
+			text: t('referential_action_set_default', { field: currentField.value }),
+			value: 'SET DEFAULT',
+		},
+		{
+			text: t('referential_action_cascade', {
+				collection: collection.value,
+				field: currentField.value,
+			}),
+			value: 'CASCADE',
+		},
+		{
+			text: t('referential_action_no_action', { field: currentField.value }),
+			value: 'NO ACTION',
+		},
+	].filter((o) => !(o.value === 'SET NULL' && field.value.schema?.is_nullable === false))
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-o2m.vue
@@ -112,9 +112,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
+import { computed } from 'vue';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
@@ -122,51 +122,32 @@ import RelatedFieldSelect from '../shared/related-field-select.vue';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect, RelatedFieldSelect },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
-		const relationsStore = useRelationsStore();
-		const fieldsStore = useFieldsStore();
+const fieldDetailStore = useFieldDetailStore();
+const relationsStore = useRelationsStore();
+const fieldsStore = useFieldsStore();
 
-		const relatedCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
-		const relatedField = syncFieldDetailStoreProperty('relations.o2m.field');
-		const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
-		const onDelete = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
-		const onDeselect = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
+const relatedCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
+const relatedField = syncFieldDetailStoreProperty('relations.o2m.field');
+const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
+const onDelete = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
+const onDeselect = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
 
-		const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
+const { collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
 
-		const isExisting = computed(() => editing.value !== '+');
-		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
+const isExisting = computed(() => editing.value !== '+');
+const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
-		const unsortableJunctionFields = computed(() => {
-			let fields = [];
+const unsortableJunctionFields = computed(() => {
+	let fields = [];
 
-			if (relatedCollection.value) {
-				const relations = relationsStore.getRelationsForCollection(relatedCollection.value);
-				fields.push(...relations.map((field) => field.field));
-			}
+	if (relatedCollection.value) {
+		const relations = relationsStore.getRelationsForCollection(relatedCollection.value);
+		fields.push(...relations.map((field) => field.field));
+	}
 
-			return fields;
-		});
-
-		return {
-			t,
-			isExisting,
-			collection,
-			relatedCollection,
-			currentPrimaryKey,
-			relatedField,
-			generationInfo,
-			sortField,
-			onDelete,
-			onDeselect,
-			unsortableJunctionFields,
-		};
-	},
+	return fields;
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-translations.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-translations.vue
@@ -145,110 +145,39 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
+import { computed } from 'vue';
 import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import RelatedFieldSelect from '../shared/related-field-select.vue';
 import { useFieldsStore } from '@/stores/fields';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect, RelatedFieldSelect },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const fieldDetailStore = useFieldDetailStore();
-		const fieldsStore = useFieldsStore();
+const fieldDetailStore = useFieldDetailStore();
+const fieldsStore = useFieldsStore();
 
-		const { field, collection, editing, generationInfo } = storeToRefs(fieldDetailStore);
+const { field, collection, editing } = storeToRefs(fieldDetailStore);
 
-		const sortField = syncFieldDetailStoreProperty('relations.o2m.meta.sort_field');
-		const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
-		const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
-		const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
-		const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
-		const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
-		const onDeleteCurrent = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
-		const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
-		const deselectAction = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
-		const correspondingField = syncFieldDetailStoreProperty('fields.corresponding');
+const junctionCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
+const junctionFieldCurrent = syncFieldDetailStoreProperty('relations.o2m.field');
+const junctionFieldRelated = syncFieldDetailStoreProperty('relations.m2o.field');
+const relatedCollection = syncFieldDetailStoreProperty('relations.m2o.related_collection');
+const autoGenerateJunctionRelation = syncFieldDetailStoreProperty('autoGenerateJunctionRelation');
+const onDeleteCurrent = syncFieldDetailStoreProperty('relations.o2m.schema.on_delete');
+const onDeleteRelated = syncFieldDetailStoreProperty('relations.m2o.schema.on_delete');
+const deselectAction = syncFieldDetailStoreProperty('relations.o2m.meta.one_deselect_action');
 
-		const type = computed(() => field.value.type);
-		const isExisting = computed(() => editing.value !== '+');
+const type = computed(() => field.value.type);
+const isExisting = computed(() => editing.value !== '+');
 
-		const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
+const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollection(collection.value!)?.field);
 
-		const relatedPrimaryKey = computed(
-			() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
-		);
-
-		const hasCorresponding = computed({
-			get() {
-				return !!correspondingField.value;
-			},
-			set(enabled: boolean) {
-				if (enabled) {
-					correspondingField.value = {
-						field: collection.value,
-						collection: relatedCollection.value,
-						type: 'alias',
-						meta: {
-							special: ['m2m'],
-							interface: 'list-m2m',
-						},
-					};
-				} else {
-					correspondingField.value = null;
-				}
-			},
-		});
-
-		const correspondingLabel = computed(() => {
-			if (junctionCollection.value) {
-				return t('add_m2m_to_collection', { collection: relatedCollection.value });
-			}
-
-			return t('add_field_related');
-		});
-
-		const correspondingFieldKey = computed({
-			get() {
-				return correspondingField.value?.field;
-			},
-			set(key: string | undefined) {
-				if (!hasCorresponding.value) {
-					hasCorresponding.value = true;
-				}
-
-				correspondingField.value!.field = key;
-			},
-		});
-
-		return {
-			t,
-			autoGenerateJunctionRelation,
-			collection,
-			type,
-			isExisting,
-			junctionCollection,
-			junctionFieldCurrent,
-			relatedCollection,
-			sortField,
-			currentPrimaryKey,
-			junctionFieldRelated,
-			relatedPrimaryKey,
-			onDeleteCurrent,
-			onDeleteRelated,
-			deselectAction,
-			hasCorresponding,
-			correspondingLabel,
-			correspondingFieldKey,
-			generationInfo,
-		};
-	},
-});
+const relatedPrimaryKey = computed(
+	() => fieldsStore.getPrimaryKeyFieldForCollection(relatedCollection.value)?.field ?? 'id'
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship.vue
@@ -6,32 +6,16 @@
 	<relationship-translations v-else-if="localType === 'translations'" />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-import RelationshipM2o from './field-detail-advanced-relationship-m2o.vue';
-import RelationshipO2m from './field-detail-advanced-relationship-o2m.vue';
-import RelationshipM2m from './field-detail-advanced-relationship-m2m.vue';
-import RelationshipM2a from './field-detail-advanced-relationship-m2a.vue';
-import RelationshipTranslations from './field-detail-advanced-relationship-translations.vue';
-
+<script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useFieldDetailStore } from '../store';
+import RelationshipM2a from './field-detail-advanced-relationship-m2a.vue';
+import RelationshipM2m from './field-detail-advanced-relationship-m2m.vue';
+import RelationshipM2o from './field-detail-advanced-relationship-m2o.vue';
+import RelationshipO2m from './field-detail-advanced-relationship-o2m.vue';
+import RelationshipTranslations from './field-detail-advanced-relationship-translations.vue';
 
-export default defineComponent({
-	components: {
-		RelationshipM2o,
-		RelationshipO2m,
-		RelationshipM2m,
-		RelationshipM2a,
-		RelationshipTranslations,
-	},
-	setup() {
-		const fieldDetailStore = useFieldDetailStore();
+const fieldDetailStore = useFieldDetailStore();
 
-		const { collection, localType } = storeToRefs(fieldDetailStore);
-
-		return { collection, localType };
-	},
-});
+const { localType } = storeToRefs(fieldDetailStore);
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-schema.vue
@@ -132,18 +132,17 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { GEOMETRY_TYPES } from '@cairncms/constants';
+<script setup lang="ts">
 import { translate } from '@/utils/translate-object-values';
 import { Type } from '@cairncms/types';
-import { TranslateResult } from 'vue-i18n';
-import { useFieldDetailStore, syncFieldDetailStoreProperty } from '../store';
 import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { TranslateResult, useI18n } from 'vue-i18n';
+import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
 
 type FieldTypeOption = { value: Type; text: TranslateResult | string; children?: FieldTypeOption[] };
-export const fieldTypes: Array<FieldTypeOption | { divider: true }> = [
+
+const fieldTypes: Array<FieldTypeOption | { divider: true }> = [
 	{
 		text: '$t:string',
 		value: 'string',
@@ -239,250 +238,216 @@ export const fieldTypes: Array<FieldTypeOption | { divider: true }> = [
 	},
 ];
 
-export default defineComponent({
-	setup() {
-		const fieldDetailStore = useFieldDetailStore();
+const fieldDetailStore = useFieldDetailStore();
 
-		const { localType, relations, editing } = storeToRefs(fieldDetailStore);
+const { localType, relations, editing } = storeToRefs(fieldDetailStore);
 
-		const isExisting = computed(() => editing.value !== '+');
+const isExisting = computed(() => editing.value !== '+');
 
-		const type = syncFieldDetailStoreProperty('field.type');
-		const defaultValue = syncFieldDetailStoreProperty('field.schema.default_value');
-		const field = syncFieldDetailStoreProperty('field.field');
-		const special = syncFieldDetailStoreProperty('field.meta.special');
-		const maxLength = syncFieldDetailStoreProperty('field.schema.max_length');
-		const numericPrecision = syncFieldDetailStoreProperty('field.schema.numeric_precision');
-		const nullable = syncFieldDetailStoreProperty('field.schema.is_nullable', true);
-		const unique = syncFieldDetailStoreProperty('field.schema.is_unique', false);
-		const numericScale = syncFieldDetailStoreProperty('field.schema.numeric_scale');
+const type = syncFieldDetailStoreProperty('field.type');
+const defaultValue = syncFieldDetailStoreProperty('field.schema.default_value');
+const field = syncFieldDetailStoreProperty('field.field');
+const special = syncFieldDetailStoreProperty('field.meta.special');
+const maxLength = syncFieldDetailStoreProperty('field.schema.max_length');
+const numericPrecision = syncFieldDetailStoreProperty('field.schema.numeric_precision');
+const nullable = syncFieldDetailStoreProperty('field.schema.is_nullable', true);
+const unique = syncFieldDetailStoreProperty('field.schema.is_unique', false);
+const numericScale = syncFieldDetailStoreProperty('field.schema.numeric_scale');
 
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const typesWithLabels = computed(() => translate(fieldTypes));
+const typesWithLabels = computed(() => translate(fieldTypes));
 
-		const typeDisabled = computed(() => localType.value !== 'standard');
+const typeDisabled = computed(() => localType.value !== 'standard');
 
-		const typePlaceholder = computed(() => {
-			if (localType.value === 'm2o') {
-				return t('determined_by_relationship');
+const typePlaceholder = computed(() => {
+	if (localType.value === 'm2o') {
+		return t('determined_by_relationship');
+	}
+
+	return t('choose_a_type');
+});
+
+const { onCreateOptions, onCreateValue } = useOnCreate();
+const { onUpdateOptions, onUpdateValue } = useOnUpdate();
+
+const hasCreateUpdateTriggers = computed(() => {
+	return ['uuid', 'date', 'time', 'dateTime', 'timestamp'].includes(type.value) && localType.value !== 'file';
+});
+
+const isAlias = computed(() => {
+	return !fieldDetailStore.field.schema;
+});
+
+const isPrimaryKey = computed(() => {
+	return fieldDetailStore.field.schema?.is_primary_key === true;
+});
+
+const isGenerated = computed(() => {
+	return fieldDetailStore.field.schema?.is_generated;
+});
+
+function useOnCreate() {
+	const onCreateSpecials = ['uuid', 'user-created', 'role-created', 'date-created'];
+
+	const onCreateOptions = computed(() => {
+		if (type.value === 'uuid') {
+			const options = [
+				{
+					text: t('do_nothing'),
+					value: null,
+				},
+				{
+					text: t('generate_and_save_uuid'),
+					value: 'uuid',
+				},
+				{
+					text: t('save_current_user_id'),
+					value: 'user-created',
+				},
+				{
+					text: t('save_current_user_role'),
+					value: 'role-created',
+				},
+			];
+
+			if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_users') {
+				return options.filter(({ value }) => [null, 'user-created'].includes(value));
 			}
 
-			return t('choose_a_type');
-		});
+			if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_roles') {
+				return options.filter(({ value }) => [null, 'role-created'].includes(value));
+			}
 
-		const { onCreateOptions, onCreateValue } = useOnCreate();
-		const { onUpdateOptions, onUpdateValue } = useOnUpdate();
-
-		const hasCreateUpdateTriggers = computed(() => {
-			return ['uuid', 'date', 'time', 'dateTime', 'timestamp'].includes(type.value) && localType.value !== 'file';
-		});
-
-		const isAlias = computed(() => {
-			return !fieldDetailStore.field.schema;
-		});
-
-		const isPrimaryKey = computed(() => {
-			return fieldDetailStore.field.schema?.is_primary_key === true;
-		});
-
-		const isGenerated = computed(() => {
-			return fieldDetailStore.field.schema?.is_generated;
-		});
-
-		return {
-			t,
-			typesWithLabels,
-			GEOMETRY_TYPES,
-			typeDisabled,
-			typePlaceholder,
-			defaultValue,
-			onCreateOptions,
-			onCreateValue,
-			onUpdateOptions,
-			onUpdateValue,
-			hasCreateUpdateTriggers,
-			field,
-			isAlias,
-			type,
-			maxLength,
-			numericPrecision,
-			numericScale,
-			special,
-			nullable,
-			unique,
-			isPrimaryKey,
-			isExisting,
-			isGenerated,
-		};
-
-		function useOnCreate() {
-			const onCreateSpecials = ['uuid', 'user-created', 'role-created', 'date-created'];
-
-			const onCreateOptions = computed(() => {
-				if (type.value === 'uuid') {
-					const options = [
-						{
-							text: t('do_nothing'),
-							value: null,
-						},
-						{
-							text: t('generate_and_save_uuid'),
-							value: 'uuid',
-						},
-						{
-							text: t('save_current_user_id'),
-							value: 'user-created',
-						},
-						{
-							text: t('save_current_user_role'),
-							value: 'role-created',
-						},
-					];
-
-					if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_users') {
-						return options.filter(({ value }) => [null, 'user-created'].includes(value));
-					}
-
-					if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_roles') {
-						return options.filter(({ value }) => [null, 'role-created'].includes(value));
-					}
-
-					return options;
-				} else if (['date', 'time', 'dateTime', 'timestamp'].includes(type.value!)) {
-					return [
-						{
-							text: t('do_nothing'),
-							value: null,
-						},
-						{
-							text: t('save_current_datetime'),
-							value: 'date-created',
-						},
-					];
-				}
-
-				return [];
-			});
-
-			const onCreateValue = computed({
-				get() {
-					const specials = special.value ?? [];
-
-					for (const special of onCreateSpecials) {
-						if (specials.includes(special)) {
-							return special;
-						}
-					}
-
-					return null;
+			return options;
+		} else if (['date', 'time', 'dateTime', 'timestamp'].includes(type.value!)) {
+			return [
+				{
+					text: t('do_nothing'),
+					value: null,
 				},
-				set(newOption: string | null) {
-					// In case of previously persisted empty string
-					if (typeof special.value === 'string') {
-						special.value = [];
-					}
-
-					special.value = (special.value ?? []).filter(
-						(special: string) => onCreateSpecials.includes(special) === false
-					);
-
-					if (newOption) {
-						special.value = [...(special.value ?? []), newOption];
-					}
-
-					// Prevent empty array saved as empty string
-					if (special.value && special.value.length === 0) {
-						special.value = null;
-					}
+				{
+					text: t('save_current_datetime'),
+					value: 'date-created',
 				},
-			});
-
-			return { onCreateSpecials, onCreateOptions, onCreateValue };
+			];
 		}
 
-		function useOnUpdate() {
-			const onUpdateSpecials = ['user-updated', 'role-updated', 'date-updated'];
+		return [];
+	});
 
-			const onUpdateOptions = computed(() => {
-				if (type.value === 'uuid') {
-					const options = [
-						{
-							text: t('do_nothing'),
-							value: null,
-						},
-						{
-							text: t('save_current_user_id'),
-							value: 'user-updated',
-						},
-						{
-							text: t('save_current_user_role'),
-							value: 'role-updated',
-						},
-					];
+	const onCreateValue = computed({
+		get() {
+			const specials = special.value ?? [];
 
-					if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_users') {
-						return options.filter(({ value }) => [null, 'user-updated'].includes(value));
-					}
-
-					if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_roles') {
-						return options.filter(({ value }) => [null, 'role-updated'].includes(value));
-					}
-
-					return options;
-				} else if (['date', 'time', 'dateTime', 'timestamp'].includes(type.value!)) {
-					return [
-						{
-							text: t('do_nothing'),
-							value: null,
-						},
-						{
-							text: t('save_current_datetime'),
-							value: 'date-updated',
-						},
-					];
+			for (const special of onCreateSpecials) {
+				if (specials.includes(special)) {
+					return special;
 				}
+			}
 
-				return [];
-			});
+			return null;
+		},
+		set(newOption: string | null) {
+			// In case of previously persisted empty string
+			if (typeof special.value === 'string') {
+				special.value = [];
+			}
 
-			const onUpdateValue = computed({
-				get() {
-					const specials = special.value ?? [];
+			special.value = (special.value ?? []).filter((special: string) => onCreateSpecials.includes(special) === false);
 
-					for (const special of onUpdateSpecials) {
-						if (specials.includes(special)) {
-							return special;
-						}
-					}
+			if (newOption) {
+				special.value = [...(special.value ?? []), newOption];
+			}
 
-					return null;
+			// Prevent empty array saved as empty string
+			if (special.value && special.value.length === 0) {
+				special.value = null;
+			}
+		},
+	});
+
+	return { onCreateSpecials, onCreateOptions, onCreateValue };
+}
+
+function useOnUpdate() {
+	const onUpdateSpecials = ['user-updated', 'role-updated', 'date-updated'];
+
+	const onUpdateOptions = computed(() => {
+		if (type.value === 'uuid') {
+			const options = [
+				{
+					text: t('do_nothing'),
+					value: null,
 				},
-				set(newOption: string | null) {
-					// In case of previously persisted empty string
-					if (typeof special.value === 'string') {
-						special.value = [];
-					}
-
-					special.value = (special.value ?? []).filter(
-						(special: string) => onUpdateSpecials.includes(special) === false
-					);
-
-					if (newOption) {
-						special.value = [...(special.value ?? []), newOption];
-					}
-
-					// Prevent empty array saved as empty string
-					if (special.value && special.value.length === 0) {
-						special.value = null;
-					}
+				{
+					text: t('save_current_user_id'),
+					value: 'user-updated',
 				},
-			});
+				{
+					text: t('save_current_user_role'),
+					value: 'role-updated',
+				},
+			];
 
-			return { onUpdateSpecials, onUpdateOptions, onUpdateValue };
+			if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_users') {
+				return options.filter(({ value }) => [null, 'user-updated'].includes(value));
+			}
+
+			if (localType.value === 'm2o' && relations.value.m2o?.related_collection === 'directus_roles') {
+				return options.filter(({ value }) => [null, 'role-updated'].includes(value));
+			}
+
+			return options;
+		} else if (['date', 'time', 'dateTime', 'timestamp'].includes(type.value!)) {
+			return [
+				{
+					text: t('do_nothing'),
+					value: null,
+				},
+				{
+					text: t('save_current_datetime'),
+					value: 'date-updated',
+				},
+			];
 		}
-	},
-});
+
+		return [];
+	});
+
+	const onUpdateValue = computed({
+		get() {
+			const specials = special.value ?? [];
+
+			for (const special of onUpdateSpecials) {
+				if (specials.includes(special)) {
+					return special;
+				}
+			}
+
+			return null;
+		},
+		set(newOption: string | null) {
+			// In case of previously persisted empty string
+			if (typeof special.value === 'string') {
+				special.value = [];
+			}
+
+			special.value = (special.value ?? []).filter((special: string) => onUpdateSpecials.includes(special) === false);
+
+			if (newOption) {
+				special.value = [...(special.value ?? []), newOption];
+			}
+
+			// Prevent empty array saved as empty string
+			if (special.value && special.value.length === 0) {
+				special.value = null;
+			}
+		},
+	});
+
+	return { onUpdateSpecials, onUpdateOptions, onUpdateValue };
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-tabs.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-tabs.vue
@@ -6,87 +6,80 @@
 	</v-tabs>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
-import { useFieldDetailStore } from '../store';
 import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useFieldDetailStore } from '../store';
 
-export default defineComponent({
-	props: {
-		currentTab: {
-			type: Array as PropType<string[]>,
-			required: true,
+const props = defineProps<{
+	currentTab: string[];
+}>();
+
+const emit = defineEmits(['update:currentTab']);
+
+const fieldDetail = useFieldDetailStore();
+
+const { localType } = storeToRefs(fieldDetail);
+
+const currentTabSync = useSync(props, 'currentTab', emit);
+
+const { t } = useI18n();
+
+const tabs = computed(() => {
+	const tabs = [
+		{
+			text: t('schema'),
+			value: 'schema',
 		},
-	},
-	emits: ['update:currentTab'],
-	setup(props, { emit }) {
-		const fieldDetail = useFieldDetailStore();
+		{
+			text: t('field', 1),
+			value: 'field',
+		},
+		{
+			text: t('interface_label'),
+			value: 'interface',
+		},
+	];
 
-		const { localType } = storeToRefs(fieldDetail);
-
-		const currentTabSync = useSync(props, 'currentTab', emit);
-
-		const { t } = useI18n();
-
-		const tabs = computed(() => {
-			const tabs = [
-				{
-					text: t('schema'),
-					value: 'schema',
-				},
-				{
-					text: t('field', 1),
-					value: 'field',
-				},
-				{
-					text: t('interface_label'),
-					value: 'interface',
-				},
-			];
-
-			if (localType.value !== 'presentation' && localType.value !== 'group') {
-				tabs.push({
-					text: t('display'),
-					value: 'display',
-				});
-			}
-
-			if (['o2m', 'm2o', 'm2m', 'm2a', 'files', 'file'].includes(localType.value)) {
-				tabs.splice(1, 0, {
-					text: t('relationship'),
-					value: 'relationship',
-				});
-			}
-
-			if (localType.value === 'translations') {
-				tabs.splice(
-					1,
-					0,
-					...[
-						{
-							text: t('translations'),
-							value: 'relationship',
-						},
-					]
-				);
-			}
-
-			tabs.push({
-				text: t('validation'),
-				value: 'validation',
-			});
-
-			tabs.push({
-				text: t('conditions'),
-				value: 'conditions',
-			});
-
-			return tabs;
+	if (localType.value !== 'presentation' && localType.value !== 'group') {
+		tabs.push({
+			text: t('display'),
+			value: 'display',
 		});
+	}
 
-		return { tabs, currentTabSync };
-	},
+	if (['o2m', 'm2o', 'm2m', 'm2a', 'files', 'file'].includes(localType.value)) {
+		tabs.splice(1, 0, {
+			text: t('relationship'),
+			value: 'relationship',
+		});
+	}
+
+	if (localType.value === 'translations') {
+		tabs.splice(
+			1,
+			0,
+			...[
+				{
+					text: t('translations'),
+					value: 'relationship',
+				},
+			]
+		);
+	}
+
+	tabs.push({
+		text: t('validation'),
+		value: 'validation',
+	});
+
+	tabs.push({
+		text: t('conditions'),
+		value: 'conditions',
+	});
+
+	return tabs;
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced.vue
@@ -19,11 +19,9 @@ import FieldDetailAdvancedDisplay from './field-detail-advanced-display.vue';
 import FieldDetailAdvancedValidation from './field-detail-advanced-validation.vue';
 import FieldDetailAdvancedConditions from './field-detail-advanced-conditions.vue';
 
-interface Props {
+defineProps<{
 	currentTab: string;
-}
-
-defineProps<Props>();
+}>();
 </script>
 
 <style scoped>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -67,53 +67,44 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+<script setup lang="ts">
+import { useCollectionsStore } from '@/stores/collections';
 import { LOCAL_TYPES } from '@cairncms/constants';
-import { syncFieldDetailStoreProperty } from '../store';
+import { orderBy } from 'lodash';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RelatedCollectionSelect from '../shared/related-collection-select.vue';
 import RelatedFieldSelect from '../shared/related-field-select.vue';
-import { orderBy } from 'lodash';
-import { useCollectionsStore } from '@/stores/collections';
+import { syncFieldDetailStoreProperty } from '../store';
 
-export default defineComponent({
-	components: { RelatedCollectionSelect, RelatedFieldSelect },
-	props: {
-		localType: {
-			type: String as PropType<(typeof LOCAL_TYPES)[number]>,
-			required: true,
-		},
-	},
-	setup() {
-		const collectionsStore = useCollectionsStore();
+defineProps<{
+	localType: (typeof LOCAL_TYPES)[number];
+}>();
 
-		const { t } = useI18n();
-		const relatedCollectionM2O = syncFieldDetailStoreProperty('relations.m2o.related_collection');
-		const o2mCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
-		const o2mField = syncFieldDetailStoreProperty('relations.o2m.field');
-		const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_collections', []);
+const collectionsStore = useCollectionsStore();
 
-		const availableCollections = computed(() => {
-			return orderBy(
-				[
-					...collectionsStore.databaseCollections,
-					{
-						divider: true,
-					},
-					{
-						name: t('system'),
-						selectable: false,
-						children: collectionsStore.crudSafeSystemCollections,
-					},
-				],
-				['collection'],
-				['asc']
-			);
-		});
+const { t } = useI18n();
+const relatedCollectionM2O = syncFieldDetailStoreProperty('relations.m2o.related_collection');
+const o2mCollection = syncFieldDetailStoreProperty('relations.o2m.collection');
+const o2mField = syncFieldDetailStoreProperty('relations.o2m.field');
+const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.one_allowed_collections', []);
 
-		return { availableCollections, oneAllowedCollections, relatedCollectionM2O, o2mCollection, o2mField, t };
-	},
+const availableCollections = computed(() => {
+	return orderBy(
+		[
+			...collectionsStore.databaseCollections,
+			{
+				divider: true,
+			},
+			{
+				name: t('system'),
+				selectable: false,
+				children: collectionsStore.crudSafeSystemCollections,
+			},
+		],
+		['collection'],
+		['asc']
+	);
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/extension-options.vue
@@ -28,103 +28,75 @@
 	</v-error-boundary>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, computed, toRefs } from 'vue';
+<script setup lang="ts">
+import { useExtension } from '@/composables/use-extension';
+import { storeToRefs } from 'pinia';
+import { computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useFieldDetailStore } from '../store';
-import { storeToRefs } from 'pinia';
-import { useExtension } from '@/composables/use-extension';
 
-export default defineComponent({
-	props: {
-		type: {
-			type: String as PropType<'interface' | 'display' | 'panel' | 'operation'>,
-			required: true,
-		},
-		extension: {
-			type: String,
-			default: null,
-		},
-		showAdvanced: {
-			type: Boolean,
-			default: false,
-		},
-		options: {
-			type: Object,
-			default: null,
-		},
-		modelValue: {
-			type: Object,
-			default: () => ({}),
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		rawEditorEnabled: {
-			type: Boolean,
-			default: false,
-		},
+const props = withDefaults(
+	defineProps<{
+		type: 'interface' | 'display' | 'panel' | 'operation';
+		extension?: string;
+		showAdvanced?: boolean;
+		options?: Record<string, any>;
+		modelValue?: Record<string, any>;
+		disabled?: boolean;
+		rawEditorEnabled?: boolean;
+	}>(),
+	{
+		modelValue: () => ({}),
+	}
+);
+
+const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
+
+const fieldDetailStore = useFieldDetailStore();
+
+const { collection, field } = storeToRefs(fieldDetailStore);
+const { extension, type } = toRefs(props);
+
+const extensionInfo = useExtension(type, extension);
+
+const usesCustomComponent = computed(() => {
+	if (!extensionInfo.value) return false;
+
+	return extensionInfo.value.options && 'render' in extensionInfo.value.options;
+});
+
+const optionsFields = computed(() => {
+	if (usesCustomComponent.value === true) return [];
+
+	let optionsObjectOrArray;
+
+	if (props.options) {
+		optionsObjectOrArray = props.options;
+	} else {
+		if (!extensionInfo.value) return [];
+		if (!extensionInfo.value?.options) return [];
+		optionsObjectOrArray = extensionInfo.value.options;
+	}
+
+	if (!optionsObjectOrArray) return [];
+
+	if (Array.isArray(optionsObjectOrArray)) return optionsObjectOrArray;
+
+	if (props.showAdvanced) {
+		return [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
+	}
+
+	return optionsObjectOrArray.standard;
+});
+
+const optionsValues = computed({
+	get() {
+		return props.modelValue;
 	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const fieldDetailStore = useFieldDetailStore();
-
-		const { collection, field } = storeToRefs(fieldDetailStore);
-		const { extension, type } = toRefs(props);
-
-		const extensionInfo = useExtension(type, extension);
-
-		const usesCustomComponent = computed(() => {
-			if (!extensionInfo.value) return false;
-
-			return extensionInfo.value.options && 'render' in extensionInfo.value.options;
-		});
-
-		const optionsFields = computed(() => {
-			if (usesCustomComponent.value === true) return [];
-
-			let optionsObjectOrArray;
-
-			if (props.options) {
-				optionsObjectOrArray = props.options;
-			} else {
-				if (!extensionInfo.value) return [];
-				if (!extensionInfo.value?.options) return [];
-				optionsObjectOrArray = extensionInfo.value.options;
-			}
-
-			if (!optionsObjectOrArray) return [];
-
-			if (Array.isArray(optionsObjectOrArray)) return optionsObjectOrArray;
-
-			if (props.showAdvanced) {
-				return [...optionsObjectOrArray.standard, ...optionsObjectOrArray.advanced];
-			}
-
-			return optionsObjectOrArray.standard;
-		});
-
-		const optionsValues = computed({
-			get() {
-				return props.modelValue;
-			},
-			set(values: Record<string, any>) {
-				emit('update:modelValue', values);
-			},
-		});
-
-		return {
-			usesCustomComponent,
-			extensionInfo,
-			optionsValues,
-			optionsFields,
-			t,
-			collection,
-			field,
-		};
+	set(values: Record<string, any>) {
+		emit('update:modelValue', values);
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
@@ -55,39 +55,29 @@
 	</v-input>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections';
 import { orderBy } from 'lodash';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props) {
-		const { t } = useI18n();
-		const collectionsStore = useCollectionsStore();
+const props = defineProps<{
+	modelValue?: string;
+	disabled?: boolean;
+}>();
 
-		const collectionExists = computed(() => {
-			return !!collectionsStore.getCollection(props.modelValue);
-		});
+defineEmits(['update:modelValue']);
 
-		const availableCollections = computed(() => {
-			return orderBy(collectionsStore.databaseCollections, ['sort', 'collection'], ['asc']);
-		});
+const { t } = useI18n();
+const collectionsStore = useCollectionsStore();
 
-		const systemCollections = collectionsStore.crudSafeSystemCollections;
-
-		return { t, collectionExists, availableCollections, systemCollections };
-	},
+const collectionExists = computed(() => {
+	return !!collectionsStore.getCollection(props.modelValue);
 });
+
+const availableCollections = computed(() => {
+	return orderBy(collectionsStore.databaseCollections, ['sort', 'collection'], ['asc']);
+});
+
+const systemCollections = collectionsStore.crudSafeSystemCollections;
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-field-select.vue
@@ -37,73 +37,52 @@
 	</v-input>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, PropType } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useFieldsStore } from '@/stores/fields';
+<script setup lang="ts">
 import { i18n } from '@/lang';
+import { useFieldsStore } from '@/stores/fields';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: String,
-			default: null,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		collection: {
-			type: String,
-			default: null,
-		},
-		disabledFields: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		typeDenyList: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		typeAllowList: {
-			type: Array as PropType<string[]>,
-			default: undefined,
-		},
-		placeholder: {
-			type: String,
-			default: () => i18n.global.t('foreign_key') + '...',
-		},
-		nullable: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props) {
-		const { t } = useI18n();
-		const fieldsStore = useFieldsStore();
+const props = withDefaults(
+	defineProps<{
+		modelValue?: string;
+		disabled?: boolean;
+		collection?: string;
+		disabledFields?: string[];
+		typeDenyList?: string[];
+		typeAllowList?: string[];
+		placeholder?: string;
+		nullable?: boolean;
+	}>(),
+	{
+		disabledFields: () => [],
+		typeDenyList: () => [],
+		placeholder: () => i18n.global.t('foreign_key') + '...',
+	}
+);
 
-		const fields = computed(() => {
-			if (!props.collection) return [];
+defineEmits(['update:modelValue']);
 
-			return fieldsStore.getFieldsForCollectionAlphabetical(props.collection).map((field) => ({
-				text: field.field,
-				value: field.field,
-				disabled:
-					!field.schema ||
-					!!field.schema?.is_primary_key ||
-					props.disabledFields.includes(field.field) ||
-					props.typeDenyList.includes(field.type) ||
-					(props.typeAllowList && !props.typeAllowList.includes(field.type)),
-			}));
-		});
+const { t } = useI18n();
+const fieldsStore = useFieldsStore();
 
-		const fieldExists = computed(() => {
-			if (!props.collection || !props.modelValue) return false;
-			return !!fieldsStore.getField(props.collection, props.modelValue);
-		});
+const fields = computed(() => {
+	if (!props.collection) return [];
 
-		return { t, fields, fieldExists };
-	},
+	return fieldsStore.getFieldsForCollectionAlphabetical(props.collection).map((field) => ({
+		text: field.field,
+		value: field.field,
+		disabled:
+			!field.schema ||
+			!!field.schema?.is_primary_key ||
+			props.disabledFields.includes(field.field) ||
+			props.typeDenyList.includes(field.type) ||
+			(props.typeAllowList && !props.typeAllowList.includes(field.type)),
+	}));
+});
+
+const fieldExists = computed(() => {
+	if (!props.collection || !props.modelValue) return false;
+	return !!fieldsStore.getField(props.collection, props.modelValue);
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select-menu.vue
@@ -76,36 +76,25 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from 'vue';
-import { Field } from '@cairncms/types';
-import { useI18n } from 'vue-i18n';
+<script setup lang="ts">
 import { getLocalTypeForField } from '@/utils/get-local-type';
+import { Field } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	name: 'FieldSelectMenu',
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		noDelete: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['toggleVisibility', 'duplicate', 'delete', 'setWidth'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	field: Field;
+	noDelete?: boolean;
+}>();
 
-		const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
-		const isPrimaryKey = computed(() => props.field.schema?.is_primary_key === true);
+defineEmits(['toggleVisibility', 'duplicate', 'delete', 'setWidth']);
 
-		const duplicable = computed(() => localType.value === 'standard' && isPrimaryKey.value === false);
+const { t } = useI18n();
 
-		return { t, localType, isPrimaryKey, duplicable };
-	},
-});
+const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
+const isPrimaryKey = computed(() => props.field.schema?.is_primary_key === true);
+
+const duplicable = computed(() => localType.value === 'standard' && isPrimaryKey.value === false);
 </script>
 
 <style scoped>

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -92,6 +92,14 @@
 							small
 						/>
 						<v-icon v-if="hidden" v-tooltip="t('hidden_field')" name="visibility_off" class="hidden-icon" small />
+
+						<router-link
+							v-if="showRelatedCollectionLink"
+							:to="`/settings/data-model/${relatedCollectionInfo!.relatedCollection}`"
+						>
+							<v-icon name="open_in_new" class="link-icon" small />
+						</router-link>
+
 						<field-select-menu
 							:field="field"
 							@toggle-visibility="toggleVisibility"
@@ -145,7 +153,7 @@
 
 <script lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed } from 'vue';
+import { defineComponent, PropType, ref, computed, unref } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRouter } from 'vue-router';
@@ -160,6 +168,7 @@ import { hideDragImage } from '@/utils/hide-drag-image';
 import Draggable from 'vuedraggable';
 import formatTitle from '@cairncms/format-title';
 import { useExtension } from '@/composables/use-extension';
+import { getRelatedCollection } from '@/utils/get-related-collection';
 
 export default defineComponent({
 	name: 'FieldSelect',
@@ -205,6 +214,15 @@ export default defineComponent({
 
 		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
 
+		const relatedCollectionInfo = computed(() => getRelatedCollection(props.field.collection, props.field.field));
+
+		const showRelatedCollectionLink = computed(
+			() =>
+				unref(relatedCollectionInfo) !== null &&
+				props.field.collection !== unref(relatedCollectionInfo)?.relatedCollection &&
+				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
+		);
+
 		return {
 			t,
 			interfaceName,
@@ -224,6 +242,8 @@ export default defineComponent({
 			hidden,
 			toggleVisibility,
 			localType,
+			showRelatedCollectionLink,
+			relatedCollectionInfo,
 			hideDragImage,
 			onGroupSortChange,
 			nestedFields,
@@ -376,6 +396,10 @@ export default defineComponent({
 		--v-icon-color: var(--warning);
 		--v-icon-color-hover: var(--warning);
 	}
+
+	&.link-icon:hover {
+		--v-icon-color: var(--foreground-normal);
+	}
 }
 
 .drag-handle {
@@ -522,7 +546,7 @@ export default defineComponent({
 }
 
 .icons {
-	.v-icon + .v-icon:not(:last-child) {
+	* + *:not(:last-child) {
 		margin-left: 8px;
 	}
 }

--- a/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/field-select.vue
@@ -151,9 +151,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed, unref } from 'vue';
+import { ref, computed, unref } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRouter } from 'vue-router';
@@ -170,193 +170,157 @@ import formatTitle from '@cairncms/format-title';
 import { useExtension } from '@/composables/use-extension';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 
-export default defineComponent({
-	name: 'FieldSelect',
-	components: { FieldSelectMenu, Draggable },
-	props: {
-		field: {
-			type: Object as PropType<Field>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		fields: {
-			type: Array as PropType<Field[]>,
-			default: () => [],
-		},
-	},
-	emits: ['setNestedSort'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		field: Field;
+		disabled?: boolean;
+		fields?: Field[];
+	}>(),
+	{
+		fields: () => [],
+	}
+);
 
-		const router = useRouter();
+const emit = defineEmits(['setNestedSort']);
 
-		const collectionsStore = useCollectionsStore();
-		const fieldsStore = useFieldsStore();
+const { t } = useI18n();
 
-		const editActive = ref(false);
+const router = useRouter();
 
-		const { deleteActive, deleting, deleteField } = useDeleteField();
-		const { duplicateActive, duplicateName, collections, duplicateTo, saveDuplicate, duplicating } = useDuplicate();
+const collectionsStore = useCollectionsStore();
+const fieldsStore = useFieldsStore();
 
-		const inter = useExtension(
-			'interface',
-			computed(() => props.field.meta?.interface ?? null)
-		);
+const { deleteActive, deleting, deleteField } = useDeleteField();
+const { duplicateActive, duplicateName, collections, duplicateTo, saveDuplicate, duplicating } = useDuplicate();
 
-		const interfaceName = computed(() => inter.value?.name ?? null);
+const inter = useExtension(
+	'interface',
+	computed(() => props.field.meta?.interface ?? null)
+);
 
-		const hidden = computed(() => props.field.meta?.hidden === true);
+const interfaceName = computed(() => inter.value?.name ?? null);
 
-		const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
+const hidden = computed(() => props.field.meta?.hidden === true);
 
-		const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
+const localType = computed(() => getLocalTypeForField(props.field.collection, props.field.field));
 
-		const relatedCollectionInfo = computed(() => getRelatedCollection(props.field.collection, props.field.field));
+const nestedFields = computed(() => props.fields.filter((field) => field.meta?.group === props.field.field));
 
-		const showRelatedCollectionLink = computed(
-			() =>
-				unref(relatedCollectionInfo) !== null &&
-				props.field.collection !== unref(relatedCollectionInfo)?.relatedCollection &&
-				['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
-		);
+const relatedCollectionInfo = computed(() => getRelatedCollection(props.field.collection, props.field.field));
 
-		return {
-			t,
-			interfaceName,
-			formatTitle,
-			editActive,
-			setWidth,
-			deleteActive,
-			deleting,
-			deleteField,
-			duplicateActive,
-			collections,
-			duplicateName,
-			duplicateTo,
-			saveDuplicate,
-			duplicating,
-			openFieldDetail,
-			hidden,
-			toggleVisibility,
-			localType,
-			showRelatedCollectionLink,
-			relatedCollectionInfo,
-			hideDragImage,
-			onGroupSortChange,
-			nestedFields,
+const showRelatedCollectionLink = computed(
+	() =>
+		unref(relatedCollectionInfo) !== null &&
+		props.field.collection !== unref(relatedCollectionInfo)?.relatedCollection &&
+		['translations', 'm2o', 'm2m', 'o2m', 'files'].includes(unref(localType) as string)
+);
+
+function setWidth(width: string) {
+	fieldsStore.updateField(props.field.collection, props.field.field, { meta: { width } });
+}
+
+function toggleVisibility() {
+	fieldsStore.updateField(props.field.collection, props.field.field, {
+		meta: { hidden: !props.field.meta?.hidden },
+	});
+}
+
+function useDeleteField() {
+	const deleteActive = ref(false);
+	const deleting = ref(false);
+
+	return {
+		deleteActive,
+		deleting,
+		deleteField,
+	};
+
+	async function deleteField() {
+		await fieldsStore.deleteField(props.field.collection, props.field.field);
+		deleting.value = false;
+		deleteActive.value = false;
+	}
+}
+
+function useDuplicate() {
+	const duplicateActive = ref(false);
+	const duplicateName = ref(props.field.field + '_copy');
+	const duplicating = ref(false);
+
+	const collections = computed(() =>
+		collectionsStore.collections
+			.map(({ collection }) => collection)
+			.filter((collection) => collection.startsWith('directus_') === false)
+	);
+
+	const duplicateTo = ref(props.field.collection);
+
+	return {
+		duplicateActive,
+		duplicateName,
+		collections,
+		duplicateTo,
+		saveDuplicate,
+		duplicating,
+	};
+
+	async function saveDuplicate() {
+		const newField: Record<string, any> = {
+			...cloneDeep(props.field),
+			field: duplicateName.value,
+			collection: duplicateTo.value,
 		};
 
-		function setWidth(width: string) {
-			fieldsStore.updateField(props.field.collection, props.field.field, { meta: { width } });
+		if (newField.meta) {
+			delete newField.meta.id;
+			delete newField.meta.sort;
+			delete newField.meta.group;
 		}
 
-		function toggleVisibility() {
-			fieldsStore.updateField(props.field.collection, props.field.field, {
-				meta: { hidden: !props.field.meta?.hidden },
+		if (newField.schema) {
+			delete newField.schema.comment;
+		}
+
+		delete newField.name;
+
+		duplicating.value = true;
+
+		try {
+			await fieldsStore.createField(duplicateTo.value, newField);
+
+			notify({
+				title: t('field_create_success', { field: newField.field }),
 			});
+
+			duplicateActive.value = false;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			duplicating.value = false;
 		}
+	}
+}
 
-		function useDeleteField() {
-			const deleteActive = ref(false);
-			const deleting = ref(false);
+async function openFieldDetail() {
+	if (!props.field.meta) {
+		const special = getSpecialForType(props.field.type);
+		await fieldsStore.updateField(props.field.collection, props.field.field, { meta: { special } });
+	}
 
-			return {
-				deleteActive,
-				deleting,
-				deleteField,
-			};
+	router.push(`/settings/data-model/${props.field.collection}/${props.field.field}`);
+}
 
-			async function deleteField() {
-				await fieldsStore.deleteField(props.field.collection, props.field.field);
-				deleting.value = false;
-				deleteActive.value = false;
-			}
-		}
+async function onGroupSortChange(fields: Field[]) {
+	const updates = fields.map((field, index) => ({
+		field: field.field,
+		meta: {
+			sort: index + 1,
+			group: props.field.meta!.field,
+		},
+	}));
 
-		function useDuplicate() {
-			const duplicateActive = ref(false);
-			const duplicateName = ref(props.field.field + '_copy');
-			const duplicating = ref(false);
-
-			const collections = computed(() =>
-				collectionsStore.collections
-					.map(({ collection }) => collection)
-					.filter((collection) => collection.startsWith('directus_') === false)
-			);
-
-			const duplicateTo = ref(props.field.collection);
-
-			return {
-				duplicateActive,
-				duplicateName,
-				collections,
-				duplicateTo,
-				saveDuplicate,
-				duplicating,
-			};
-
-			async function saveDuplicate() {
-				const newField: Record<string, any> = {
-					...cloneDeep(props.field),
-					field: duplicateName.value,
-					collection: duplicateTo.value,
-				};
-
-				if (newField.meta) {
-					delete newField.meta.id;
-					delete newField.meta.sort;
-					delete newField.meta.group;
-				}
-
-				if (newField.schema) {
-					delete newField.schema.comment;
-				}
-
-				delete newField.name;
-
-				duplicating.value = true;
-
-				try {
-					await fieldsStore.createField(duplicateTo.value, newField);
-
-					notify({
-						title: t('field_create_success', { field: newField.field }),
-					});
-
-					duplicateActive.value = false;
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					duplicating.value = false;
-				}
-			}
-		}
-
-		async function openFieldDetail() {
-			if (!props.field.meta) {
-				const special = getSpecialForType(props.field.type);
-				await fieldsStore.updateField(props.field.collection, props.field.field, { meta: { special } });
-			}
-
-			router.push(`/settings/data-model/${props.field.collection}/${props.field.field}`);
-		}
-
-		async function onGroupSortChange(fields: Field[]) {
-			const updates = fields.map((field, index) => ({
-				field: field.field,
-				meta: {
-					sort: index + 1,
-					group: props.field.meta!.field,
-				},
-			}));
-
-			emit('setNestedSort', updates);
-		}
-	},
-});
+	emit('setNestedSort', updates);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/fields-management.vue
@@ -49,133 +49,122 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, toRefs } from 'vue';
-import { useCollection } from '@cairncms/composables';
-import Draggable from 'vuedraggable';
-import { Field } from '@cairncms/types';
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
-import FieldSelect from './field-select.vue';
 import { hideDragImage } from '@/utils/hide-drag-image';
-import { orderBy, isNil } from 'lodash';
-import { LocalType } from '@cairncms/types';
+import { useCollection } from '@cairncms/composables';
+import { Field, LocalType } from '@cairncms/types';
+import { isNil, orderBy } from 'lodash';
+import { computed, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
+import FieldSelect from './field-select.vue';
 
-export default defineComponent({
-	name: 'FieldsManagement',
-	components: { Draggable, FieldSelect },
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: string;
+}>();
 
-		const { collection } = toRefs(props);
-		const { fields } = useCollection(collection);
-		const fieldsStore = useFieldsStore();
+const { t } = useI18n();
 
-		const parsedFields = computed(() => {
-			return orderBy(fields.value, [(o) => (o.meta?.sort ? Number(o.meta?.sort) : null), (o) => o.meta?.id]).filter(
-				(field) => field.field.startsWith('$') === false
-			);
-		});
+const { collection } = toRefs(props);
+const { fields } = useCollection(collection);
+const fieldsStore = useFieldsStore();
 
-		const lockedFields = computed(() => {
-			return parsedFields.value.filter((field) => field.meta?.system === true);
-		});
-
-		const usableFields = computed(() => {
-			return parsedFields.value.filter((field) => field.meta?.system !== true);
-		});
-
-		const addOptions = computed<Array<{ type: LocalType; icon: string; text: any } | { divider: boolean }>>(() => [
-			{
-				type: 'standard',
-				icon: 'create',
-				text: t('standard_field'),
-			},
-			{
-				type: 'presentation',
-				icon: 'scatter_plot',
-				text: t('presentation_and_aliases'),
-			},
-			{
-				type: 'group',
-				icon: 'view_in_ar',
-				text: t('field_group'),
-			},
-			{
-				divider: true,
-			},
-			{
-				type: 'file',
-				icon: 'photo',
-				text: t('single_file'),
-			},
-			{
-				type: 'files',
-				icon: 'collections',
-				text: t('multiple_files'),
-			},
-			{
-				divider: true,
-			},
-			{
-				type: 'm2o',
-				icon: 'call_merge',
-				text: t('m2o_relationship'),
-			},
-			{
-				type: 'o2m',
-				icon: 'call_split',
-				text: t('o2m_relationship'),
-			},
-			{
-				type: 'm2m',
-				icon: 'import_export',
-				text: t('m2m_relationship'),
-			},
-			{
-				type: 'm2a',
-				icon: 'gesture',
-				text: t('m2a_relationship'),
-			},
-			{
-				divider: true,
-			},
-			{
-				type: 'translations',
-				icon: 'translate',
-				text: t('translations'),
-			},
-		]);
-
-		return { t, usableFields, lockedFields, setSort, hideDragImage, addOptions, setNestedSort, isNil };
-
-		async function setSort(fields: Field[]) {
-			const updates = fields.map((field, index) => ({
-				field: field.field,
-				meta: {
-					sort: index + 1,
-					group: null,
-				},
-			}));
-
-			await fieldsStore.updateFields(collection.value, updates);
-		}
-
-		async function setNestedSort(updates?: Field[]) {
-			updates = (updates || []).filter((val) => isNil(val) === false);
-
-			if (updates.length > 0) {
-				await fieldsStore.updateFields(collection.value, updates);
-			}
-		}
-	},
+const parsedFields = computed(() => {
+	return orderBy(fields.value, [(o) => (o.meta?.sort ? Number(o.meta?.sort) : null), (o) => o.meta?.id]).filter(
+		(field) => field.field.startsWith('$') === false
+	);
 });
+
+const lockedFields = computed(() => {
+	return parsedFields.value.filter((field) => field.meta?.system === true);
+});
+
+const usableFields = computed(() => {
+	return parsedFields.value.filter((field) => field.meta?.system !== true);
+});
+
+const addOptions = computed<Array<{ type: LocalType; icon: string; text: any } | { divider: boolean }>>(() => [
+	{
+		type: 'standard',
+		icon: 'create',
+		text: t('standard_field'),
+	},
+	{
+		type: 'presentation',
+		icon: 'scatter_plot',
+		text: t('presentation_and_aliases'),
+	},
+	{
+		type: 'group',
+		icon: 'view_in_ar',
+		text: t('field_group'),
+	},
+	{
+		divider: true,
+	},
+	{
+		type: 'file',
+		icon: 'photo',
+		text: t('single_file'),
+	},
+	{
+		type: 'files',
+		icon: 'collections',
+		text: t('multiple_files'),
+	},
+	{
+		divider: true,
+	},
+	{
+		type: 'm2o',
+		icon: 'call_merge',
+		text: t('m2o_relationship'),
+	},
+	{
+		type: 'o2m',
+		icon: 'call_split',
+		text: t('o2m_relationship'),
+	},
+	{
+		type: 'm2m',
+		icon: 'import_export',
+		text: t('m2m_relationship'),
+	},
+	{
+		type: 'm2a',
+		icon: 'gesture',
+		text: t('m2a_relationship'),
+	},
+	{
+		divider: true,
+	},
+	{
+		type: 'translations',
+		icon: 'translate',
+		text: t('translations'),
+	},
+]);
+
+async function setSort(fields: Field[]) {
+	const updates = fields.map((field, index) => ({
+		field: field.field,
+		meta: {
+			sort: index + 1,
+			group: null,
+		},
+	}));
+
+	await fieldsStore.updateFields(collection.value, updates);
+}
+
+async function setNestedSort(updates?: Field[]) {
+	updates = (updates || []).filter((val) => isNil(val) === false);
+
+	if (updates.length > 0) {
+		await fieldsStore.updateFields(collection.value, updates);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -99,116 +99,77 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, toRefs, ref } from 'vue';
-import SettingsNavigation from '../../../components/navigation.vue';
-import { useCollection } from '@cairncms/composables';
-import FieldsManagement from './components/fields-management.vue';
-
+<script setup lang="ts">
+import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
-import { useRouter } from 'vue-router';
+import { useShortcut } from '@/composables/use-shortcut';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
-import { useShortcut } from '@/composables/use-shortcut';
-import { useEditsGuard } from '@/composables/use-edits-guard';
+import { useCollection } from '@cairncms/composables';
+import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import SettingsNavigation from '../../../components/navigation.vue';
+import FieldsManagement from './components/fields-management.vue';
 
-export default defineComponent({
-	components: { SettingsNavigation, FieldsManagement },
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
+const props = defineProps<{
+	collection: string;
+	// Field detail modal only
+	field?: string;
+	type?: string;
+}>();
 
-		// Field detail modal only
-		field: {
-			type: String,
-			default: null,
-		},
-		type: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const router = useRouter();
+const router = useRouter();
 
-		const { collection } = toRefs(props);
-		const { info: collectionInfo, fields } = useCollection(collection);
-		const collectionsStore = useCollectionsStore();
-		const fieldsStore = useFieldsStore();
+const { collection } = toRefs(props);
+const { info: collectionInfo } = useCollection(collection);
+const collectionsStore = useCollectionsStore();
+const fieldsStore = useFieldsStore();
 
-		const { isNew, edits, item, saving, loading, error, save, remove, deleting, saveAsCopy, isBatch } = useItem(
-			ref('directus_collections'),
-			collection
-		);
+const { edits, item, saving, loading, save, remove, deleting, isBatch } = useItem(
+	ref('directus_collections'),
+	collection
+);
 
-		const hasEdits = computed<boolean>(() => {
-			if (!edits.value.meta) return false;
-			return Object.keys(edits.value.meta).length > 0;
-		});
-
-		useShortcut('meta+s', () => {
-			if (hasEdits.value) saveAndStay();
-		});
-
-		const confirmDelete = ref(false);
-
-		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
-
-		return {
-			t,
-			collectionInfo,
-			fields,
-			confirmDelete,
-			isNew,
-			edits,
-			item,
-			saving,
-			loading,
-			error,
-			save,
-			remove,
-			deleting,
-			saveAsCopy,
-			isBatch,
-			deleteAndQuit,
-			saveAndQuit,
-			hasEdits,
-			confirmLeave,
-			leaveTo,
-			discardAndLeave,
-		};
-
-		async function deleteAndQuit() {
-			await remove();
-			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
-			edits.value = {};
-			router.replace(`/settings/data-model`);
-		}
-
-		async function saveAndStay() {
-			await save();
-			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
-		}
-
-		async function saveAndQuit() {
-			await save();
-			await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
-			router.push(`/settings/data-model`);
-		}
-
-		function discardAndLeave() {
-			if (!leaveTo.value) return;
-			edits.value = {};
-			confirmLeave.value = false;
-			router.push(leaveTo.value);
-		}
-	},
+const hasEdits = computed<boolean>(() => {
+	if (!edits.value.meta) return false;
+	return Object.keys(edits.value.meta).length > 0;
 });
+
+useShortcut('meta+s', () => {
+	if (hasEdits.value) saveAndStay();
+});
+
+const confirmDelete = ref(false);
+
+const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
+
+async function deleteAndQuit() {
+	await remove();
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+	edits.value = {};
+	router.replace(`/settings/data-model`);
+}
+
+async function saveAndStay() {
+	await save();
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+}
+
+async function saveAndQuit() {
+	await save();
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+	router.push(`/settings/data-model`);
+}
+
+function discardAndLeave() {
+	if (!leaveTo.value) return;
+	edits.value = {};
+	confirmLeave.value = false;
+	router.push(leaveTo.value);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -126,20 +126,19 @@
 	</v-drawer>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { cloneDeep } from 'lodash';
-import { defineComponent, ref, reactive, watch } from 'vue';
+<script setup lang="ts">
 import api from '@/api';
-import { Field, Relation } from '@cairncms/types';
-import { useFieldsStore } from '@/stores/fields';
+import { useDialogRoute } from '@/composables/use-dialog-route';
 import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { notify } from '@/utils/notify';
-import { useDialogRoute } from '@/composables/use-dialog-route';
-import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
-import { DeepPartial } from '@cairncms/types';
+import { DeepPartial, Field, Relation } from '@cairncms/types';
+import { cloneDeep } from 'lodash';
+import { reactive, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 const defaultSystemFields = {
 	status: {
@@ -186,329 +185,311 @@ const defaultSystemFields = {
 	},
 };
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const router = useRouter();
+const router = useRouter();
 
-		const collectionsStore = useCollectionsStore();
-		const fieldsStore = useFieldsStore();
-		const relationsStore = useRelationsStore();
+const collectionsStore = useCollectionsStore();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
 
-		const isOpen = useDialogRoute();
+const isOpen = useDialogRoute();
 
-		const currentTab = ref(['collection_setup']);
+const currentTab = ref(['collection_setup']);
 
-		const collectionName = ref(null);
-		const singleton = ref(false);
-		const primaryKeyFieldName = ref('id');
-		const primaryKeyFieldType = ref<'auto_int' | 'auto_big_int' | 'uuid' | 'manual'>('auto_int');
+const collectionName = ref(null);
+const singleton = ref(false);
+const primaryKeyFieldName = ref('id');
+const primaryKeyFieldType = ref<'auto_int' | 'auto_big_int' | 'uuid' | 'manual'>('auto_int');
 
-		const sortField = ref<string>();
+const sortField = ref<string>();
 
-		const archiveField = ref<string>();
-		const archiveValue = ref<string>();
-		const unarchiveValue = ref<string>();
+const archiveField = ref<string>();
+const archiveValue = ref<string>();
+const unarchiveValue = ref<string>();
 
-		const systemFields = reactive(cloneDeep(defaultSystemFields));
+const systemFields = reactive(cloneDeep(defaultSystemFields));
 
-		const saving = ref(false);
+const saving = ref(false);
 
-		watch(() => singleton.value, setOptionsForSingleton);
+watch(() => singleton.value, setOptionsForSingleton);
 
+function setOptionsForSingleton() {
+	systemFields.sort = { ...defaultSystemFields.sort };
+	systemFields.sort.inputDisabled = singleton.value;
+}
+
+async function save() {
+	saving.value = true;
+
+	try {
+		await api.post(`/collections`, {
+			collection: collectionName.value,
+			fields: [getPrimaryKeyField(), ...getSystemFields()],
+			schema: {},
+			meta: {
+				sort_field: sortField.value,
+				archive_field: archiveField.value,
+				archive_value: archiveValue.value,
+				unarchive_value: unarchiveValue.value,
+				singleton: singleton.value,
+			},
+		});
+
+		const storeHydrations: Promise<void>[] = [];
+
+		const relations = getSystemRelations();
+
+		if (relations.length > 0) {
+			const requests = relations.map((relation) => api.post('/relations', relation));
+			await Promise.all(requests);
+			storeHydrations.push(relationsStore.hydrate());
+		}
+
+		storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate());
+		await Promise.all(storeHydrations);
+
+		notify({
+			title: t('collection_created'),
+		});
+
+		router.replace(`/settings/data-model/${collectionName.value}`);
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		saving.value = false;
+	}
+}
+
+function getPrimaryKeyField() {
+	if (primaryKeyFieldType.value === 'uuid') {
 		return {
-			t,
-			router,
-			isOpen,
-			currentTab,
-			save,
-			systemFields,
-			primaryKeyFieldName,
-			primaryKeyFieldType,
-			collectionName,
-			saving,
-			singleton,
+			field: primaryKeyFieldName.value,
+			type: 'uuid',
+			meta: {
+				hidden: true,
+				readonly: true,
+				interface: 'input',
+				special: ['uuid'],
+			},
+			schema: {
+				is_primary_key: true,
+				length: 36,
+				has_auto_increment: false,
+			},
 		};
+	} else if (primaryKeyFieldType.value === 'manual') {
+		return {
+			field: primaryKeyFieldName.value,
+			type: 'string',
+			meta: {
+				interface: 'input',
+				readonly: false,
+				hidden: false,
+			},
+			schema: {
+				is_primary_key: true,
+				length: 255,
+				has_auto_increment: false,
+			},
+		};
+	} else {
+		return {
+			field: primaryKeyFieldName.value,
+			type: primaryKeyFieldType.value === 'auto_big_int' ? 'bigInteger' : 'integer',
+			meta: {
+				hidden: true,
+				interface: 'input',
+				readonly: true,
+			},
+			schema: {
+				is_primary_key: true,
+				has_auto_increment: true,
+			},
+		};
+	}
+}
 
-		function setOptionsForSingleton() {
-			systemFields.sort = { ...defaultSystemFields.sort };
-			systemFields.sort.inputDisabled = singleton.value;
-		}
+function getSystemFields() {
+	const fields: DeepPartial<Field>[] = [];
 
-		async function save() {
-			saving.value = true;
-
-			try {
-				await api.post(`/collections`, {
-					collection: collectionName.value,
-					fields: [getPrimaryKeyField(), ...getSystemFields()],
-					schema: {},
-					meta: {
-						sort_field: sortField.value,
-						archive_field: archiveField.value,
-						archive_value: archiveValue.value,
-						unarchive_value: unarchiveValue.value,
-						singleton: singleton.value,
-					},
-				});
-
-				const storeHydrations: Promise<void>[] = [];
-
-				const relations = getSystemRelations();
-
-				if (relations.length > 0) {
-					const requests = relations.map((relation) => api.post('/relations', relation));
-					await Promise.all(requests);
-					storeHydrations.push(relationsStore.hydrate());
-				}
-
-				storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate());
-				await Promise.all(storeHydrations);
-
-				notify({
-					title: t('collection_created'),
-				});
-
-				router.replace(`/settings/data-model/${collectionName.value}`);
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				saving.value = false;
-			}
-		}
-
-		function getPrimaryKeyField() {
-			if (primaryKeyFieldType.value === 'uuid') {
-				return {
-					field: primaryKeyFieldName.value,
-					type: 'uuid',
-					meta: {
-						hidden: true,
-						readonly: true,
-						interface: 'input',
-						special: ['uuid'],
-					},
-					schema: {
-						is_primary_key: true,
-						length: 36,
-						has_auto_increment: false,
-					},
-				};
-			} else if (primaryKeyFieldType.value === 'manual') {
-				return {
-					field: primaryKeyFieldName.value,
-					type: 'string',
-					meta: {
-						interface: 'input',
-						readonly: false,
-						hidden: false,
-					},
-					schema: {
-						is_primary_key: true,
-						length: 255,
-						has_auto_increment: false,
-					},
-				};
-			} else {
-				return {
-					field: primaryKeyFieldName.value,
-					type: primaryKeyFieldType.value === 'auto_big_int' ? 'bigInteger' : 'integer',
-					meta: {
-						hidden: true,
-						interface: 'input',
-						readonly: true,
-					},
-					schema: {
-						is_primary_key: true,
-						has_auto_increment: true,
-					},
-				};
-			}
-		}
-
-		function getSystemFields() {
-			const fields: DeepPartial<Field>[] = [];
-
-			// Status
-			if (systemFields.status.enabled === true) {
-				fields.push({
-					field: systemFields.status.name,
-					type: 'string',
-					meta: {
-						width: 'full',
-						options: {
-							choices: [
-								{
-									text: '$t:published',
-									value: 'published',
-								},
-								{
-									text: '$t:draft',
-									value: 'draft',
-								},
-								{
-									text: '$t:archived',
-									value: 'archived',
-								},
-							],
+	// Status
+	if (systemFields.status.enabled === true) {
+		fields.push({
+			field: systemFields.status.name,
+			type: 'string',
+			meta: {
+				width: 'full',
+				options: {
+					choices: [
+						{
+							text: '$t:published',
+							value: 'published',
 						},
-						interface: 'select-dropdown',
-						display: 'labels',
-						display_options: {
-							showAsDot: false,
-							choices: [
-								{
-									text: '$t:published',
-									value: 'published',
-									foreground: 'var(--status-published-fg)',
-									background: 'var(--status-published-bg)',
-								},
-								{
-									text: '$t:draft',
-									value: 'draft',
-									foreground: 'var(--status-draft-fg)',
-									background: 'var(--status-draft-bg)',
-								},
-								{
-									text: '$t:archived',
-									value: 'archived',
-									foreground: 'var(--status-archived-fg)',
-									background: 'var(--status-archived-bg)',
-								},
-							],
+						{
+							text: '$t:draft',
+							value: 'draft',
 						},
-					},
-					schema: {
-						default_value: 'draft',
-						is_nullable: false,
-					},
-				});
-
-				archiveField.value = systemFields.status.name;
-				archiveValue.value = 'archived';
-				unarchiveValue.value = 'draft';
-			}
-
-			// Sort
-			if (systemFields.sort.enabled === true) {
-				fields.push({
-					field: systemFields.sort.name,
-					type: 'integer',
-					meta: {
-						interface: 'input',
-						hidden: true,
-					},
-					schema: {},
-				});
-
-				sortField.value = systemFields.sort.name;
-			}
-
-			if (systemFields.userCreated.enabled === true) {
-				fields.push({
-					field: systemFields.userCreated.name,
-					type: 'uuid',
-					meta: {
-						special: ['user-created'],
-						interface: 'select-dropdown-m2o',
-						options: {
-							template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+						{
+							text: '$t:archived',
+							value: 'archived',
 						},
-						display: 'user',
-						readonly: true,
-						hidden: true,
-						width: 'half',
-					},
-					schema: {},
-				});
-			}
-
-			if (systemFields.dateCreated.enabled === true) {
-				fields.push({
-					field: systemFields.dateCreated.name,
-					type: 'timestamp',
-					meta: {
-						special: ['date-created'],
-						interface: 'datetime',
-						readonly: true,
-						hidden: true,
-						width: 'half',
-						display: 'datetime',
-						display_options: {
-							relative: true,
+					],
+				},
+				interface: 'select-dropdown',
+				display: 'labels',
+				display_options: {
+					showAsDot: false,
+					choices: [
+						{
+							text: '$t:published',
+							value: 'published',
+							foreground: 'var(--status-published-fg)',
+							background: 'var(--status-published-bg)',
 						},
-					},
-					schema: {},
-				});
-			}
-
-			if (systemFields.userUpdated.enabled === true) {
-				fields.push({
-					field: systemFields.userUpdated.name,
-					type: 'uuid',
-					meta: {
-						special: ['user-updated'],
-						interface: 'select-dropdown-m2o',
-						options: {
-							template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+						{
+							text: '$t:draft',
+							value: 'draft',
+							foreground: 'var(--status-draft-fg)',
+							background: 'var(--status-draft-bg)',
 						},
-						display: 'user',
-						readonly: true,
-						hidden: true,
-						width: 'half',
-					},
-					schema: {},
-				});
-			}
-
-			if (systemFields.dateUpdated.enabled === true) {
-				fields.push({
-					field: systemFields.dateUpdated.name,
-					type: 'timestamp',
-					meta: {
-						special: ['date-updated'],
-						interface: 'datetime',
-						readonly: true,
-						hidden: true,
-						width: 'half',
-						display: 'datetime',
-						display_options: {
-							relative: true,
+						{
+							text: '$t:archived',
+							value: 'archived',
+							foreground: 'var(--status-archived-fg)',
+							background: 'var(--status-archived-bg)',
 						},
-					},
-					schema: {},
-				});
-			}
+					],
+				},
+			},
+			schema: {
+				default_value: 'draft',
+				is_nullable: false,
+			},
+		});
 
-			return fields;
-		}
+		archiveField.value = systemFields.status.name;
+		archiveValue.value = 'archived';
+		unarchiveValue.value = 'draft';
+	}
 
-		function getSystemRelations() {
-			const relations: Partial<Relation>[] = [];
+	// Sort
+	if (systemFields.sort.enabled === true) {
+		fields.push({
+			field: systemFields.sort.name,
+			type: 'integer',
+			meta: {
+				interface: 'input',
+				hidden: true,
+			},
+			schema: {},
+		});
 
-			if (systemFields.userCreated.enabled === true) {
-				relations.push({
-					collection: collectionName.value!,
-					field: systemFields.userCreated.name,
-					related_collection: 'directus_users',
-					schema: {},
-				});
-			}
+		sortField.value = systemFields.sort.name;
+	}
 
-			if (systemFields.userUpdated.enabled === true) {
-				relations.push({
-					collection: collectionName.value!,
-					field: systemFields.userUpdated.name,
-					related_collection: 'directus_users',
-					schema: {},
-				});
-			}
+	if (systemFields.userCreated.enabled === true) {
+		fields.push({
+			field: systemFields.userCreated.name,
+			type: 'uuid',
+			meta: {
+				special: ['user-created'],
+				interface: 'select-dropdown-m2o',
+				options: {
+					template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+				},
+				display: 'user',
+				readonly: true,
+				hidden: true,
+				width: 'half',
+			},
+			schema: {},
+		});
+	}
 
-			return relations;
-		}
-	},
-});
+	if (systemFields.dateCreated.enabled === true) {
+		fields.push({
+			field: systemFields.dateCreated.name,
+			type: 'timestamp',
+			meta: {
+				special: ['date-created'],
+				interface: 'datetime',
+				readonly: true,
+				hidden: true,
+				width: 'half',
+				display: 'datetime',
+				display_options: {
+					relative: true,
+				},
+			},
+			schema: {},
+		});
+	}
+
+	if (systemFields.userUpdated.enabled === true) {
+		fields.push({
+			field: systemFields.userUpdated.name,
+			type: 'uuid',
+			meta: {
+				special: ['user-updated'],
+				interface: 'select-dropdown-m2o',
+				options: {
+					template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}',
+				},
+				display: 'user',
+				readonly: true,
+				hidden: true,
+				width: 'half',
+			},
+			schema: {},
+		});
+	}
+
+	if (systemFields.dateUpdated.enabled === true) {
+		fields.push({
+			field: systemFields.dateUpdated.name,
+			type: 'timestamp',
+			meta: {
+				special: ['date-updated'],
+				interface: 'datetime',
+				readonly: true,
+				hidden: true,
+				width: 'half',
+				display: 'datetime',
+				display_options: {
+					relative: true,
+				},
+			},
+			schema: {},
+		});
+	}
+
+	return fields;
+}
+
+function getSystemRelations() {
+	const relations: Partial<Relation>[] = [];
+
+	if (systemFields.userCreated.enabled === true) {
+		relations.push({
+			collection: collectionName.value!,
+			field: systemFields.userCreated.name,
+			related_collection: 'directus_users',
+			schema: {},
+		});
+	}
+
+	if (systemFields.userUpdated.enabled === true) {
+		relations.push({
+			collection: collectionName.value!,
+			field: systemFields.userUpdated.name,
+			related_collection: 'directus_users',
+			schema: {},
+		});
+	}
+
+	return relations;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/not-found.vue
+++ b/app/src/modules/settings/routes/not-found.vue
@@ -12,18 +12,11 @@
 	</private-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import SettingsNavigation from '../components/navigation.vue';
 
-export default defineComponent({
-	components: { SettingsNavigation },
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -145,171 +145,130 @@
 	</component>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref } from 'vue';
-import SettingsNavigation from '../../../components/navigation.vue';
-import PresetsInfoSidebarDetail from './components/presets-info-sidebar-detail.vue';
-
-import { useCollection, useLayout } from '@cairncms/composables';
+<script setup lang="ts">
+import { useExtension } from '@/composables/use-extension';
+import { usePreset } from '@/composables/use-preset';
+import { usePermissionsStore } from '@/stores/permissions';
+import { usePresetsStore } from '@/stores/presets';
+import { useUserStore } from '@/stores/user';
+import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import RefreshSidebarDetail from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
-import { usePermissionsStore } from '@/stores/permissions';
-import { useUserStore } from '@/stores/user';
-import { usePresetsStore } from '@/stores/presets';
-import DrawerBatch from '@/views/private/components/drawer-batch.vue';
-import { usePreset } from '@/composables/use-preset';
-import { useExtension } from '@/composables/use-extension';
+import { useCollection, useLayout } from '@cairncms/composables';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import SettingsNavigation from '../../../components/navigation.vue';
+import PresetsInfoSidebarDetail from './components/presets-info-sidebar-detail.vue';
 
-export default defineComponent({
-	name: 'ContentCollection',
-	components: {
-		SettingsNavigation,
-		PresetsInfoSidebarDetail,
-		LayoutSidebarDetail,
-		SearchInput,
-		DrawerBatch,
-		RefreshSidebarDetail,
-	},
-	setup() {
-		const layout = ref('tabular');
-		const collection = ref('directus_presets');
-		const { layoutOptions, layoutQuery, filter, search, refreshInterval } = usePreset(collection);
+const layout = ref('tabular');
+const collection = ref('directus_presets');
+const { layoutOptions, layoutQuery, filter, search, refreshInterval } = usePreset(collection);
 
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const userStore = useUserStore();
-		const permissionsStore = usePermissionsStore();
-		const layoutRef = ref();
+const userStore = useUserStore();
+const permissionsStore = usePermissionsStore();
+const layoutRef = ref();
 
-		const { selection } = useSelection();
-		const { info: currentCollection } = useCollection(collection);
+const { selection } = useSelection();
+const { info: currentCollection } = useCollection(collection);
 
-		const { layoutWrapper } = useLayout(layout);
+const { layoutWrapper } = useLayout(layout);
 
-		const { confirmDelete, deleting, batchDelete, error: deleteError, batchEditActive } = useBatch();
+const { confirmDelete, deleting, batchDelete, error: deleteError, batchEditActive } = useBatch();
 
-		const currentLayout = useExtension('layout', layout);
+const currentLayout = useExtension('layout', layout);
 
-		const { batchEditAllowed, batchDeleteAllowed, createAllowed } = usePermissions();
+const { batchEditAllowed, batchDeleteAllowed, createAllowed } = usePermissions();
 
-		const presetsStore = usePresetsStore();
+const presetsStore = usePresetsStore();
 
-		return {
-			t,
-			batchDelete,
-			batchEditActive,
-			confirmDelete,
-			currentCollection,
-			deleting,
-			filter,
-			layoutRef,
-			layoutWrapper,
-			selection,
-			layoutOptions,
-			layoutQuery,
-			layout,
-			search,
-			clearFilters,
-			batchEditAllowed,
-			batchDeleteAllowed,
-			deleteError,
-			createAllowed,
-			drawerBatchRefresh,
-			refresh,
-			refreshInterval,
-			currentLayout,
-			collection,
-		};
+async function refresh() {
+	await layoutRef.value?.state?.refresh?.();
+}
 
-		async function refresh() {
-			await layoutRef.value?.state?.refresh?.();
-		}
+async function drawerBatchRefresh() {
+	selection.value = [];
+	await refresh();
+}
 
-		async function drawerBatchRefresh() {
+function useSelection() {
+	const selection = ref<number[]>([]);
+
+	return { selection };
+}
+
+function useBatch() {
+	const confirmDelete = ref(false);
+	const deleting = ref(false);
+
+	const batchEditActive = ref(false);
+
+	const error = ref<any>(null);
+
+	return { batchEditActive, confirmDelete, deleting, batchDelete, error };
+
+	async function batchDelete() {
+		deleting.value = true;
+
+		try {
+			const batchPrimaryKeys = selection.value;
+			await presetsStore.delete(batchPrimaryKeys);
+
 			selection.value = [];
 			await refresh();
+
+			confirmDelete.value = false;
+		} catch (err: any) {
+			error.value = err;
+		} finally {
+			deleting.value = false;
 		}
+	}
+}
 
-		function useSelection() {
-			const selection = ref<number[]>([]);
+function clearFilters() {
+	filter.value = null;
+	search.value = null;
+}
 
-			return { selection };
-		}
+function usePermissions() {
+	const batchEditAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-		function useBatch() {
-			const confirmDelete = ref(false);
-			const deleting = ref(false);
+		const updatePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'update' && permission.collection === collection.value
+		);
 
-			const batchEditActive = ref(false);
+		return !!updatePermissions;
+	});
 
-			const error = ref<any>(null);
+	const batchDeleteAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-			return { batchEditActive, confirmDelete, deleting, batchDelete, error };
+		const deletePermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'delete' && permission.collection === collection.value
+		);
 
-			async function batchDelete() {
-				deleting.value = true;
+		return !!deletePermissions;
+	});
 
-				try {
-					const batchPrimaryKeys = selection.value;
-					await presetsStore.delete(batchPrimaryKeys);
+	const createAllowed = computed(() => {
+		const admin = userStore?.currentUser?.role.admin_access === true;
+		if (admin) return true;
 
-					selection.value = [];
-					await refresh();
+		const createPermissions = permissionsStore.permissions.find(
+			(permission) => permission.action === 'create' && permission.collection === collection.value
+		);
 
-					confirmDelete.value = false;
-				} catch (err: any) {
-					error.value = err;
-				} finally {
-					deleting.value = false;
-				}
-			}
-		}
+		return !!createPermissions;
+	});
 
-		function clearFilters() {
-			filter.value = null;
-			search.value = null;
-		}
-
-		function usePermissions() {
-			const batchEditAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const updatePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'update' && permission.collection === collection.value
-				);
-
-				return !!updatePermissions;
-			});
-
-			const batchDeleteAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const deletePermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'delete' && permission.collection === collection.value
-				);
-
-				return !!deletePermissions;
-			});
-
-			const createAllowed = computed(() => {
-				const admin = userStore?.currentUser?.role.admin_access === true;
-				if (admin) return true;
-
-				const createPermissions = permissionsStore.permissions.find(
-					(permission) => permission.action === 'create' && permission.collection === collection.value
-				);
-
-				return !!createPermissions;
-			});
-
-			return { batchEditAllowed, batchDeleteAllowed, createAllowed };
-		}
-	},
-});
+	return { batchEditAllowed, batchDeleteAllowed, createAllowed };
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/presets/collection/components/presets-info-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/presets/collection/components/presets-info-sidebar-detail.vue
@@ -17,46 +17,40 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref } from 'vue';
+<script setup lang="ts">
 import api from '@/api';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const loading = ref(false);
-		const bookmarksCount = ref<number | null>(null);
-		const presetsCount = ref<number | null>(null);
+const loading = ref(false);
+const bookmarksCount = ref<number | null>(null);
+const presetsCount = ref<number | null>(null);
 
-		fetchCounts();
+fetchCounts();
 
-		return { t, bookmarksCount, presetsCount };
+async function fetchCounts() {
+	loading.value = true;
 
-		async function fetchCounts() {
-			loading.value = true;
+	try {
+		const response = await api.get(`/presets`, {
+			params: {
+				[`filter[bookmark][_nnull]`]: true,
+				fields: ['id'],
+				meta: 'filter_count,total_count',
+			},
+		});
 
-			try {
-				const response = await api.get(`/presets`, {
-					params: {
-						[`filter[bookmark][_nnull]`]: true,
-						fields: ['id'],
-						meta: 'filter_count,total_count',
-					},
-				});
-
-				bookmarksCount.value = response.data.meta.filter_count as number;
-				presetsCount.value = (response.data.meta.total_count as number) - bookmarksCount.value;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
-		}
-	},
-});
+		bookmarksCount.value = response.data.meta.filter_count as number;
+		presetsCount.value = (response.data.meta.total_count as number) - bookmarksCount.value;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/project/components/project-info-sidebar-detail.vue
+++ b/app/src/modules/settings/routes/project/components/project-info-sidebar-detail.vue
@@ -38,20 +38,13 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import { useProjectInfo } from '../../../composables/use-project-info';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const { parsedInfo } = useProjectInfo();
-
-		return { t, parsedInfo };
-	},
-});
+const { parsedInfo } = useProjectInfo();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/project/project.vue
+++ b/app/src/modules/settings/routes/project/project.vue
@@ -40,76 +40,58 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed } from 'vue';
-import SettingsNavigation from '../../components/navigation.vue';
-import { useCollection } from '@cairncms/composables';
-import { useSettingsStore } from '@/stores/settings';
-import { useServerStore } from '@/stores/server';
-import ProjectInfoSidebarDetail from './components/project-info-sidebar-detail.vue';
-import { clone } from 'lodash';
-import { useShortcut } from '@/composables/use-shortcut';
+<script setup lang="ts">
 import { useEditsGuard } from '@/composables/use-edits-guard';
+import { useShortcut } from '@/composables/use-shortcut';
+import { useServerStore } from '@/stores/server';
+import { useSettingsStore } from '@/stores/settings';
+import { useCollection } from '@cairncms/composables';
+import { clone } from 'lodash';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+import SettingsNavigation from '../../components/navigation.vue';
+import ProjectInfoSidebarDetail from './components/project-info-sidebar-detail.vue';
 
-export default defineComponent({
-	components: { SettingsNavigation, ProjectInfoSidebarDetail },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const router = useRouter();
+const router = useRouter();
 
-		const settingsStore = useSettingsStore();
-		const serverStore = useServerStore();
+const settingsStore = useSettingsStore();
+const serverStore = useServerStore();
 
-		const { fields } = useCollection('directus_settings');
+const { fields } = useCollection('directus_settings');
 
-		const initialValues = ref(clone(settingsStore.settings));
+const initialValues = ref(clone(settingsStore.settings));
 
-		const edits = ref<{ [key: string]: any } | null>(null);
+const edits = ref<{ [key: string]: any } | null>(null);
 
-		const hasEdits = computed(() => edits.value !== null && Object.keys(edits.value).length > 0);
+const hasEdits = computed(() => edits.value !== null && Object.keys(edits.value).length > 0);
 
-		const saving = ref(false);
+const saving = ref(false);
 
-		useShortcut('meta+s', () => {
-			if (hasEdits.value) save();
-		});
-
-		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
-
-		return {
-			t,
-			fields,
-			initialValues,
-			edits,
-			hasEdits,
-			saving,
-			confirmLeave,
-			leaveTo,
-			save,
-			discardAndLeave,
-		};
-
-		async function save() {
-			if (edits.value === null) return;
-			saving.value = true;
-			await settingsStore.updateSettings(edits.value);
-			await serverStore.hydrate({ isLanguageUpdated: 'default_language' in edits.value });
-			edits.value = null;
-			saving.value = false;
-			initialValues.value = clone(settingsStore.settings);
-		}
-
-		function discardAndLeave() {
-			if (!leaveTo.value) return;
-			edits.value = {};
-			confirmLeave.value = false;
-			router.push(leaveTo.value);
-		}
-	},
+useShortcut('meta+s', () => {
+	if (hasEdits.value) save();
 });
+
+const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
+
+async function save() {
+	if (edits.value === null) return;
+	saving.value = true;
+	await settingsStore.updateSettings(edits.value);
+	await serverStore.hydrate({ isLanguageUpdated: 'default_language' in edits.value });
+	edits.value = null;
+	saving.value = false;
+	initialValues.value = clone(settingsStore.settings);
+}
+
+function discardAndLeave() {
+	if (!leaveTo.value) return;
+	edits.value = {};
+	confirmLeave.value = false;
+	router.push(leaveTo.value);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -55,134 +55,124 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref } from 'vue';
-import SettingsNavigation from '../../components/navigation.vue';
-
+<script setup lang="ts">
 import api from '@/api';
 import { Header as TableHeader } from '@/components/v-table/types';
-import { useRouter } from 'vue-router';
-import { unexpectedError } from '@/utils/unexpected-error';
 import { translate } from '@/utils/translate-object-values';
-import { Role } from '@cairncms/types';
+import { unexpectedError } from '@/utils/unexpected-error';
 import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+import { Role } from '@cairncms/types';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import SettingsNavigation from '../../components/navigation.vue';
 
 type RoleItem = Partial<Role> & {
 	count?: number;
 };
 
-export default defineComponent({
-	name: 'RolesCollection',
-	components: { SettingsNavigation },
-	props: {},
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const router = useRouter();
+const router = useRouter();
 
-		const roles = ref<RoleItem[]>([]);
-		const loading = ref(false);
+const roles = ref<RoleItem[]>([]);
+const loading = ref(false);
 
-		const lastAdminRoleId = computed(() => {
-			const adminRoles = roles.value.filter((role) => role.admin_access === true);
-			return adminRoles.length === 1 ? adminRoles[0].id : null;
-		});
-
-		const tableHeaders = ref<TableHeader[]>([
-			{
-				text: '',
-				value: 'icon',
-				sortable: false,
-				width: 42,
-				align: 'left',
-				description: null,
-			},
-			{
-				text: t('name'),
-				value: 'name',
-				sortable: false,
-				width: 200,
-				align: 'left',
-				description: null,
-			},
-			{
-				text: t('users'),
-				value: 'count',
-				sortable: false,
-				width: 140,
-				align: 'left',
-				description: null,
-			},
-			{
-				text: t('description'),
-				value: 'description',
-				sortable: false,
-				width: 470,
-				align: 'left',
-				description: null,
-			},
-		]);
-
-		fetchRoles();
-
-		const addNewLink = computed(() => {
-			return `/settings/roles/+`;
-		});
-
-		return { t, loading, roles, tableHeaders, addNewLink, navigateToRole };
-
-		async function fetchRoles() {
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/roles`, {
-					params: {
-						limit: -1,
-						fields: ['id', 'name', 'description', 'icon', 'admin_access', 'users'],
-						deep: {
-							users: {
-								_aggregate: { count: 'id' },
-								_groupBy: ['role'],
-								_sort: 'role',
-								_limit: -1,
-							},
-						},
-						sort: 'name',
-					},
-				});
-
-				roles.value = response.data.data.map((role: any) => {
-					const isSentinel = role.id === PUBLIC_ROLE_ID;
-
-					return {
-						...translate(role),
-						// Route clicks on the sentinel to the existing /settings/roles/public
-						// URL, which resolves to the permissions-only public-item.vue view.
-						id: isSentinel ? 'public' : role.id,
-						public: isSentinel,
-						count: isSentinel ? null : role.users[0]?.count.id || 0,
-					};
-				});
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		function navigateToRole({ item }: { item: Role }) {
-			if (item.id !== 'public' && lastAdminRoleId.value) {
-				router.push({
-					name: 'settings-roles-item',
-					params: { primaryKey: item.id, lastAdminRoleId: lastAdminRoleId.value },
-				});
-			} else {
-				router.push(`/settings/roles/${item.id}`);
-			}
-		}
-	},
+const lastAdminRoleId = computed(() => {
+	const adminRoles = roles.value.filter((role) => role.admin_access === true);
+	return adminRoles.length === 1 ? adminRoles[0].id : null;
 });
+
+const tableHeaders = ref<TableHeader[]>([
+	{
+		text: '',
+		value: 'icon',
+		sortable: false,
+		width: 42,
+		align: 'left',
+		description: null,
+	},
+	{
+		text: t('name'),
+		value: 'name',
+		sortable: false,
+		width: 200,
+		align: 'left',
+		description: null,
+	},
+	{
+		text: t('users'),
+		value: 'count',
+		sortable: false,
+		width: 140,
+		align: 'left',
+		description: null,
+	},
+	{
+		text: t('description'),
+		value: 'description',
+		sortable: false,
+		width: 470,
+		align: 'left',
+		description: null,
+	},
+]);
+
+fetchRoles();
+
+const addNewLink = computed(() => {
+	return `/settings/roles/+`;
+});
+
+async function fetchRoles() {
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/roles`, {
+			params: {
+				limit: -1,
+				fields: ['id', 'name', 'description', 'icon', 'admin_access', 'users'],
+				deep: {
+					users: {
+						_aggregate: { count: 'id' },
+						_groupBy: ['role'],
+						_sort: 'role',
+						_limit: -1,
+					},
+				},
+				sort: 'name',
+			},
+		});
+
+		roles.value = response.data.data.map((role: any) => {
+			const isSentinel = role.id === PUBLIC_ROLE_ID;
+
+			return {
+				...translate(role),
+				// Route clicks on the sentinel to the existing /settings/roles/public
+				// URL, which resolves to the permissions-only public-item.vue view.
+				id: isSentinel ? 'public' : role.id,
+				public: isSentinel,
+				count: isSentinel ? null : role.users[0]?.count.id || 0,
+			};
+		});
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
+
+function navigateToRole({ item }: { item: Role }) {
+	if (item.id !== 'public' && lastAdminRoleId.value) {
+		router.push({
+			name: 'settings-roles-item',
+			params: { primaryKey: item.id, lastAdminRoleId: lastAdminRoleId.value },
+		});
+	} else {
+		router.push(`/settings/roles/${item.id}`);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-row.vue
@@ -52,52 +52,31 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { Collection, Permission } from '@cairncms/types';
+import { toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, toRefs } from 'vue';
-import { Permission, Collection } from '@cairncms/types';
-import PermissionsOverviewToggle from './permissions-overview-toggle.vue';
 import useUpdatePermissions from '../composables/use-update-permissions';
+import PermissionsOverviewToggle from './permissions-overview-toggle.vue';
 
-export default defineComponent({
-	components: { PermissionsOverviewToggle },
-	props: {
-		role: {
-			type: String,
-			default: null,
-		},
-		collection: {
-			type: Object as PropType<Collection>,
-			required: true,
-		},
-		permissions: {
-			type: Array as PropType<Permission[]>,
-			required: true,
-		},
-		refreshing: {
-			type: Array as PropType<number[]>,
-			required: true,
-		},
-		appMinimal: {
-			type: [Boolean, Array] as PropType<false | Partial<Permission>[]>,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: Collection;
+	permissions: Permission[];
+	refreshing: number[];
+	role?: string;
+	appMinimal?: Partial<Permission>[];
+}>();
 
-		const { collection, role, permissions } = toRefs(props);
-		const { setFullAccessAll, setNoAccessAll, getPermission } = useUpdatePermissions(collection, permissions, role);
+const { t } = useI18n();
 
-		return { t, getPermission, isLoading, setFullAccessAll, setNoAccessAll };
+const { collection, role, permissions } = toRefs(props);
+const { setFullAccessAll, setNoAccessAll, getPermission } = useUpdatePermissions(collection, permissions, role);
 
-		function isLoading(action: string) {
-			const permission = getPermission(action);
-			if (!permission) return false;
-			return props.refreshing.includes(permission.id);
-		}
-	},
-});
+function isLoading(action: string) {
+	const permission = getPermission(action);
+	if (!permission) return false;
+	return props.refreshing.includes(permission.id);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-toggle.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-toggle.vue
@@ -63,105 +63,85 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed, inject, ref, toRefs } from 'vue';
-import { Permission, Collection } from '@cairncms/types';
-import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+<script setup lang="ts">
 import api from '@/api';
+import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+import { Collection, Permission } from '@cairncms/types';
+import { computed, inject, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import useUpdatePermissions from '../composables/use-update-permissions';
 
-export default defineComponent({
-	props: {
-		collection: {
-			type: Object as PropType<Collection>,
-			required: true,
-		},
-		role: {
-			type: String,
-			default: null,
-		},
-		action: {
-			type: String,
-			required: true,
-		},
-		permissions: {
-			type: Array as PropType<Permission[]>,
-			default: null,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		appMinimal: {
-			type: [Boolean, Object] as PropType<false | Partial<Permission>>,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: Collection;
+	action: string;
+	role?: string;
+	permissions?: Permission[];
+	loading?: boolean;
+	appMinimal?: Partial<Permission>;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const { collection, role, permissions } = toRefs(props);
-		const resolvedRoleId = computed(() => (props.role === 'public' ? PUBLIC_ROLE_ID : props.role));
-		const { setFullAccess, setNoAccess, getPermission } = useUpdatePermissions(collection, permissions, role);
+const router = useRouter();
 
-		const permission = computed(() => getPermission(props.action));
+const { collection, role, permissions } = toRefs(props);
+const { setFullAccess, setNoAccess, getPermission } = useUpdatePermissions(collection, permissions, role);
 
-		const permissionLevel = computed<'all' | 'none' | 'custom'>(() => {
-			if (permission.value === undefined) return 'none';
-			if (
-				permission.value.fields?.includes('*') &&
-				Object.keys(permission.value.permissions || {}).length === 0 &&
-				Object.keys(permission.value.validation || {}).length === 0
-			)
-				return 'all';
+const resolvedRoleId = computed(() => (props.role === 'public' ? PUBLIC_ROLE_ID : props.role));
 
-			return 'custom';
-		});
+const permission = computed(() => getPermission(props.action));
 
-		const saving = ref(false);
+const permissionLevel = computed<'all' | 'none' | 'custom'>(() => {
+	if (permission.value === undefined) return 'none';
 
-		const refresh = inject<() => Promise<void>>('refresh-permissions');
+	if (
+		permission.value.fields?.includes('*') &&
+		Object.keys(permission.value.permissions || {}).length === 0 &&
+		Object.keys(permission.value.validation || {}).length === 0
+	) {
+		return 'all';
+	}
 
-		const appMinimalLevel = computed(() => {
-			if (props.appMinimal === false) return null;
-			if (Object.keys(props.appMinimal).length === 2) return 'full';
-			return 'partial';
-		});
-
-		return { t, permissionLevel, saving, setFullAccess, setNoAccess, openPermissions, appMinimalLevel };
-
-		async function openPermissions() {
-			// If this collection isn't "managed" yet, make sure to add it to directus_collections first
-			// before trying to associate any permissions with it
-			if (props.collection.meta === null) {
-				await api.patch(`/collections/${props.collection.collection}`, {
-					meta: {},
-				});
-			}
-
-			if (permission.value) {
-				router.push(`/settings/roles/${props.role || 'public'}/${permission.value.id}`);
-			} else {
-				saving.value = true;
-
-				const permResponse = await api.post('/permissions', {
-					role: resolvedRoleId.value,
-					collection: props.collection.collection,
-					action: props.action,
-				});
-
-				await refresh?.();
-
-				saving.value = false;
-				router.push(`/settings/roles/${props.role || 'public'}/${permResponse.data.data.id}`);
-			}
-		}
-	},
+	return 'custom';
 });
+
+const saving = ref(false);
+
+const refresh = inject<() => Promise<void>>('refresh-permissions');
+
+const appMinimalLevel = computed(() => {
+	if (!props.appMinimal) return null;
+	if (Object.keys(props.appMinimal).length === 2) return 'full';
+	return 'partial';
+});
+
+async function openPermissions() {
+	// If this collection isn't "managed" yet, make sure to add it to directus_collections first
+	// before trying to associate any permissions with it
+	if (props.collection.meta === null) {
+		await api.patch(`/collections/${props.collection.collection}`, {
+			meta: {},
+		});
+	}
+
+	if (permission.value) {
+		router.push(`/settings/roles/${props.role || 'public'}/${permission.value.id}`);
+	} else {
+		saving.value = true;
+
+		const permResponse = await api.post('/permissions', {
+			role: resolvedRoleId.value,
+			collection: props.collection.collection,
+			action: props.action,
+		});
+
+		await refresh?.();
+
+		saving.value = false;
+		router.push(`/settings/roles/${props.role || 'public'}/${permResponse.data.data.id}`);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview.vue
@@ -62,168 +62,138 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed, ref, provide, watch } from 'vue';
+<script setup lang="ts">
+import api from '@/api';
 import { useCollectionsStore } from '@/stores/collections';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+import { Permission } from '@cairncms/types';
+import { orderBy } from 'lodash';
+import { computed, provide, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { appMinimalPermissions, appRecommendedPermissions } from '../../app-permissions';
 import PermissionsOverviewHeader from './permissions-overview-header.vue';
 import PermissionsOverviewRow from './permissions-overview-row.vue';
-import { Permission } from '@cairncms/types';
-import { PUBLIC_ROLE_ID } from '@cairncms/constants';
-import api from '@/api';
-import { appRecommendedPermissions, appMinimalPermissions } from '../../app-permissions';
-import { unexpectedError } from '@/utils/unexpected-error';
-import { orderBy } from 'lodash';
 
-export default defineComponent({
-	components: { PermissionsOverviewHeader, PermissionsOverviewRow },
-	props: {
-		role: {
-			type: String,
-			default: null,
-		},
-		permission: {
-			// the permission row primary key in case we're on the permission detail modal view
-			type: String,
-			default: null,
-		},
-		appAccess: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	role?: string;
+	// the permission row primary key in case we're on the permission detail modal view
+	permission?: string;
+	appAccess?: boolean;
+}>();
 
-		const collectionsStore = useCollectionsStore();
+const { t } = useI18n();
 
-		const regularCollections = computed(() => collectionsStore.databaseCollections);
+const resolvedRoleId = computed(() => (props.role === 'public' ? PUBLIC_ROLE_ID : props.role));
 
-		const systemCollections = computed(() =>
-			orderBy(
-				collectionsStore.collections.filter((collection) => collection.collection.startsWith('directus_') === true),
-				'name'
-			)
-		);
+const collectionsStore = useCollectionsStore();
 
-		const systemVisible = ref(false);
+const regularCollections = computed(() => collectionsStore.databaseCollections);
 
-		const resolvedRoleId = computed(() => (props.role === 'public' ? PUBLIC_ROLE_ID : props.role));
+const systemCollections = computed(() =>
+	orderBy(
+		collectionsStore.collections.filter((collection) => collection.collection.startsWith('directus_') === true),
+		'name'
+	)
+);
 
-		const { permissions, loading, fetchPermissions, refreshPermission, refreshing } = usePermissions();
+const systemVisible = ref(false);
 
-		const { resetActive, resetSystemPermissions, resetting, resetError } = useReset();
+const { permissions, fetchPermissions, refreshing } = usePermissions();
 
-		fetchPermissions();
+const { resetActive, resetSystemPermissions, resetting } = useReset();
 
-		watch(() => props.permission, fetchPermissions, { immediate: true });
+fetchPermissions();
 
-		provide('refresh-permissions', fetchPermissions);
+watch(() => props.permission, fetchPermissions, { immediate: true });
 
-		return {
-			t,
-			systemVisible,
-			regularCollections,
-			systemCollections,
-			permissions,
-			loading,
-			fetchPermissions,
-			refreshPermission,
-			refreshing,
-			resetActive,
-			resetSystemPermissions,
-			resetting,
-			resetError,
-			appMinimalPermissions,
-		};
+provide('refresh-permissions', fetchPermissions);
 
-		function usePermissions() {
-			const permissions = ref<Permission[]>([]);
-			const loading = ref(false);
-			const refreshing = ref<number[]>([]);
+function usePermissions() {
+	const permissions = ref<Permission[]>([]);
+	const loading = ref(false);
+	const refreshing = ref<number[]>([]);
 
-			return { permissions, loading, fetchPermissions, refreshPermission, refreshing };
+	return { permissions, loading, fetchPermissions, refreshPermission, refreshing };
 
-			async function fetchPermissions() {
-				loading.value = true;
+	async function fetchPermissions() {
+		loading.value = true;
 
-				try {
-					const params: any = {
-						filter: { role: { _eq: resolvedRoleId.value } },
-						limit: -1,
-					};
+		try {
+			const params: any = {
+				filter: { role: { _eq: resolvedRoleId.value } },
+				limit: -1,
+			};
 
-					const response = await api.get('/permissions', { params });
+			const response = await api.get('/permissions', { params });
 
-					permissions.value = response.data.data;
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					loading.value = false;
-				}
-			}
+			permissions.value = response.data.data;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			loading.value = false;
+		}
+	}
 
-			async function refreshPermission(id: number) {
-				if (refreshing.value.includes(id) === false) {
-					refreshing.value.push(id);
-				}
-
-				try {
-					const response = await api.get(`/permissions/${id}`);
-
-					permissions.value = permissions.value.map((permission) => {
-						if (permission.id === id) return response.data.data;
-						return permission;
-					});
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					refreshing.value = refreshing.value.filter((inProgressID) => inProgressID !== id);
-				}
-			}
+	async function refreshPermission(id: number) {
+		if (refreshing.value.includes(id) === false) {
+			refreshing.value.push(id);
 		}
 
-		function useReset() {
-			const resetActive = ref<string | boolean>(false);
-			const resetting = ref(false);
-			const resetError = ref<any>(null);
+		try {
+			const response = await api.get(`/permissions/${id}`);
 
-			return { resetActive, resetSystemPermissions, resetting, resetError };
-
-			async function resetSystemPermissions(useRecommended: boolean) {
-				resetting.value = true;
-
-				const toBeDeleted = permissions.value
-					.filter((permission) => permission.collection.startsWith('directus_'))
-					.map((permission) => permission.id);
-
-				try {
-					if (toBeDeleted.length > 0) {
-						await api.delete(`/permissions`, { data: toBeDeleted });
-					}
-
-					if (props.role !== null && props.appAccess === true && useRecommended === true) {
-						await api.post(
-							'/permissions',
-							appRecommendedPermissions.map((permission) => ({
-								...permission,
-								role: resolvedRoleId.value,
-							}))
-						);
-					}
-
-					await fetchPermissions();
-
-					resetActive.value = false;
-				} catch (err: any) {
-					resetError.value = err;
-				} finally {
-					resetting.value = false;
-				}
-			}
+			permissions.value = permissions.value.map((permission) => {
+				if (permission.id === id) return response.data.data;
+				return permission;
+			});
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			refreshing.value = refreshing.value.filter((inProgressID) => inProgressID !== id);
 		}
-	},
-});
+	}
+}
+
+function useReset() {
+	const resetActive = ref<string | boolean>(false);
+	const resetting = ref(false);
+	const resetError = ref<any>(null);
+
+	return { resetActive, resetSystemPermissions, resetting, resetError };
+
+	async function resetSystemPermissions(useRecommended: boolean) {
+		resetting.value = true;
+
+		const toBeDeleted = permissions.value
+			.filter((permission) => permission.collection.startsWith('directus_'))
+			.map((permission) => permission.id);
+
+		try {
+			if (toBeDeleted.length > 0) {
+				await api.delete(`/permissions`, { data: toBeDeleted });
+			}
+
+			if (props.role !== null && props.appAccess === true && useRecommended === true) {
+				await api.post(
+					'/permissions',
+					appRecommendedPermissions.map((permission) => ({
+						...permission,
+						role: resolvedRoleId.value,
+					}))
+				);
+			}
+
+			await fetchPermissions();
+
+			resetActive.value = false;
+		} catch (err: any) {
+			resetError.value = err;
+		} finally {
+			resetting.value = false;
+		}
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/actions.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/actions.vue
@@ -6,56 +6,46 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref } from 'vue';
-import { Permission } from '@cairncms/types';
+<script setup lang="ts">
 import api from '@/api';
-import { useRouter } from 'vue-router';
-import { unexpectedError } from '@/utils/unexpected-error';
 import { isPermissionEmpty } from '@/utils/is-permission-empty';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { Permission } from '@cairncms/types';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
-export default defineComponent({
-	props: {
-		roleKey: {
-			type: String,
-			default: null,
-		},
-		permission: {
-			type: Object as PropType<Permission>,
-			required: true,
-		},
-	},
-	emits: ['refresh'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	permission: Permission;
+	roleKey?: string;
+}>();
 
-		const router = useRouter();
+const emit = defineEmits(['refresh']);
 
-		const loading = ref(false);
+const { t } = useI18n();
 
-		return { t, save, loading };
+const router = useRouter();
 
-		async function save() {
-			loading.value = true;
+const loading = ref(false);
 
-			try {
-				if (isPermissionEmpty(props.permission)) {
-					await api.delete(`/permissions/${props.permission.id}`);
-				} else {
-					await api.patch(`/permissions/${props.permission.id}`, props.permission);
-				}
+async function save() {
+	loading.value = true;
 
-				emit('refresh');
-				router.push(`/settings/roles/${props.roleKey || 'public'}`);
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
+	try {
+		if (isPermissionEmpty(props.permission)) {
+			await api.delete(`/permissions/${props.permission.id}`);
+		} else {
+			await api.patch(`/permissions/${props.permission.id}`, props.permission);
 		}
-	},
-});
+
+		emit('refresh');
+		router.push(`/settings/roles/${props.roleKey || 'public'}`);
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/fields.vue
@@ -25,74 +25,60 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Permission, Role } from '@cairncms/types';
-import { Field } from '@cairncms/types';
-import { useSync } from '@cairncms/composables';
+<script setup lang="ts">
 import { useFieldsStore } from '@/stores/fields';
+import { useSync } from '@cairncms/composables';
+import { Field, Permission, Role } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		permission: {
-			type: Object as PropType<Permission>,
-			required: true,
-		},
-		role: {
-			type: Object as PropType<Role>,
-			default: null,
-		},
-		appMinimal: {
-			type: Object as PropType<Partial<Permission>>,
-			default: undefined,
-		},
+const props = defineProps<{
+	permission: Permission;
+	role?: Role;
+	appMinimal?: Partial<Permission>;
+}>();
+
+const emit = defineEmits(['update:permission']);
+
+const { t } = useI18n();
+
+const fieldsStore = useFieldsStore();
+
+const internalPermission = useSync(props, 'permission', emit);
+
+const fieldsInCollection = computed(() => {
+	const fields = fieldsStore.getFieldsForCollectionSorted(props.permission.collection);
+
+	return fields.map((field: Field) => {
+		return {
+			text: field.name,
+			value: field.field,
+		};
+	});
+});
+
+const fields = computed({
+	get() {
+		if (!internalPermission.value.fields) return [];
+
+		if (internalPermission.value.fields.includes('*')) {
+			return fieldsInCollection.value.map(({ value }: { value: string }) => value);
+		}
+
+		return internalPermission.value.fields;
 	},
-	emits: ['update:permission'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const fieldsStore = useFieldsStore();
-
-		const internalPermission = useSync(props, 'permission', emit);
-
-		const fieldsInCollection = computed(() => {
-			const fields = fieldsStore.getFieldsForCollectionSorted(props.permission.collection);
-
-			return fields.map((field: Field) => {
-				return {
-					text: field.name,
-					value: field.field,
-				};
-			});
-		});
-
-		const fields = computed({
-			get() {
-				if (!internalPermission.value.fields) return [];
-
-				if (internalPermission.value.fields.includes('*')) {
-					return fieldsInCollection.value.map(({ value }: { value: string }) => value);
-				}
-
-				return internalPermission.value.fields;
-			},
-			set(newFields: string[] | null) {
-				if (newFields && newFields.length > 0) {
-					internalPermission.value = {
-						...internalPermission.value,
-						fields: newFields,
-					};
-				} else {
-					internalPermission.value = {
-						...internalPermission.value,
-						fields: null,
-					};
-				}
-			},
-		});
-
-		return { t, fields, fieldsInCollection };
+	set(newFields: string[] | null) {
+		if (newFields && newFields.length > 0) {
+			internalPermission.value = {
+				...internalPermission.value,
+				fields: newFields,
+			};
+		} else {
+			internalPermission.value = {
+				...internalPermission.value,
+				fields: null,
+			};
+		}
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/permissions.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/permissions.vue
@@ -19,50 +19,37 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Permission, Role } from '@cairncms/types';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
+import { Permission, Role } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		permission: {
-			type: Object as PropType<Permission>,
-			required: true,
-		},
-		role: {
-			type: Object as PropType<Role>,
-			default: null,
-		},
-		appMinimal: {
-			type: Object as PropType<Partial<Permission>>,
-			default: undefined,
-		},
-	},
-	emits: ['update:permission'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	permission: Permission;
+	role?: Role;
+	appMinimal?: Partial<Permission>;
+}>();
 
-		const permissionSync = useSync(props, 'permission', emit);
+const emit = defineEmits(['update:permission']);
 
-		const fields = computed(() => [
-			{
-				field: 'permissions',
-				name: t('rule'),
-				type: 'json',
-				meta: {
-					interface: 'system-filter',
-					options: {
-						collectionName: permissionSync.value.collection,
-					},
-				},
+const { t } = useI18n();
+
+const permissionSync = useSync(props, 'permission', emit);
+
+const fields = computed(() => [
+	{
+		field: 'permissions',
+		name: t('rule'),
+		type: 'json',
+		meta: {
+			interface: 'system-filter',
+			options: {
+				collectionName: permissionSync.value.collection,
 			},
-		]);
-
-		return { t, fields, permissionSync };
+		},
 	},
-});
+]);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/presets.test.ts
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/presets.test.ts
@@ -1,0 +1,74 @@
+import { i18n } from '@/lang';
+import { useRelationsStore } from '@/stores/relations';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Presets from './presets.vue';
+
+const stubs = {
+	'v-notice': { props: ['type'], template: '<div class="v-notice" :data-type="type"><slot /></div>' },
+	'interface-input-code': true,
+};
+
+function mountPresets(presets: Record<string, any> | null) {
+	return mount(Presets, {
+		props: {
+			permission: { collection: 'articles', action: 'create', presets } as any,
+		},
+		global: {
+			plugins: [i18n],
+			stubs,
+		},
+	});
+}
+
+describe('Role preset editor relational-field warnings', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }));
+
+		// articles has two relational O2M fields, comments and tags
+		useRelationsStore().getRelationsForCollection = vi.fn(
+			() => [{ meta: { one_field: 'comments' } }, { meta: { one_field: 'tags' } }] as any
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function warnings(wrapper: ReturnType<typeof mountPresets>) {
+		return wrapper.findAll('.v-notice[data-type="warning"]');
+	}
+
+	it('warns for a relational field whose preset uses non-empty array syntax', () => {
+		const wrapper = mountPresets({ comments: [1, 2] });
+
+		expect(warnings(wrapper)).toHaveLength(1);
+		expect(warnings(wrapper)[0]!.text()).toContain('comments');
+	});
+
+	it('does not warn for a relational field configured with detailed object syntax', () => {
+		const wrapper = mountPresets({ tags: { create: [], update: [], delete: [] } });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('does not warn for a relational field whose preset is an empty array', () => {
+		const wrapper = mountPresets({ comments: [] });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('does not warn for a non-relational field', () => {
+		const wrapper = mountPresets({ title: 'Hello' });
+
+		expect(warnings(wrapper)).toHaveLength(0);
+	});
+
+	it('warns only for the relational fields among a mix of preset fields', () => {
+		const wrapper = mountPresets({ comments: [1], tags: [2], title: 'Hello' });
+
+		expect(warnings(wrapper)).toHaveLength(2);
+	});
+});

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
@@ -8,18 +8,26 @@
 				})
 			}}
 		</v-notice>
+		<v-notice v-for="field in fieldWarnings" :key="field" type="warning">
+			{{
+				t('presets_field_warning', {
+					field,
+				})
+			}}
+		</v-notice>
 		<interface-input-code :value="presets" language="json" type="json" @input="presets = $event" />
 	</div>
 </template>
 
 <script setup lang="ts">
+import { useRelationsStore } from '@/stores/relations';
 import { useSync } from '@cairncms/composables';
 import { Permission, Role } from '@cairncms/types';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	permission?: Permission;
+	permission: Permission;
 	role?: Role;
 }>();
 
@@ -39,6 +47,36 @@ const presets = computed({
 			presets: newPresets,
 		};
 	},
+});
+
+const relationsStore = useRelationsStore();
+const relations = relationsStore.getRelationsForCollection(props.permission.collection);
+/**
+ * Display a warning for all relational fields if an array is used as the preset value.
+ * Interfaces in the app that use the useRelationMultiple composable expect the detailed syntax and not the array syntax.
+ *
+ * The useRelationMultiple composable treats arrays as an empty value and the preset would therefore not be shown in the app interface.
+ * If the app interface is used, presets for relational fields have to be entered with the detailed syntax.
+ * The api works correctly in both cases, so if the relational interface is not used in the app, the array syntax can be used as preset as well.
+ */
+// one_field is the field name that is used in the update syntax for a relational field
+const relationFields = relations.map((relation) => relation.meta?.one_field).filter((field) => field);
+
+const fieldWarnings = computed(() => {
+	const warnings: string[] = [];
+
+	if (!presets.value) {
+		return warnings;
+	}
+
+	for (const key of Object.keys(presets.value)) {
+		if (relationFields.includes(key) && Array.isArray(presets.value[key]) && presets.value[key].length > 0) {
+			// Show the warning if the relational field uses a non-empty array as preset
+			warnings.push(key);
+		}
+	}
+
+	return warnings;
 });
 </script>
 

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/presets.vue
@@ -12,42 +12,32 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Permission, Role } from '@cairncms/types';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
+import { Permission, Role } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		permission: {
-			type: Object as PropType<Permission>,
-			default: null,
-		},
-		role: {
-			type: Object as PropType<Role>,
-			default: null,
-		},
+const props = defineProps<{
+	permission?: Permission;
+	role?: Role;
+}>();
+
+const emit = defineEmits(['update:permission']);
+
+const { t } = useI18n();
+
+const internalPermission = useSync(props, 'permission', emit);
+
+const presets = computed({
+	get() {
+		return internalPermission.value.presets;
 	},
-	emits: ['update:permission'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const internalPermission = useSync(props, 'permission', emit);
-
-		const presets = computed({
-			get() {
-				return internalPermission.value.presets;
-			},
-			set(newPresets: Record<string, any> | null) {
-				internalPermission.value = {
-					...internalPermission.value,
-					presets: newPresets,
-				};
-			},
-		});
-
-		return { t, presets };
+	set(newPresets: Record<string, any> | null) {
+		internalPermission.value = {
+			...internalPermission.value,
+			presets: newPresets,
+		};
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/tabs.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/tabs.vue
@@ -7,28 +7,17 @@
 	</v-tabs>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
 
-export default defineComponent({
-	props: {
-		currentTab: {
-			type: Array,
-			default: null,
-		},
-		tabs: {
-			type: Array,
-			required: true,
-		},
-	},
-	emits: ['update:currentTab'],
-	setup(props, { emit }) {
-		const internalCurrentTab = useSync(props, 'currentTab', emit);
+const props = defineProps<{
+	tabs: [];
+	currentTab?: [];
+}>();
 
-		return { internalCurrentTab };
-	},
-});
+const emit = defineEmits(['update:currentTab']);
+
+const internalCurrentTab = useSync(props, 'currentTab', emit);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/components/validation.vue
@@ -13,48 +13,38 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Permission, Role } from '@cairncms/types';
+<script setup lang="ts">
 import { useSync } from '@cairncms/composables';
+import { Permission, Role } from '@cairncms/types';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		permission: {
-			type: Object as PropType<Permission>,
-			required: true,
-		},
-		role: {
-			type: Object as PropType<Role>,
-			default: null,
-		},
-	},
-	emits: ['update:permission'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	permission: Permission;
+	role?: Role;
+}>();
 
-		const permissionSync = useSync(props, 'permission', emit);
+const emit = defineEmits(['update:permission']);
 
-		const fields = computed(() => [
-			{
-				field: 'validation',
-				name: t('rule'),
-				type: 'json',
-				meta: {
-					interface: 'system-filter',
-					options: {
-						collectionName: permissionSync.value.collection,
-						includeValidation: true,
-						includeRelations: false,
-					},
-				},
+const { t } = useI18n();
+
+const permissionSync = useSync(props, 'permission', emit);
+
+const fields = computed(() => [
+	{
+		field: 'validation',
+		name: t('rule'),
+		type: 'json',
+		meta: {
+			interface: 'system-filter',
+			options: {
+				collectionName: permissionSync.value.collection,
+				includeValidation: true,
+				includeRelations: false,
 			},
-		]);
-
-		return { t, permissionSync, fields };
+		},
 	},
-});
+]);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
@@ -8,7 +8,7 @@
 		@cancel="close"
 	>
 		<template v-if="!loading" #sidebar>
-			<tabs v-model:current-tab="currentTab" :tabs="tabs" />
+			<tabs v-model:current-tab="currentTab" :tabs="tabsValue" />
 		</template>
 
 		<div v-if="!loading" class="content">
@@ -44,177 +44,164 @@
 	</v-drawer>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, watch } from 'vue';
+<script setup lang="ts">
 import api from '@/api';
-import { Permission, Role } from '@cairncms/types';
-import { useCollectionsStore } from '@/stores/collections';
-import { useRouter } from 'vue-router';
-import Actions from './components/actions.vue';
-import Tabs from './components/tabs.vue';
-
-import Permissions from './components/permissions.vue';
-import Fields from './components/fields.vue';
-import Validation from './components/validation.vue';
-import Presets from './components/presets.vue';
-import { unexpectedError } from '@/utils/unexpected-error';
-import { appMinimalPermissions } from '../app-permissions';
 import { useDialogRoute } from '@/composables/use-dialog-route';
+import { useCollectionsStore } from '@/stores/collections';
 import { isPermissionEmpty } from '@/utils/is-permission-empty';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { Permission, Role } from '@cairncms/types';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { appMinimalPermissions } from '../app-permissions';
+import Actions from './components/actions.vue';
+import Fields from './components/fields.vue';
+import Permissions from './components/permissions.vue';
+import Presets from './components/presets.vue';
+import Tabs from './components/tabs.vue';
+import Validation from './components/validation.vue';
 
-export default defineComponent({
-	components: { Actions, Tabs, Permissions, Fields, Validation, Presets },
-	props: {
-		roleKey: {
-			type: String,
-			default: null,
-		},
-		permissionKey: {
-			type: String,
-			required: true,
-		},
-	},
-	emits: ['refresh'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	permissionKey: string;
+	roleKey?: string;
+}>();
 
-		const router = useRouter();
+defineEmits(['refresh']);
 
-		const collectionsStore = useCollectionsStore();
+const { t } = useI18n();
 
-		const isOpen = useDialogRoute();
+const router = useRouter();
 
-		const permission = ref<Permission>();
-		const role = ref<Role>();
-		const loading = ref(false);
+const collectionsStore = useCollectionsStore();
 
-		const collectionName = computed(() => {
-			if (!permission.value) return null;
-			return collectionsStore.collections.find((collection) => collection.collection === permission.value!.collection)
-				?.name;
-		});
+const isOpen = useDialogRoute();
 
-		const isSentinel = computed(() => props.roleKey === 'public');
+const permission = ref<Permission>();
+const role = ref<Role>();
+const loading = ref(false);
 
-		const modalTitle = computed(() => {
-			if (loading.value || !permission.value) return t('loading');
-
-			if (props.roleKey && !isSentinel.value) {
-				return role.value!.name + ' -> ' + collectionName.value + ' -> ' + t(permission.value.action);
-			}
-
-			return t('public_label') + ' -> ' + collectionName.value + ' -> ' + t(permission.value.action);
-		});
-
-		watch(() => props.permissionKey, load, { immediate: true });
-
-		const tabs = computed(() => {
-			if (!permission.value) return [];
-
-			const action = permission.value.action;
-
-			const tabs = [];
-
-			if (['read', 'update', 'delete', 'share'].includes(action)) {
-				tabs.push({
-					text: t('item_permissions'),
-					value: 'permissions',
-					hasValue: permission.value.permissions !== null && Object.keys(permission.value.permissions).length > 0,
-				});
-			}
-
-			if (['create', 'read', 'update'].includes(action)) {
-				tabs.push({
-					text: t('field_permissions'),
-					value: 'fields',
-					hasValue: permission.value.fields !== null,
-				});
-			}
-
-			if (['create', 'update'].includes(action)) {
-				tabs.push({
-					text: t('field_validation'),
-					value: 'validation',
-					hasValue: permission.value.validation !== null && Object.keys(permission.value.validation).length > 0,
-				});
-			}
-
-			if (['create', 'update'].includes(action)) {
-				tabs.push({
-					text: t('field_presets'),
-					value: 'presets',
-					hasValue: permission.value.presets !== null && Object.keys(permission.value.presets).length > 0,
-				});
-			}
-
-			return tabs;
-		});
-
-		const currentTab = ref<string[]>([]);
-
-		const currentTabInfo = computed(() => {
-			const tabKey = currentTab.value?.[0];
-			if (!tabKey) return null;
-			return tabs.value.find((tab) => tab.value === tabKey);
-		});
-
-		watch(
-			tabs,
-			(newTabs, oldTabs) => {
-				if (newTabs && oldTabs && newTabs.length === oldTabs.length) return;
-				currentTab.value = [tabs?.value?.[0]?.value];
-			},
-			{ immediate: true }
-		);
-
-		const appMinimal = computed(() => {
-			if (!permission.value) return null;
-			return appMinimalPermissions.find(
-				(p: Partial<Permission>) =>
-					p.collection === permission.value!.collection && p.action === permission.value!.action
-			);
-		});
-
-		return { isOpen, permission, role, loading, modalTitle, tabs, currentTab, currentTabInfo, appMinimal, close };
-
-		async function close() {
-			if (permission.value && isPermissionEmpty(permission.value)) {
-				await api.delete(`/permissions/${permission.value.id}`);
-				router.replace(`/settings/roles/${props.roleKey || 'public'}`);
-			} else {
-				router.push(`/settings/roles/${props.roleKey || 'public'}`);
-			}
-		}
-
-		async function load() {
-			loading.value = true;
-
-			try {
-				if (props.roleKey && !isSentinel.value) {
-					const response = await api.get(`/roles/${props.roleKey}`, {
-						params: {
-							deep: { users: { _limit: 0 } },
-						},
-					});
-
-					role.value = response.data.data;
-				}
-
-				const response = await api.get(`/permissions/${props.permissionKey}`);
-				permission.value = response.data.data;
-			} catch (err: any) {
-				if (err?.response?.status === 403) {
-					router.push(`/settings/roles/${props.roleKey || 'public'}`);
-				} else {
-					unexpectedError(err);
-				}
-			} finally {
-				loading.value = false;
-			}
-		}
-	},
+const collectionName = computed(() => {
+	if (!permission.value) return null;
+	return collectionsStore.collections.find((collection) => collection.collection === permission.value!.collection)
+		?.name;
 });
+
+const isSentinel = computed(() => props.roleKey === 'public');
+
+const modalTitle = computed(() => {
+	if (loading.value || !permission.value) return t('loading');
+
+	if (props.roleKey && !isSentinel.value) {
+		return role.value!.name + ' -> ' + collectionName.value + ' -> ' + t(permission.value.action);
+	}
+
+	return t('public_label') + ' -> ' + collectionName.value + ' -> ' + t(permission.value.action);
+});
+
+watch(() => props.permissionKey, load, { immediate: true });
+
+const tabsValue = computed(() => {
+	if (!permission.value) return [];
+
+	const action = permission.value.action;
+
+	const tabs = [];
+
+	if (['read', 'update', 'delete', 'share'].includes(action)) {
+		tabs.push({
+			text: t('item_permissions'),
+			value: 'permissions',
+			hasValue: permission.value.permissions !== null && Object.keys(permission.value.permissions).length > 0,
+		});
+	}
+
+	if (['create', 'read', 'update'].includes(action)) {
+		tabs.push({
+			text: t('field_permissions'),
+			value: 'fields',
+			hasValue: permission.value.fields !== null,
+		});
+	}
+
+	if (['create', 'update'].includes(action)) {
+		tabs.push({
+			text: t('field_validation'),
+			value: 'validation',
+			hasValue: permission.value.validation !== null && Object.keys(permission.value.validation).length > 0,
+		});
+	}
+
+	if (['create', 'update'].includes(action)) {
+		tabs.push({
+			text: t('field_presets'),
+			value: 'presets',
+			hasValue: permission.value.presets !== null && Object.keys(permission.value.presets).length > 0,
+		});
+	}
+
+	return tabs;
+});
+
+const currentTab = ref<string[]>([]);
+
+const currentTabInfo = computed(() => {
+	const tabKey = currentTab.value?.[0];
+	if (!tabKey) return null;
+	return tabsValue.value.find((tab) => tab.value === tabKey);
+});
+
+watch(
+	tabsValue,
+	(newTabs, oldTabs) => {
+		if (newTabs && oldTabs && newTabs.length === oldTabs.length) return;
+		currentTab.value = [tabsValue?.value?.[0]?.value];
+	},
+	{ immediate: true }
+);
+
+const appMinimal = computed(() => {
+	if (!permission.value) return null;
+	return appMinimalPermissions.find(
+		(p: Partial<Permission>) => p.collection === permission.value!.collection && p.action === permission.value!.action
+	);
+});
+
+async function close() {
+	if (permission.value && isPermissionEmpty(permission.value)) {
+		await api.delete(`/permissions/${permission.value.id}`);
+		router.replace(`/settings/roles/${props.roleKey || 'public'}`);
+	} else {
+		router.push(`/settings/roles/${props.roleKey || 'public'}`);
+	}
+}
+
+async function load() {
+	loading.value = true;
+
+	try {
+		if (props.roleKey && !isSentinel.value) {
+			const response = await api.get(`/roles/${props.roleKey}`, {
+				params: {
+					deep: { users: { _limit: 0 } },
+				},
+			});
+
+			role.value = response.data.data;
+		}
+
+		const response = await api.get(`/permissions/${props.permissionKey}`);
+		permission.value = response.data.data;
+	} catch (err: any) {
+		if (err?.response?.status === 403) {
+			router.push(`/settings/roles/${props.roleKey || 'public'}`);
+		} else {
+			unexpectedError(err);
+		}
+	} finally {
+		loading.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -21,28 +21,17 @@
 	</private-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
-
 import SettingsNavigation from '../../components/navigation.vue';
 import PermissionsOverview from './item/components/permissions-overview.vue';
 import RoleInfoSidebarDetail from './item/components/role-info-sidebar-detail.vue';
 
-export default defineComponent({
-	name: 'RolesItem',
-	components: { SettingsNavigation, PermissionsOverview, RoleInfoSidebarDetail },
-	props: {
-		permissionKey: {
-			type: String,
-			default: null,
-		},
-	},
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+defineProps<{
+	permissionKey?: string;
+}>();
+
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/users/components/navigation-role.vue
+++ b/app/src/modules/users/components/navigation-role.vue
@@ -18,38 +18,27 @@
 	</v-list-item>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, defineComponent, PropType } from 'vue';
+<script setup lang="ts">
 import { useUserStore } from '@/stores/user';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { BasicRole } from '../composables/use-navigation';
 
-export default defineComponent({
-	props: {
-		role: {
-			type: Object as PropType<BasicRole>,
-			required: true,
-		},
-		lastAdmin: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	role: BasicRole;
+	lastAdmin: boolean;
+}>();
 
-		const { isAdmin } = useUserStore();
+const { t } = useI18n();
 
-		const settingLink = computed(() => {
-			return props.role.id !== 'public' && props.lastAdmin
-				? {
-						name: 'settings-roles-item',
-						params: { primaryKey: props.role.id, lastAdminRoleId: props.role.id },
-				  }
-				: `/settings/roles/${props.role.id}`;
-		});
+const { isAdmin } = useUserStore();
 
-		return { t, isAdmin, settingLink };
-	},
+const settingLink = computed(() => {
+	return props.role.id !== 'public' && props.lastAdmin
+		? {
+				name: 'settings-roles-item',
+				params: { primaryKey: props.role.id, lastAdminRoleId: props.role.id },
+		  }
+		: `/settings/roles/${props.role.id}`;
 });
 </script>

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -23,38 +23,36 @@
 	</v-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { computed, defineComponent } from 'vue';
-
 import useNavigation from '../composables/use-navigation';
 import NavigationRole from './navigation-role.vue';
 
-export default defineComponent({
-	components: { NavigationRole },
-	props: {
-		currentRole: {
-			type: String,
-			default: null,
-		},
-	},
-	setup() {
-		const { t } = useI18n();
+defineProps<{
+	currentRole?: string;
+}>();
 
-		const { roles, loading } = useNavigation();
+const { t } = useI18n();
 
-		const lastAdminRoleId = computed(() => {
-			if (!roles.value) return null;
-			const adminRoles = roles.value.filter((role) => role.admin_access === true);
-			return adminRoles.length === 1 ? adminRoles[0].id : null;
-		});
+const { roles, loading } = useNavigation();
 
-		return { t, roles, loading, lastAdminRoleId };
-	},
+const lastAdminRoleId = computed(() => {
+	if (!roles.value) return null;
+	const adminRoles = roles.value.filter((role) => role.admin_access === true);
+	return adminRoles.length === 1 ? adminRoles[0].id : null;
 });
 </script>
 
 <style lang="scss" scoped>
+.v-skeleton-loader {
+	--v-skeleton-loader-background-color: var(--background-normal-alt);
+}
+
+.v-divider {
+	--v-divider-color: var(--background-normal-alt);
+}
+
 .users-navigation {
 	--v-list-item-active-rule-width: 2px;
 	--v-list-item-active-rule-color: var(--primary);
@@ -63,13 +61,5 @@ export default defineComponent({
 	:deep(.v-list-item.active) {
 		--v-list-item-icon-color: var(--primary);
 	}
-}
-
-.v-skeleton-loader {
-	--v-skeleton-loader-background-color: var(--background-normal-alt);
-}
-
-.v-divider {
-	--v-divider-color: var(--background-normal-alt);
 }
 </style>

--- a/app/src/modules/users/components/user-info-sidebar-detail.vue
+++ b/app/src/modules/users/components/user-info-sidebar-detail.vue
@@ -43,45 +43,34 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch } from 'vue';
-import { localizedFormat } from '@/utils/localized-format';
+<script setup lang="ts">
 import { useClipboard } from '@/composables/use-clipboard';
+import { localizedFormat } from '@/utils/localized-format';
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		user: {
-			type: Object,
-			default: null,
-		},
-		isNew: {
-			type: Boolean,
-			default: false,
-		},
+const props = defineProps<{
+	user?: Record<string, any>;
+	isNew?: boolean;
+}>();
+
+const { t } = useI18n();
+
+const { isCopySupported, copyToClipboard } = useClipboard();
+
+const lastAccessDate = ref('');
+
+watch(
+	[() => props.user, () => props.isNew],
+	async () => {
+		if (!props.user) return;
+
+		if (props.user.last_access) {
+			lastAccessDate.value = localizedFormat(new Date(props.user.last_access), String(t('date-fns_date_short')));
+		}
 	},
-	setup(props) {
-		const { t } = useI18n();
-
-		const { isCopySupported, copyToClipboard } = useClipboard();
-
-		const lastAccessDate = ref('');
-
-		watch(
-			[() => props.user, () => props.isNew],
-			async () => {
-				if (!props.user) return;
-
-				if (props.user.last_access) {
-					lastAccessDate.value = localizedFormat(new Date(props.user.last_access), String(t('date-fns_date_short')));
-				}
-			},
-			{ immediate: true }
-		);
-
-		return { t, lastAccessDate, isCopySupported, copyToClipboard };
-	},
-});
+	{ immediate: true }
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -181,10 +181,7 @@
 	</private-view>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, ref, toRefs, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-
+<script setup lang="ts">
 import api from '@/api';
 import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useFormFields } from '@/composables/use-form-fields';
@@ -192,10 +189,10 @@ import { useItem } from '@/composables/use-item';
 import { usePermissions } from '@/composables/use-permissions';
 import { useShortcut } from '@/composables/use-shortcut';
 import { setLanguage } from '@/lang/set-language';
-import { useUserStore } from '@/stores/user';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useServerStore } from '@/stores/server';
+import { useUserStore } from '@/stores/user';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
@@ -203,327 +200,269 @@ import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-d
 import SaveOptions from '@/views/private/components/save-options.vue';
 import { useCollection } from '@cairncms/composables';
 import { Field } from '@cairncms/types';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
 import UserInfoSidebarDetail from '../components/user-info-sidebar-detail.vue';
 
-export default defineComponent({
-	name: 'UsersItem',
-	components: { UsersNavigation, RevisionsDrawerDetail, SaveOptions, CommentsSidebarDetail, UserInfoSidebarDetail },
-	props: {
-		primaryKey: {
-			type: String,
-			required: true,
-		},
-		role: {
-			type: String,
-			default: null,
-		},
-	},
-	setup(props) {
-		const { t, locale } = useI18n();
+const props = defineProps<{
+	primaryKey: string;
+	role?: string;
+}>();
 
-		const router = useRouter();
+const { t, locale } = useI18n();
 
-		const form = ref<HTMLElement>();
-		const fieldsStore = useFieldsStore();
-		const collectionsStore = useCollectionsStore();
-		const userStore = useUserStore();
-		const serverStore = useServerStore();
+const router = useRouter();
 
-		const { primaryKey } = toRefs(props);
-		const { breadcrumb } = useBreadcrumb();
+const form = ref<HTMLElement>();
+const fieldsStore = useFieldsStore();
+const collectionsStore = useCollectionsStore();
+const userStore = useUserStore();
+const serverStore = useServerStore();
 
-		const { info: collectionInfo } = useCollection('directus_users');
+const { primaryKey } = toRefs(props);
+const { breadcrumb } = useBreadcrumb();
 
-		const revisionsDrawerDetail = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
+const { info: collectionInfo } = useCollection('directus_users');
 
-		const {
-			isNew,
-			edits,
-			hasEdits,
-			item,
-			saving,
-			loading,
-			save,
-			remove,
-			deleting,
-			saveAsCopy,
-			isBatch,
-			archive,
-			archiving,
-			isArchived,
-			validationErrors,
-		} = useItem(ref('directus_users'), primaryKey);
+const revisionsDrawerDetail = ref<InstanceType<typeof RevisionsDrawerDetail> | null>(null);
 
-		if (props.role) {
-			edits.value = {
-				role: props.role,
-				...edits.value,
-			};
-		}
+const {
+	isNew,
+	edits,
+	hasEdits,
+	item,
+	saving,
+	loading,
+	save,
+	remove,
+	deleting,
+	saveAsCopy,
+	isBatch,
+	archive,
+	archiving,
+	isArchived,
+	validationErrors,
+} = useItem(ref('directus_users'), primaryKey);
 
-		const isSavable = computed(() => saveAllowed.value && hasEdits.value);
+if (props.role) {
+	edits.value = {
+		role: props.role,
+		...edits.value,
+	};
+}
 
-		const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
+const isSavable = computed(() => saveAllowed.value && hasEdits.value);
 
-		const confirmDelete = ref(false);
-		const confirmArchive = ref(false);
+const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 
-		const avatarError = ref(null);
+const confirmDelete = ref(false);
+const confirmArchive = ref(false);
 
-		const title = computed(() => {
-			if (loading.value === true) return t('loading');
+const avatarError = ref(null);
 
-			if (isNew.value === false && item.value) {
-				const user = item.value as any;
-				return userName(user);
-			}
+const title = computed(() => {
+	if (loading.value === true) return t('loading');
 
-			return t('adding_user');
-		});
+	if (isNew.value === false && item.value) {
+		const user = item.value as any;
+		return userName(user);
+	}
 
-		const { loading: previewLoading, avatarSrc, roleName } = useUserPreview();
-
-		const { createAllowed, deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields } =
-			usePermissions(ref('directus_users'), item, isNew);
-
-		// These fields will be shown in the sidebar instead
-		const fieldsDenyList = ['id', 'last_page', 'created_on', 'created_by', 'modified_by', 'modified_on', 'last_access'];
-
-		const fieldsFiltered = computed(() => {
-			return fields.value.filter((field: Field) => {
-				// These fields should only be editable when creating new users or by administrators
-				if (!isNew.value && ['provider', 'external_identifier'].includes(field.field) && !userStore.isAdmin) {
-					field.meta.readonly = true;
-				}
-
-				return !fieldsDenyList.includes(field.field);
-			});
-		});
-
-		const { formFields } = useFormFields(fieldsFiltered);
-
-		const archiveTooltip = computed(() => {
-			if (archiveAllowed.value === false) return t('not_allowed');
-			if (isArchived.value === true) return t('unarchive');
-			return t('archive');
-		});
-
-		useShortcut('meta+s', saveAndStay, form);
-		useShortcut('meta+shift+s', saveAndAddNew, form);
-
-		return {
-			t,
-			router,
-			title,
-			item,
-			loading,
-			isNew,
-			navigateBack,
-			breadcrumb,
-			edits,
-			hasEdits,
-			saving,
-			saveAndQuit,
-			deleteAndQuit,
-			confirmDelete,
-			deleting,
-			saveAndStay,
-			saveAndAddNew,
-			saveAsCopyAndNavigate,
-			discardAndStay,
-			isBatch,
-			revisionsDrawerDetail,
-			previewLoading,
-			avatarSrc,
-			roleName,
-			confirmLeave,
-			leaveTo,
-			discardAndLeave,
-			formFields,
-			createAllowed,
-			deleteAllowed,
-			saveAllowed,
-			archiveAllowed,
-			isArchived,
-			updateAllowed,
-			toggleArchive,
-			confirmArchive,
-			collectionInfo,
-			archiving,
-			archiveTooltip,
-			form,
-			userName,
-			revisionsAllowed,
-			validationErrors,
-			revert,
-			avatarError,
-			isSavable,
-		};
-
-		function navigateBack() {
-			const backState = router.options.history.state.back;
-
-			if (typeof backState !== 'string' || !backState.startsWith('/login')) {
-				router.back();
-				return;
-			}
-
-			router.push('/users');
-		}
-
-		function useBreadcrumb() {
-			const breadcrumb = computed(() => [
-				{
-					name: t('user_directory'),
-					to: `/users`,
-				},
-			]);
-
-			return { breadcrumb };
-		}
-
-		async function saveAndQuit() {
-			try {
-				const savedItem: Record<string, any> = await save();
-				await setLang(savedItem);
-				await refreshCurrentUser();
-				router.push(`/users`);
-			} catch {
-				// `save` will show unexpected error dialog
-			}
-		}
-
-		async function saveAndStay() {
-			try {
-				const savedItem: Record<string, any> = await save();
-				await setLang(savedItem);
-				await refreshCurrentUser();
-
-				revisionsDrawerDetail.value?.refresh?.();
-
-				if (props.primaryKey === '+') {
-					const newPrimaryKey = savedItem.id;
-					router.replace(`/users/${newPrimaryKey}`);
-				}
-			} catch {
-				// `save` will show unexpected error dialog
-			}
-		}
-
-		async function saveAndAddNew() {
-			try {
-				const savedItem: Record<string, any> = await save();
-				await setLang(savedItem);
-				await refreshCurrentUser();
-				router.push(`/users/+`);
-			} catch {
-				// `save` will show unexpected error dialog
-			}
-		}
-
-		async function saveAsCopyAndNavigate() {
-			try {
-				const newPrimaryKey = await saveAsCopy();
-				if (newPrimaryKey) router.push(`/users/${newPrimaryKey}`);
-			} catch {
-				// `save` will show unexpected error dialog
-			}
-		}
-
-		async function deleteAndQuit() {
-			try {
-				await remove();
-				edits.value = {};
-				router.replace(`/users`);
-			} catch {
-				// `remove` will show the unexpected error dialog
-			}
-		}
-
-		async function setLang(user: Record<string, any>) {
-			if (userStore.currentUser!.id !== item.value?.id) return;
-
-			const newLang = user?.language ?? serverStore.info?.project?.default_language;
-
-			if (newLang && newLang !== locale.value) {
-				await setLanguage(newLang);
-
-				await Promise.all([fieldsStore.hydrate(), collectionsStore.hydrate()]);
-			}
-		}
-
-		async function refreshCurrentUser() {
-			if (userStore.currentUser!.id === item.value?.id) {
-				await userStore.hydrate();
-			}
-		}
-
-		function useUserPreview() {
-			const loading = ref(false);
-			const avatarSrc = ref<string | null>(null);
-			const roleName = ref<string | null>(null);
-
-			watch(() => props.primaryKey, getUserPreviewData, { immediate: true });
-
-			return { loading, avatarSrc, roleName };
-
-			async function getUserPreviewData() {
-				if (props.primaryKey === '+') return;
-
-				loading.value = true;
-
-				try {
-					const response = await api.get(`/users/${props.primaryKey}`, {
-						params: {
-							fields: ['role.name', 'avatar.id'],
-						},
-					});
-
-					avatarSrc.value = response.data.data.avatar?.id
-						? `/assets/${response.data.data.avatar.id}?key=system-medium-cover`
-						: null;
-
-					roleName.value = response.data.data?.role?.name;
-				} catch (err: any) {
-					unexpectedError(err);
-				} finally {
-					loading.value = false;
-				}
-			}
-		}
-
-		function discardAndLeave() {
-			if (!leaveTo.value) return;
-			edits.value = {};
-			confirmLeave.value = false;
-			router.push(leaveTo.value);
-		}
-
-		function discardAndStay() {
-			edits.value = {};
-			confirmLeave.value = false;
-		}
-
-		async function toggleArchive() {
-			await archive();
-
-			if (isArchived.value === true) {
-				router.push('/users');
-			} else {
-				confirmArchive.value = false;
-			}
-		}
-
-		function revert(values: Record<string, any>) {
-			edits.value = {
-				...edits.value,
-				...values,
-			};
-		}
-	},
+	return t('adding_user');
 });
+
+const { loading: previewLoading, avatarSrc, roleName } = useUserPreview();
+
+const { createAllowed, deleteAllowed, archiveAllowed, saveAllowed, updateAllowed, revisionsAllowed, fields } =
+	usePermissions(ref('directus_users'), item, isNew);
+
+// These fields will be shown in the sidebar instead
+const fieldsDenyList = ['id', 'last_page', 'created_on', 'created_by', 'modified_by', 'modified_on', 'last_access'];
+
+const fieldsFiltered = computed(() => {
+	return fields.value.filter((field: Field) => {
+		// These fields should only be editable when creating new users or by administrators
+		if (!isNew.value && ['provider', 'external_identifier'].includes(field.field) && !userStore.isAdmin) {
+			field.meta.readonly = true;
+		}
+
+		return !fieldsDenyList.includes(field.field);
+	});
+});
+
+const { formFields } = useFormFields(fieldsFiltered);
+
+const archiveTooltip = computed(() => {
+	if (archiveAllowed.value === false) return t('not_allowed');
+	if (isArchived.value === true) return t('unarchive');
+	return t('archive');
+});
+
+useShortcut('meta+s', saveAndStay, form);
+useShortcut('meta+shift+s', saveAndAddNew, form);
+
+function navigateBack() {
+	const backState = router.options.history.state.back;
+
+	if (typeof backState !== 'string' || !backState.startsWith('/login')) {
+		router.back();
+		return;
+	}
+
+	router.push('/users');
+}
+
+function useBreadcrumb() {
+	const breadcrumb = computed(() => [
+		{
+			name: t('user_directory'),
+			to: `/users`,
+		},
+	]);
+
+	return { breadcrumb };
+}
+
+async function saveAndQuit() {
+	try {
+		const savedItem: Record<string, any> = await save();
+		await setLang(savedItem);
+		await refreshCurrentUser();
+		router.push(`/users`);
+	} catch {
+		// `save` will show unexpected error dialog
+	}
+}
+
+async function saveAndStay() {
+	try {
+		const savedItem: Record<string, any> = await save();
+		await setLang(savedItem);
+		await refreshCurrentUser();
+
+		revisionsDrawerDetail.value?.refresh?.();
+
+		if (props.primaryKey === '+') {
+			const newPrimaryKey = savedItem.id;
+			router.replace(`/users/${newPrimaryKey}`);
+		}
+	} catch {
+		// `save` will show unexpected error dialog
+	}
+}
+
+async function saveAndAddNew() {
+	try {
+		const savedItem: Record<string, any> = await save();
+		await setLang(savedItem);
+		await refreshCurrentUser();
+		router.push(`/users/+`);
+	} catch {
+		// `save` will show unexpected error dialog
+	}
+}
+
+async function saveAsCopyAndNavigate() {
+	try {
+		const newPrimaryKey = await saveAsCopy();
+		if (newPrimaryKey) router.push(`/users/${newPrimaryKey}`);
+	} catch {
+		// `save` will show unexpected error dialog
+	}
+}
+
+async function deleteAndQuit() {
+	try {
+		await remove();
+		edits.value = {};
+		router.replace(`/users`);
+	} catch {
+		// `remove` will show the unexpected error dialog
+	}
+}
+
+async function setLang(user: Record<string, any>) {
+	if (userStore.currentUser!.id !== item.value?.id) return;
+
+	const newLang = user?.language ?? serverStore.info?.project?.default_language;
+
+	if (newLang && newLang !== locale.value) {
+		await setLanguage(newLang);
+
+		await Promise.all([fieldsStore.hydrate(), collectionsStore.hydrate()]);
+	}
+}
+
+async function refreshCurrentUser() {
+	if (userStore.currentUser!.id === item.value?.id) {
+		await userStore.hydrate();
+	}
+}
+
+function useUserPreview() {
+	const loading = ref(false);
+	const avatarSrc = ref<string | null>(null);
+	const roleName = ref<string | null>(null);
+
+	watch(() => props.primaryKey, getUserPreviewData, { immediate: true });
+
+	return { loading, avatarSrc, roleName };
+
+	async function getUserPreviewData() {
+		if (props.primaryKey === '+') return;
+
+		loading.value = true;
+
+		try {
+			const response = await api.get(`/users/${props.primaryKey}`, {
+				params: {
+					fields: ['role.name', 'avatar.id'],
+				},
+			});
+
+			avatarSrc.value = response.data.data.avatar?.id
+				? `/assets/${response.data.data.avatar.id}?key=system-medium-cover`
+				: null;
+
+			roleName.value = response.data.data?.role?.name;
+		} catch (err: any) {
+			unexpectedError(err);
+		} finally {
+			loading.value = false;
+		}
+	}
+}
+
+function discardAndLeave() {
+	if (!leaveTo.value) return;
+	edits.value = {};
+	confirmLeave.value = false;
+	router.push(leaveTo.value);
+}
+
+function discardAndStay() {
+	edits.value = {};
+	confirmLeave.value = false;
+}
+
+async function toggleArchive() {
+	await archive();
+
+	if (isArchived.value === true) {
+		router.push('/users');
+	} else {
+		confirmArchive.value = false;
+	}
+}
+
+function revert(values: Record<string, any>) {
+	edits.value = {
+		...edits.value,
+		...values,
+	};
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -31,61 +31,55 @@
 	</public-view>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
+import api, { RequestError } from '@/api';
+import { translateAPIError } from '@/lang';
+import { jwtPayload } from '@/utils/jwt-payload';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
-import { defineComponent, computed, ref } from 'vue';
-import { translateAPIError } from '@/lang';
-import api, { RequestError } from '@/api';
-import { jwtPayload } from '@/utils/jwt-payload';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const route = useRoute();
+const route = useRoute();
 
-		const acceptToken = computed(() => route.query.token as string);
+const acceptToken = computed(() => route.query.token as string);
 
-		const password = ref(null);
+const password = ref(null);
 
-		const creating = ref(false);
-		const error = ref<RequestError | null>(null);
-		const done = ref(false);
+const creating = ref(false);
+const error = ref<RequestError | null>(null);
+const done = ref(false);
 
-		const errorFormatted = computed(() => {
-			if (error.value) {
-				return translateAPIError(error.value);
-			}
+const errorFormatted = computed(() => {
+	if (error.value) {
+		return translateAPIError(error.value);
+	}
 
-			return null;
+	return null;
+});
+
+const signInLink = computed(() => `/login`);
+
+const email = computed(() => jwtPayload(acceptToken.value).email);
+
+async function onSubmit() {
+	creating.value = true;
+	error.value = null;
+
+	try {
+		await api.post(`/users/invite/accept`, {
+			password: password.value,
+			token: acceptToken.value,
 		});
 
-		const signInLink = computed(() => `/login`);
-
-		const email = computed(() => jwtPayload(acceptToken.value).email);
-
-		return { t, creating, error, done, password, onSubmit, signInLink, errorFormatted, email };
-
-		async function onSubmit() {
-			creating.value = true;
-			error.value = null;
-
-			try {
-				await api.post(`/users/invite/accept`, {
-					password: password.value,
-					token: acceptToken.value,
-				});
-
-				done.value = true;
-			} catch (err: any) {
-				error.value = err;
-			} finally {
-				creating.value = false;
-			}
-		}
-	},
-});
+		done.value = true;
+	} catch (err: any) {
+		error.value = err;
+	} finally {
+		creating.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/login/components/continue-as.vue
+++ b/app/src/routes/login/components/continue-as.vue
@@ -15,67 +15,60 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, onMounted } from 'vue';
-
+<script lang="ts" setup>
 import api from '@/api';
-import { hydrate } from '@/hydrate';
-import { useRouter } from 'vue-router';
-import { userName } from '@/utils/user-name';
-import { unexpectedError } from '@/utils/unexpected-error';
 import { logout } from '@/auth';
+import { hydrate } from '@/hydrate';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { userName } from '@/utils/user-name';
+import { onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const router = useRouter();
+const router = useRouter();
 
-		const loading = ref(false);
-		const name = ref<string | null>(null);
-		const lastPage = ref<string | null>(null);
+const loading = ref(false);
+const name = ref<string | null>(null);
+const lastPage = ref<string | null>(null);
 
-		fetchUser();
+fetchUser();
 
-		onMounted(() => {
-			if ('continue' in router.currentRoute.value.query) {
-				hydrateAndLogin();
-			}
+onMounted(() => {
+	if ('continue' in router.currentRoute.value.query) {
+		hydrateAndLogin();
+	}
+});
+
+async function fetchUser() {
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/users/me`, {
+			params: {
+				fields: ['email', 'first_name', 'last_name', 'last_page'],
+			},
 		});
 
-		return { t, name, lastPage, loading, hydrateAndLogin };
-
-		async function fetchUser() {
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/users/me`, {
-					params: {
-						fields: ['email', 'first_name', 'last_name', 'last_page'],
-					},
-				});
-
-				if (response.data.data.share) {
-					await logout();
-				}
-
-				name.value = userName(response.data.data);
-				lastPage.value = response.data.data.last_page;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
+		if (response.data.data.share) {
+			await logout();
 		}
 
-		async function hydrateAndLogin() {
-			await hydrate();
-			const redirectQuery = router.currentRoute.value.query.redirect as string;
-			router.push(redirectQuery || lastPage.value || `/content`);
-		}
-	},
-});
+		name.value = userName(response.data.data);
+		lastPage.value = response.data.data.last_page;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function hydrateAndLogin() {
+	await hydrate();
+	const redirectQuery = router.currentRoute.value.query.redirect as string;
+	router.push(redirectQuery || lastPage.value || `/content`);
+}
 </script>
 
 <style scoped>

--- a/app/src/routes/login/components/login-form/ldap-form.vue
+++ b/app/src/routes/login/components/login-form/ldap-form.vue
@@ -14,14 +14,14 @@
 	</form>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, watch, toRefs } from 'vue';
-import { useRouter } from 'vue-router';
-import { login } from '@/auth';
+<script lang="ts" setup>
 import { RequestError } from '@/api';
+import { login } from '@/auth';
 import { translateAPIError } from '@/lang';
 import { useUserStore } from '@/stores/user';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 type Credentials = {
 	identifier: string;
@@ -29,96 +29,81 @@ type Credentials = {
 	otp?: string;
 };
 
-export default defineComponent({
-	props: {
-		provider: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	provider: string;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const { provider } = toRefs(props);
-		const loggingIn = ref(false);
-		const identifier = ref<string | null>(null);
-		const password = ref<string | null>(null);
-		const error = ref<RequestError | string | null>(null);
-		const otp = ref<string | null>(null);
-		const requiresTFA = ref(false);
-		const userStore = useUserStore();
+const router = useRouter();
 
-		watch(identifier, () => {
-			if (requiresTFA.value === true) requiresTFA.value = false;
-		});
+const { provider } = toRefs(props);
+const loggingIn = ref(false);
+const identifier = ref<string | null>(null);
+const password = ref<string | null>(null);
+const error = ref<RequestError | string | null>(null);
+const otp = ref<string | null>(null);
+const requiresTFA = ref(false);
+const userStore = useUserStore();
 
-		watch(provider, () => {
-			identifier.value = null;
-			password.value = null;
-			error.value = null;
-			otp.value = null;
-			requiresTFA.value = false;
-		});
+watch(identifier, () => {
+	if (requiresTFA.value === true) requiresTFA.value = false;
+});
 
-		const errorFormatted = computed(() => {
-			if (error.value === 'INVALID_PAYLOAD') {
-				return translateAPIError('INVALID_CREDENTIALS');
-			}
+watch(provider, () => {
+	identifier.value = null;
+	password.value = null;
+	error.value = null;
+	otp.value = null;
+	requiresTFA.value = false;
+});
 
-			if (error.value) {
-				return translateAPIError(error.value);
-			}
+const errorFormatted = computed(() => {
+	if (error.value === 'INVALID_PAYLOAD') {
+		return translateAPIError('INVALID_CREDENTIALS');
+	}
 
-			return null;
-		});
+	if (error.value) {
+		return translateAPIError(error.value);
+	}
 
-		return {
-			t,
-			errorFormatted,
-			error,
-			identifier,
-			password,
-			onSubmit,
-			loggingIn,
-			translateAPIError,
-			otp,
-			requiresTFA,
+	return null;
+});
+
+async function onSubmit() {
+	if (identifier.value === null || password.value === null) return;
+
+	try {
+		loggingIn.value = true;
+
+		const credentials: Credentials = {
+			identifier: identifier.value,
+			password: password.value,
 		};
 
-		async function onSubmit() {
-			if (identifier.value === null || password.value === null) return;
-
-			try {
-				loggingIn.value = true;
-
-				const credentials: Credentials = {
-					identifier: identifier.value,
-					password: password.value,
-				};
-
-				if (otp.value) {
-					credentials.otp = otp.value;
-				}
-
-				await login({ provider: provider.value, credentials });
-
-				// Stores are hydrated after login
-				const lastPage = userStore.currentUser?.last_page;
-				router.push(lastPage || '/content');
-			} catch (err: any) {
-				if (err.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_OTP' && requiresTFA.value === false) {
-					requiresTFA.value = true;
-				} else {
-					error.value = err.response?.data?.errors?.[0]?.extensions?.code || err;
-				}
-			} finally {
-				loggingIn.value = false;
-			}
+		if (otp.value) {
+			credentials.otp = otp.value;
 		}
-	},
-});
+
+		await login({ provider: provider.value, credentials });
+
+		let lastPage: string | undefined;
+
+		if (userStore.currentUser && 'last_page' in userStore.currentUser) {
+			lastPage = userStore.currentUser.last_page;
+		}
+
+		router.push(lastPage || '/content');
+	} catch (err: any) {
+		if (err.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_OTP' && requiresTFA.value === false) {
+			requiresTFA.value = true;
+		} else {
+			error.value = err.response?.data?.errors?.[0]?.extensions?.code || err;
+		}
+	} finally {
+		loggingIn.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -19,14 +19,14 @@
 	</form>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, watch, toRefs } from 'vue';
-import { useRouter } from 'vue-router';
-import { login } from '@/auth';
+<script setup lang="ts">
 import { RequestError } from '@/api';
+import { login } from '@/auth';
 import { translateAPIError } from '@/lang';
 import { useUserStore } from '@/stores/user';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 type Credentials = {
 	email: string;
@@ -34,100 +34,84 @@ type Credentials = {
 	otp?: string;
 };
 
-export default defineComponent({
-	props: {
-		provider: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	provider: string;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const { provider } = toRefs(props);
-		const loggingIn = ref(false);
-		const email = ref<string | null>(null);
-		const password = ref<string | null>(null);
-		const error = ref<RequestError | string | null>(null);
-		const otp = ref<string | null>(null);
-		const requiresTFA = ref(false);
-		const userStore = useUserStore();
+const router = useRouter();
 
-		watch(email, () => {
-			if (requiresTFA.value === true) requiresTFA.value = false;
-		});
+const { provider } = toRefs(props);
+const loggingIn = ref(false);
+const email = ref<string | null>(null);
+const password = ref<string | null>(null);
+const error = ref<RequestError | string | null>(null);
+const otp = ref<string | null>(null);
+const requiresTFA = ref(false);
+const userStore = useUserStore();
 
-		watch(provider, () => {
-			email.value = null;
-			password.value = null;
-			error.value = null;
-			otp.value = null;
-			requiresTFA.value = false;
-		});
+watch(email, () => {
+	if (requiresTFA.value === true) requiresTFA.value = false;
+});
 
-		const errorFormatted = computed(() => {
-			// Show "Wrong username or password" for wrongly formatted emails as well
-			if (error.value === 'INVALID_PAYLOAD') {
-				return translateAPIError('INVALID_CREDENTIALS');
-			}
+watch(provider, () => {
+	email.value = null;
+	password.value = null;
+	error.value = null;
+	otp.value = null;
+	requiresTFA.value = false;
+});
 
-			if (error.value) {
-				return translateAPIError(error.value);
-			}
+const errorFormatted = computed(() => {
+	// Show "Wrong username or password" for wrongly formatted emails as well
+	if (error.value === 'INVALID_PAYLOAD') {
+		return translateAPIError('INVALID_CREDENTIALS');
+	}
 
-			return null;
-		});
+	if (error.value) {
+		return translateAPIError(error.value);
+	}
 
-		return {
-			t,
-			errorFormatted,
-			error,
-			email,
-			password,
-			onSubmit,
-			loggingIn,
-			translateAPIError,
-			otp,
-			requiresTFA,
+	return null;
+});
+
+async function onSubmit() {
+	if (email.value === null || password.value === null) return;
+
+	try {
+		loggingIn.value = true;
+
+		const credentials: Credentials = {
+			email: email.value,
+			password: password.value,
 		};
 
-		async function onSubmit() {
-			if (email.value === null || password.value === null) return;
-
-			try {
-				loggingIn.value = true;
-
-				const credentials: Credentials = {
-					email: email.value,
-					password: password.value,
-				};
-
-				if (otp.value) {
-					credentials.otp = otp.value;
-				}
-
-				await login({ provider: provider.value, credentials });
-
-				const redirectQuery = router.currentRoute.value.query.redirect as string;
-
-				// Stores are hydrated after login
-				const lastPage = userStore.currentUser?.last_page;
-
-				router.push(redirectQuery || lastPage || '/content');
-			} catch (err: any) {
-				if (err.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_OTP' && requiresTFA.value === false) {
-					requiresTFA.value = true;
-				} else {
-					error.value = err.response?.data?.errors?.[0]?.extensions?.code || err;
-				}
-			} finally {
-				loggingIn.value = false;
-			}
+		if (otp.value) {
+			credentials.otp = otp.value;
 		}
-	},
-});
+
+		await login({ provider: provider.value, credentials });
+
+		const redirectQuery = router.currentRoute.value.query.redirect as string;
+
+		let lastPage: string | undefined;
+
+		if (userStore.currentUser && 'last_page' in userStore.currentUser) {
+			lastPage = userStore.currentUser.last_page;
+		}
+
+		router.push(redirectQuery || lastPage || '/content');
+	} catch (err: any) {
+		if (err.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_OTP' && requiresTFA.value === false) {
+			requiresTFA.value = true;
+		} else {
+			error.value = err.response?.data?.errors?.[0]?.extensions?.code || err;
+		}
+	} finally {
+		loggingIn.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -19,68 +19,62 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, watch, toRefs, PropType } from 'vue';
-import { useRouter } from 'vue-router';
-import { AuthProvider } from '@/types/login';
+<script setup lang="ts">
 import { AUTH_SSO_DRIVERS } from '@/constants';
 import { translateAPIError } from '@/lang';
+import { AuthProvider } from '@/types/login';
 import { getRootPath } from '@/utils/get-root-path';
 import formatTitle from '@cairncms/format-title';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 
-export default defineComponent({
-	props: {
-		providers: {
-			type: Array as PropType<AuthProvider[]>,
-			default: () => [],
-		},
+const props = defineProps<{
+	providers: AuthProvider[];
+}>();
+
+const { t } = useI18n();
+
+const route = useRoute();
+
+const { providers } = toRefs(props);
+const ssoProviders = ref<{ name: string; label: string; link: string; icon: string }[]>([]);
+
+watch(
+	providers,
+	() => {
+		ssoProviders.value = providers.value
+			.filter((provider) => AUTH_SSO_DRIVERS.includes(provider.driver))
+			.map((provider) => {
+				const ssoLoginLink = new URL(window.location.origin);
+				ssoLoginLink.pathname = `${getRootPath()}auth/login/${provider.name}`;
+
+				const redirectToLink = new URL(window.location.href);
+				redirectToLink.searchParams.set('continue', '');
+
+				ssoLoginLink.searchParams.set('redirect', redirectToLink.toString());
+
+				return {
+					name: provider.name,
+					label: provider.label || formatTitle(provider.name),
+					link: ssoLoginLink.toString(),
+					icon: provider.icon ?? 'account_circle',
+				};
+			});
 	},
-	setup(props) {
-		const { t } = useI18n();
+	{ immediate: true }
+);
 
-		const router = useRouter();
+const errorFormatted = computed(() => {
+	const validReasons = ['SIGN_OUT', 'SESSION_EXPIRED'];
 
-		const { providers } = toRefs(props);
-		const ssoProviders = ref<{ name: string; link: string; icon: string }[]>([]);
+	const reason = Array.isArray(route.query.reason) ? route.query.reason[0] : route.query.reason;
 
-		watch(
-			providers,
-			() => {
-				ssoProviders.value = providers.value
-					.filter((provider: AuthProvider) => AUTH_SSO_DRIVERS.includes(provider.driver))
-					.map((provider: AuthProvider) => {
-						const ssoLoginLink = new URL(window.location.origin);
-						ssoLoginLink.pathname = `${getRootPath()}auth/login/${provider.name}`;
+	if (reason && !validReasons.includes(reason)) {
+		return translateAPIError(reason);
+	}
 
-						const redirectToLink = new URL(window.location.href);
-						redirectToLink.searchParams.set('continue', '');
-
-						ssoLoginLink.searchParams.set('redirect', redirectToLink.toString());
-
-						return {
-							name: provider.name,
-							label: provider.label || formatTitle(provider.name),
-							link: ssoLoginLink.toString(),
-							icon: provider.icon ?? 'account_circle',
-						};
-					});
-			},
-			{ immediate: true }
-		);
-
-		const errorFormatted = computed(() => {
-			const validReasons = ['SIGN_OUT', 'SESSION_EXPIRED'];
-
-			if (router.currentRoute.value.query.reason && !validReasons.includes(router.currentRoute.value.query.reason)) {
-				return translateAPIError(router.currentRoute.value.query.reason);
-			}
-
-			return null;
-		});
-
-		return { t, ssoProviders, errorFormatted };
-	},
+	return null;
 });
 </script>
 

--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -15,21 +15,24 @@
 
 		<sso-links v-if="!authenticated" :providers="auth.providers" />
 
-		<template v-if="authenticated" #notice>
-			<v-icon name="lock_open" left />
-			{{ t('authenticated') }}
-		</template>
-		<template v-else #notice>
-			<v-icon name="lock" left />
-			{{
-				logoutReason && te(`logoutReason.${logoutReason}`) ? t(`logoutReason.${logoutReason}`) : t('not_authenticated')
-			}}
+		<template #notice>
+			<div v-if="authenticated">
+				<v-icon name="lock_open" left />
+				{{ t('authenticated') }}
+			</div>
+			<div v-else>
+				{{
+					logoutReason && te(`logoutReason.${logoutReason}`)
+						? t(`logoutReason.${logoutReason}`)
+						: t('not_authenticated')
+				}}
+			</div>
 		</template>
 	</public-view>
 </template>
 
 <script lang="ts" setup>
-import { DEFAULT_AUTH_PROVIDER, DEFAULT_AUTH_DRIVER } from '@/constants';
+import { DEFAULT_AUTH_DRIVER, DEFAULT_AUTH_PROVIDER } from '@/constants';
 import { useAppStore } from '@/stores/app';
 import { useServerStore } from '@/stores/server';
 import { storeToRefs } from 'pinia';

--- a/app/src/routes/logout.vue
+++ b/app/src/routes/logout.vue
@@ -4,16 +4,12 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, onMounted } from 'vue';
+<script setup lang="ts">
 import { logout } from '@/auth';
+import { onMounted } from 'vue';
 
-export default defineComponent({
-	setup() {
-		onMounted(() => {
-			logout();
-		});
-	},
+onMounted(() => {
+	logout();
 });
 </script>
 

--- a/app/src/routes/private-not-found.vue
+++ b/app/src/routes/private-not-found.vue
@@ -8,16 +8,10 @@
 	</private-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/reset-password/request.vue
+++ b/app/src/routes/reset-password/request.vue
@@ -12,53 +12,46 @@
 	</form>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed } from 'vue';
-import api from '@/api';
+<script setup lang="ts">
+import api, { RequestError } from '@/api';
 import { translateAPIError } from '@/lang';
-import { RequestError } from '@/api';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const email = ref(null);
+const email = ref(null);
 
-		const sending = ref(false);
-		const error = ref<RequestError | null>(null);
-		const done = ref(false);
+const sending = ref(false);
+const error = ref<RequestError | null>(null);
+const done = ref(false);
 
-		const errorFormatted = computed(() => {
-			if (error.value) {
-				return translateAPIError(error.value);
-			}
+const errorFormatted = computed(() => {
+	if (error.value) {
+		return translateAPIError(error.value);
+	}
 
-			return null;
+	return null;
+});
+
+const signInLink = computed(() => `/login`);
+
+async function onSubmit() {
+	sending.value = true;
+	error.value = null;
+
+	try {
+		await api.post(`/auth/password/request`, {
+			email: email.value,
 		});
 
-		const signInLink = computed(() => `/login`);
-
-		return { t, sending, error, done, email, onSubmit, signInLink, errorFormatted };
-
-		async function onSubmit() {
-			sending.value = true;
-			error.value = null;
-
-			try {
-				await api.post(`/auth/password/request`, {
-					email: email.value,
-				});
-
-				done.value = true;
-			} catch (err: any) {
-				error.value = err;
-			} finally {
-				sending.value = false;
-			}
-		}
-	},
-});
+		done.value = true;
+	} catch (err: any) {
+		error.value = err;
+	} finally {
+		sending.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/reset-password/reset-password.vue
+++ b/app/src/routes/reset-password/reset-password.vue
@@ -12,25 +12,18 @@
 	</public-view>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
-import { defineComponent, computed } from 'vue';
 import RequestForm from './request.vue';
 import ResetForm from './reset.vue';
 
-export default defineComponent({
-	components: { RequestForm, ResetForm },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const route = useRoute();
+const route = useRoute();
 
-		const resetToken = computed(() => route.query.token);
-
-		return { t, resetToken };
-	},
-});
+const resetToken = computed(() => (Array.isArray(route.query.token) ? route.query.token[0] : route.query.token));
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/shared/components/share-item.vue
+++ b/app/src/routes/shared/components/share-item.vue
@@ -9,28 +9,16 @@
 	/>
 </template>
 
-<script lang="ts">
-import { defineComponent, toRefs } from 'vue';
+<script setup lang="ts">
 import { useItem } from '@/composables/use-item';
+import { toRefs } from 'vue';
 
-export default defineComponent({
-	id: 'ShareItem',
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		primaryKey: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { collection, primaryKey } = toRefs(props);
+const props = defineProps<{
+	collection: string;
+	primaryKey: string;
+}>();
 
-		const { edits, item, loading } = useItem(collection, primaryKey);
+const { collection, primaryKey } = toRefs(props);
 
-		return { edits, item, loading };
-	},
-});
+const { edits, item, loading } = useItem(collection, primaryKey);
 </script>

--- a/app/src/routes/shared/shared.vue
+++ b/app/src/routes/shared/shared.vue
@@ -39,161 +39,139 @@
 	</shared-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { useRoute, useRouter } from 'vue-router';
-import { defineComponent, computed, ref } from 'vue';
-import { useAppStore } from '@/stores/app';
+<script setup lang="ts">
 import api, { RequestError } from '@/api';
 import { login, logout } from '@/auth';
-import { Share } from '@cairncms/types';
-import ShareItem from './components/share-item.vue';
 import { hydrate } from '@/hydrate';
+import { useAppStore } from '@/stores/app';
 import { useCollection } from '@cairncms/composables';
+import { Share } from '@cairncms/types';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import ShareItem from './components/share-item.vue';
 
 type ShareInfo = Pick<
 	Share,
 	'id' | 'collection' | 'item' | 'password' | 'date_start' | 'date_end' | 'max_uses' | 'times_used'
 >;
 
-export default defineComponent({
-	components: { ShareItem },
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const appStore = useAppStore();
-		const authenticated = computed(() => appStore.authenticated);
+const appStore = useAppStore();
+const authenticated = computed(() => appStore.authenticated);
 
-		const loading = ref(true);
-		const authenticating = ref(false);
+const loading = ref(true);
+const authenticating = ref(false);
 
-		const notFound = ref(false);
+const notFound = ref(false);
 
-		const error = ref<RequestError | null>(null);
+const error = ref<RequestError | null>(null);
 
-		const router = useRouter();
-		const route = useRoute();
+const router = useRouter();
+const route = useRoute();
 
-		const shareId = route.params.id as string;
-		const share = ref<ShareInfo>();
+const shareId = route.params.id as string;
+const share = ref<ShareInfo>();
 
-		const usesLeft = ref<number | null>(null);
+const usesLeft = ref<number | null>(null);
 
-		const usesLeftNoticeType = computed(() => {
-			if (!usesLeft.value) return 'info';
-			if (usesLeft.value < 3) return 'warning';
-			return 'info';
-		});
-
-		const password = ref<string>();
-		const passwordWrong = ref(false);
-
-		getShareInformation(shareId);
-
-		const { info } = useCollection(computed(() => share.value?.collection ?? null));
-		const collectionName = computed(() => info.value?.name);
-
-		const title = computed(() => {
-			if (notFound.value) return t('share_access_not_found_title');
-			if (collectionName.value) return t('viewing_in', { collection: collectionName.value });
-			return t('share_access_page');
-		});
-
-		return {
-			t,
-			share,
-			error,
-			title,
-			loading,
-			notFound,
-			password,
-			authenticate,
-			authenticated,
-			authenticating,
-			usesLeft,
-			usesLeftNoticeType,
-			collectionName,
-			passwordWrong,
-		};
-
-		async function getShareInformation(shareId: string) {
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/shares/info/${shareId}`);
-				share.value = response.data.data;
-
-				if (!share.value) {
-					notFound.value = true;
-					loading.value = false;
-					return;
-				}
-
-				const { max_uses, times_used } = share.value;
-
-				if (max_uses) {
-					usesLeft.value = max_uses - times_used;
-				}
-
-				await handleAuth();
-			} catch (err: any) {
-				if (err.response?.status === 404 || err.response?.status === 403) {
-					notFound.value = true;
-				} else {
-					error.value = err;
-				}
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		async function handleAuth() {
-			if (appStore.authenticated) {
-				const currentUser = await api.get('/users/me', { params: { fields: ['id'] } });
-
-				if (currentUser.data.data?.share) {
-					if (currentUser.data.data.share !== shareId) {
-						await logout({ navigate: false });
-					} else {
-						await hydrate();
-					}
-				}
-
-				// Logged in as regular user
-				if (currentUser.data.data?.id && !currentUser.data.data?.share) {
-					router.replace(`/content/${share.value!.collection}/${share.value!.item}`);
-					return;
-				}
-			}
-
-			if (!share.value?.password && !share.value?.max_uses) {
-				if (appStore.authenticated) {
-					await hydrate();
-				} else {
-					await authenticate();
-				}
-			}
-		}
-
-		async function authenticate() {
-			authenticating.value = true;
-
-			try {
-				const credentials = { share: shareId, password: password.value };
-				await login({ share: true, credentials });
-			} catch (err: any) {
-				if (err?.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_CREDENTIALS') {
-					passwordWrong.value = true;
-					return;
-				}
-
-				error.value = err;
-			} finally {
-				authenticating.value = false;
-			}
-		}
-	},
+const usesLeftNoticeType = computed(() => {
+	if (!usesLeft.value) return 'info';
+	if (usesLeft.value < 3) return 'warning';
+	return 'info';
 });
+
+const password = ref<string>();
+const passwordWrong = ref(false);
+
+getShareInformation(shareId);
+
+const { info } = useCollection(computed(() => share.value?.collection ?? null));
+const collectionName = computed(() => info.value?.name);
+
+const title = computed(() => {
+	if (notFound.value) return t('share_access_not_found_title');
+	if (collectionName.value) return t('viewing_in', { collection: collectionName.value });
+	return t('share_access_page');
+});
+
+async function getShareInformation(shareId: string) {
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/shares/info/${shareId}`);
+		share.value = response.data.data;
+
+		if (!share.value) {
+			notFound.value = true;
+			loading.value = false;
+			return;
+		}
+
+		const { max_uses, times_used } = share.value;
+
+		if (max_uses) {
+			usesLeft.value = max_uses - times_used;
+		}
+
+		await handleAuth();
+	} catch (err: any) {
+		if (err.response?.status === 404 || err.response?.status === 403) {
+			notFound.value = true;
+		} else {
+			error.value = err;
+		}
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function handleAuth() {
+	if (appStore.authenticated) {
+		const currentUser = await api.get('/users/me', { params: { fields: ['id'] } });
+
+		if (currentUser.data.data?.share) {
+			if (currentUser.data.data.share !== shareId) {
+				await logout({ navigate: false });
+			} else {
+				await hydrate();
+			}
+		}
+
+		// Logged in as regular user
+		if (currentUser.data.data?.id && !currentUser.data.data?.share) {
+			router.replace(`/content/${share.value!.collection}/${share.value!.item}`);
+			return;
+		}
+	}
+
+	if (!share.value?.password && !share.value?.max_uses) {
+		if (appStore.authenticated) {
+			await hydrate();
+		} else {
+			await authenticate();
+		}
+	}
+}
+
+async function authenticate() {
+	authenticating.value = true;
+
+	try {
+		const credentials = { share: shareId, password: password.value };
+		await login({ share: true, credentials });
+	} catch (err: any) {
+		if (err?.response?.data?.errors?.[0]?.extensions?.code === 'INVALID_CREDENTIALS') {
+			passwordWrong.value = true;
+			return;
+		}
+
+		error.value = err;
+	} finally {
+		authenticating.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/routes/tfa-setup.vue
+++ b/app/src/routes/tfa-setup.vue
@@ -40,70 +40,50 @@
 	</public-view>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, nextTick, onMounted, ref, watch } from 'vue';
+<script setup lang="ts">
 import { useTFASetup } from '@/composables/use-tfa-setup';
+import { router } from '@/router';
 import { useAppStore } from '@/stores/app';
 import { useUserStore } from '@/stores/user';
-import { router } from '@/router';
 import { User } from '@cairncms/types';
+import { nextTick, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
-		const appStore = useAppStore();
-		const userStore = useUserStore();
+const { t } = useI18n();
+const appStore = useAppStore();
+const userStore = useUserStore();
 
-		const inputOTP = ref<any>(null);
+const inputOTP = ref<any>(null);
 
-		onMounted(() => {
-			if (appStore.authenticated === false) {
-				router.push('/login');
-			}
-		});
-
-		const { generateTFA, enableTFA, loading, password, tfaEnabled, tfaGenerated, secret, otp, error, canvasID } =
-			useTFASetup(false);
-
-		watch(
-			() => tfaGenerated.value,
-			async (generated) => {
-				if (generated) {
-					await nextTick();
-					(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
-				}
-			}
-		);
-
-		return {
-			t,
-			generateTFA,
-			enableTFA,
-			loading,
-			password,
-			tfaEnabled,
-			tfaGenerated,
-			secret,
-			otp,
-			error,
-			canvasID,
-			enable,
-			inputOTP,
-		};
-
-		async function enable() {
-			await enableTFA();
-
-			if (error.value === null) {
-				const redirectQuery = router.currentRoute.value.query.redirect as string;
-				router.push(redirectQuery || (userStore.currentUser as User)?.last_page || '/login');
-			} else {
-				(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
-			}
-		}
-	},
+onMounted(() => {
+	if (appStore.authenticated === false) {
+		router.push('/login');
+	}
 });
+
+const { generateTFA, enableTFA, loading, password, tfaEnabled, tfaGenerated, secret, otp, error, canvasID } =
+	useTFASetup(false);
+
+watch(
+	() => tfaGenerated.value,
+	async (generated) => {
+		if (generated) {
+			await nextTick();
+			(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
+		}
+	}
+);
+
+async function enable() {
+	await enableTFA();
+
+	if (error.value === null) {
+		const redirectQuery = router.currentRoute.value.query.redirect as string;
+		router.push(redirectQuery || (userStore.currentUser as User)?.last_page || '/login');
+	} else {
+		(inputOTP.value.$el as HTMLElement).querySelector('input')!.focus();
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/utils/render-string-template.test.ts
+++ b/app/src/utils/render-string-template.test.ts
@@ -1,0 +1,37 @@
+import { useAliasFields } from '@/composables/use-alias-fields';
+import { createTestingPinia } from '@pinia/testing';
+import { set } from 'lodash';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderDisplayStringTemplate } from './render-string-template';
+
+vi.mock('@/utils/adjust-fields-for-displays', () => ({
+	adjustFieldsForDisplays: (fields: string[]) => fields,
+}));
+
+describe('renderDisplayStringTemplate', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+	});
+
+	it('resolves a display template field whose value was fetched under an aliased key', () => {
+		const collection = 'articles';
+		const template = '{{ author.name }} <{{ author.email }}>';
+
+		const values: Record<string, string> = {
+			'author.name': 'Ada Lovelace',
+			'author.email': 'ada@example.com',
+		};
+
+		const { aliasedFields } = useAliasFields(Object.keys(values), collection);
+		const item: Record<string, any> = {};
+
+		for (const field of Object.values(aliasedFields.value)) {
+			if (!field.aliased) continue;
+			const leaf = field.key.split('.').slice(1).join('.');
+			set(item, `${field.fieldAlias}.${leaf}`, values[field.key]);
+		}
+
+		expect(renderDisplayStringTemplate(collection, template, item)).toBe('Ada Lovelace <ada@example.com>');
+	});
+});

--- a/app/src/utils/render-string-template.ts
+++ b/app/src/utils/render-string-template.ts
@@ -1,11 +1,11 @@
 import { useAliasFields } from '@/composables/use-alias-fields';
+import { useExtension } from '@/composables/use-extension';
 import { useFieldsStore } from '@/stores/fields';
 import { Field } from '@cairncms/types';
 import { get, getFieldsFromTemplate } from '@cairncms/utils';
-import { render, renderFn } from 'micromustache';
-import { computed, ComputedRef, Ref, ref, unref } from 'vue';
 import { set } from 'lodash';
-import { useExtension } from '@/composables/use-extension';
+import { render, renderFn } from 'micromustache';
+import { ComputedRef, Ref, computed, unref } from 'vue';
 
 type StringTemplate = {
 	fieldsInTemplate: ComputedRef<string[]>;
@@ -67,15 +67,12 @@ export function renderDisplayStringTemplate(
 		set(fieldsUsed, key, fieldsStore.getField(collection, key));
 	}
 
-	const { aliasFields } = useAliasFields(ref(fields));
-
 	const parsedItem: Record<string, any> = {};
 
+	const { getFromAliasedItem } = useAliasFields(fields, collection);
+
 	for (const key of fields) {
-		const value =
-			!aliasFields.value?.[key] || get(item, key) !== undefined
-				? get(item, key)
-				: get(item, aliasFields.value[key].fullAlias);
+		const value = getFromAliasedItem(item, key);
 
 		const display = useExtension(
 			'display',

--- a/app/src/utils/save-as-csv.ts
+++ b/app/src/utils/save-as-csv.ts
@@ -1,11 +1,10 @@
 import { useAliasFields } from '@/composables/use-alias-fields';
+import { useExtension } from '@/composables/use-extension';
 import { useFieldsStore } from '@/stores/fields';
-import { get } from '@cairncms/utils';
 import { Field, Item } from '@cairncms/types';
 import { saveAs } from 'file-saver';
 import { parse } from 'json2csv';
-import { computed, ref } from 'vue';
-import { useExtension } from '@/composables/use-extension';
+import { computed } from 'vue';
 
 /**
  * Saves the given collection + items combination as a CSV file
@@ -19,7 +18,7 @@ export async function saveAsCSV(collection: string, fields: string[], items: Ite
 		fieldsUsed[key] = fieldsStore.getField(collection, key);
 	}
 
-	const { aliasFields } = useAliasFields(ref(fields));
+	const { getFromAliasedItem } = useAliasFields(fields, collection);
 
 	const parsedItems = [];
 
@@ -43,10 +42,7 @@ export async function saveAsCSV(collection: string, fields: string[], items: Ite
 				name = fieldsUsed[key]?.name ?? key;
 			}
 
-			const value =
-				!aliasFields.value?.[key] || item[key] !== undefined
-					? get(item, key)
-					: get(item, aliasFields.value[key].fullAlias);
+			const value = getFromAliasedItem(item, key);
 
 			const display = useExtension(
 				'display',

--- a/app/src/views/private/components/archive-sidebar-detail.vue
+++ b/app/src/views/private/components/archive-sidebar-detail.vue
@@ -15,58 +15,46 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
+import { computed, ref, unref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
-import { computed, defineComponent, watch, ref } from 'vue';
 
-export default defineComponent({
-	props: {
-		collection: {
-			type: String,
-			default: null,
-		},
-		archive: {
-			type: String,
-			default: null,
-		},
+const props = defineProps<{
+	collection?: string;
+	archive?: string;
+}>();
+
+const { t } = useI18n();
+
+const router = useRouter();
+
+const selectedItem = ref<string | undefined>(props.archive);
+
+const items = [
+	{
+		text: t('show_active_items'),
+		value: null,
 	},
-	setup(props) {
-		const { t } = useI18n();
+	{ text: t('show_archived_items'), value: 'archived' },
+	{ text: t('show_all_items'), value: 'all' },
+];
 
-		const router = useRouter();
+const active = computed(() => !!unref(selectedItem));
 
-		const selectedItem = ref<string | null>(props.archive);
+watch(selectedItem, () => {
+	const url = new URL(unref(router.currentRoute).fullPath, window.location.origin);
 
-		const items = [
-			{
-				text: t('show_active_items'),
-				value: null,
-			},
-			{ text: t('show_archived_items'), value: 'archived' },
-			{ text: t('show_all_items'), value: 'all' },
-		];
+	url.searchParams.delete('archived');
+	url.searchParams.delete('all');
 
-		const active = computed(() => selectedItem.value !== null);
+	const selectedItemValue = unref(selectedItem);
 
-		watch(
-			() => selectedItem.value,
-			() => {
-				const url = new URL(router.currentRoute.value.fullPath, window.location.origin);
+	if (selectedItemValue) {
+		url.searchParams.set(selectedItemValue, '');
+	}
 
-				url.searchParams.delete('archived');
-				url.searchParams.delete('all');
-
-				if (selectedItem.value !== null) {
-					url.searchParams.set(selectedItem.value, '');
-				}
-
-				router.push(url.pathname + url.search);
-			}
-		);
-
-		return { t, active, selectedItem, items };
-	},
+	router.push(url.pathname + url.search);
 });
 </script>
 

--- a/app/src/views/private/components/bookmark-add.vue
+++ b/app/src/views/private/components/bookmark-add.vue
@@ -35,49 +35,42 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
+import { reactive } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { defineComponent, reactive } from 'vue';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
-		saving: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['save', 'update:modelValue'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+defineProps<{
+	modelValue?: boolean;
+	saving?: boolean;
+}>();
 
-		const bookmarkValue = reactive({
-			name: null,
-			icon: 'bookmark',
-			color: null,
-		});
+const emit = defineEmits<{
+	(e: 'save', value: { name: string | null; icon: string | null; color: string | null }): void;
+	(e: 'update:modelValue', value: boolean): void;
+}>();
 
-		return { t, bookmarkValue, setIcon, setColor, cancel };
+const { t } = useI18n();
 
-		function setIcon(icon: any) {
-			bookmarkValue.icon = icon;
-		}
-
-		function setColor(color: any) {
-			bookmarkValue.color = color;
-		}
-
-		function cancel() {
-			bookmarkValue.name = null;
-			bookmarkValue.icon = 'bookmark';
-			bookmarkValue.color = null;
-			emit('update:modelValue', false);
-		}
-	},
+const bookmarkValue = reactive({
+	name: null,
+	icon: 'bookmark',
+	color: null,
 });
+
+function setIcon(icon: any) {
+	bookmarkValue.icon = icon;
+}
+
+function setColor(color: any) {
+	bookmarkValue.color = color;
+}
+
+function cancel() {
+	bookmarkValue.name = null;
+	bookmarkValue.icon = 'bookmark';
+	bookmarkValue.color = null;
+	emit('update:modelValue', false);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/comment-input.vue
+++ b/app/src/views/private/components/comment-input.vue
@@ -30,7 +30,7 @@
 				>
 					<v-list-item-icon>
 						<v-avatar x-small>
-							<v-image v-if="user.avatar" :src="avatarSource(user.avatar)" />
+							<v-image v-if="user.avatar" :src="avatarSource(user.avatar.id)" />
 							<v-icon v-else name="person_outline" />
 						</v-avatar>
 					</v-list-item-icon>
@@ -68,6 +68,7 @@
 <script setup lang="ts">
 import api from '@/api';
 import { useShortcut } from '@/composables/use-shortcut';
+import { Activity } from '@/types/activity';
 import { md } from '@/utils/md';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -77,7 +78,6 @@ import axios, { CancelTokenSource } from 'axios';
 import { cloneDeep, throttle } from 'lodash';
 import { ComponentPublicInstance, computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { Activity } from '@/types/activity';
 
 const props = withDefaults(
 	defineProps<{
@@ -119,7 +119,7 @@ watch(
 const saving = ref(false);
 const showMentionDropDown = ref(false);
 
-const searchResult = ref<User[]>([]);
+const searchResult = ref<Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'>[]>([]);
 const userPreviews = ref<Record<string, string>>({});
 
 watch(

--- a/app/src/views/private/components/comment-item-header.vue
+++ b/app/src/views/private/components/comment-item-header.vue
@@ -60,17 +60,20 @@
 </template>
 
 <script setup lang="ts">
+import api from '@/api';
+import { Activity } from '@/types/activity';
+import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
+import type { User } from '@cairncms/types';
 import format from 'date-fns/format';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { Activity } from '@/types/activity';
-
-import api from '@/api';
-import { unexpectedError } from '@/utils/unexpected-error';
 
 const props = defineProps<{
-	activity: Activity;
+	activity: Activity & {
+		display: string;
+		user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'>;
+	};
 	refresh: () => void;
 }>();
 

--- a/app/src/views/private/components/comment-item.vue
+++ b/app/src/views/private/components/comment-item.vue
@@ -17,17 +17,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { Activity } from '@/types/activity';
-import CommentItemHeader from './comment-item-header.vue';
-import CommentInput from './comment-input.vue';
-
 import api from '@/api';
+import { Activity } from '@/types/activity';
 import { unexpectedError } from '@/utils/unexpected-error';
+import type { User } from '@cairncms/types';
+import { ref, watch } from 'vue';
+import CommentInput from './comment-input.vue';
+import CommentItemHeader from './comment-item-header.vue';
 
 interface Props {
 	activity: Activity & {
 		display: string;
+		user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'>;
 	};
 	refresh: () => void;
 	collection: string;

--- a/app/src/views/private/components/comments-sidebar-detail.vue
+++ b/app/src/views/private/components/comments-sidebar-detail.vue
@@ -25,21 +25,22 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { ref } from 'vue';
-
 import api from '@/api';
 import { Activity, ActivityByDate } from '@/types/activity';
-import CommentInput from './comment-input.vue';
-import { groupBy, orderBy, flatten } from 'lodash';
 import { localizedFormat } from '@/utils/localized-format';
-import { isToday, isYesterday, isThisYear } from 'date-fns';
-import CommentItem from './comment-item.vue';
 import { userName } from '@/utils/user-name';
+import type { User } from '@cairncms/types';
+import { isThisYear, isToday, isYesterday } from 'date-fns';
+import { flatten, groupBy, orderBy } from 'lodash';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import CommentInput from './comment-input.vue';
+import CommentItem from './comment-item.vue';
 
 type ActivityByDateDisplay = ActivityByDate & {
 	activity: (Activity & {
 		display: string;
+		user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'>;
 	})[];
 };
 
@@ -103,6 +104,9 @@ function useActivity(collection: string, primaryKey: string | number) {
 				return {
 					...comment,
 					display,
+				} as Activity & {
+					display: string;
+					user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name' | 'avatar'>;
 				};
 			});
 

--- a/app/src/views/private/components/drawer-batch.vue
+++ b/app/src/views/private/components/drawer-batch.vue
@@ -23,129 +23,116 @@
 	</v-drawer>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, PropType, toRefs } from 'vue';
+<script lang="ts" setup>
 import api from '@/api';
 import { VALIDATION_TYPES } from '@/constants';
 import { APIError } from '@/types/error';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { getEndpoint } from '@cairncms/utils';
+import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		active: {
-			type: Boolean,
-			default: false,
-		},
-		collection: {
-			type: String,
-			required: true,
-		},
-		edits: {
-			type: Object as PropType<Record<string, any>>,
-			default: undefined,
-		},
-		primaryKeys: {
-			type: Array as PropType<(number | string)[]>,
-			required: true,
-		},
-	},
-	emits: ['update:active', 'refresh'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: string;
+	primaryKeys: (number | string)[];
+	active?: boolean;
+	edits?: Record<string, any>;
+}>();
 
-		const { internalEdits } = useEdits();
-		const { internalActive } = useActiveState();
-		const { save, cancel, saving, validationErrors } = useActions();
+const emit = defineEmits<{
+	(e: 'update:active', value: boolean): void;
+	(e: 'refresh'): void;
+}>();
 
-		const { collection } = toRefs(props);
+const { t } = useI18n();
 
-		return { t, internalActive, internalEdits, save, saving, cancel, validationErrors };
+const { internalEdits } = useEdits();
+const { internalActive } = useActiveState();
+const { save, cancel, saving, validationErrors } = useActions();
 
-		function useEdits() {
-			const localEdits = ref<Record<string, any>>({});
+const { collection } = toRefs(props);
 
-			const internalEdits = computed<Record<string, any>>({
-				get() {
-					if (props.edits !== undefined) {
-						return {
-							...props.edits,
-							...localEdits.value,
-						};
-					}
+function useEdits() {
+	const localEdits = ref<Record<string, any>>({});
 
-					return localEdits.value;
-				},
-				set(newEdits) {
-					localEdits.value = newEdits;
-				},
-			});
-
-			return { internalEdits };
-		}
-
-		function useActiveState() {
-			const localActive = ref(false);
-
-			const internalActive = computed({
-				get() {
-					return props.active === undefined ? localActive.value : props.active;
-				},
-				set(newActive: boolean) {
-					localActive.value = newActive;
-					emit('update:active', newActive);
-				},
-			});
-
-			return { internalActive };
-		}
-
-		function useActions() {
-			const saving = ref(false);
-			const validationErrors = ref([]);
-
-			return { save, cancel, saving, validationErrors };
-
-			async function save() {
-				saving.value = true;
-
-				try {
-					await api.patch(getEndpoint(collection.value), {
-						keys: props.primaryKeys,
-						data: internalEdits.value,
-					});
-
-					emit('refresh');
-
-					internalActive.value = false;
-					internalEdits.value = {};
-				} catch (err: any) {
-					validationErrors.value = err.response.data.errors
-						.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
-						.map((err: APIError) => {
-							return err.extensions;
-						});
-
-					const otherErrors = err.response.data.errors.filter(
-						(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
-					);
-
-					if (otherErrors.length > 0) {
-						otherErrors.forEach(unexpectedError);
-					}
-				} finally {
-					saving.value = false;
-				}
+	const internalEdits = computed<Record<string, any>>({
+		get() {
+			if (props.edits !== undefined) {
+				return {
+					...props.edits,
+					...localEdits.value,
+				};
 			}
 
-			function cancel() {
-				internalActive.value = false;
-				internalEdits.value = {};
+			return localEdits.value;
+		},
+		set(newEdits) {
+			localEdits.value = newEdits;
+		},
+	});
+
+	return { internalEdits };
+}
+
+function useActiveState() {
+	const localActive = ref(false);
+
+	const internalActive = computed({
+		get() {
+			return props.active === undefined ? localActive.value : props.active;
+		},
+		set(newActive: boolean) {
+			localActive.value = newActive;
+			emit('update:active', newActive);
+		},
+	});
+
+	return { internalActive };
+}
+
+function useActions() {
+	const saving = ref(false);
+	const validationErrors = ref([]);
+
+	return { save, cancel, saving, validationErrors };
+
+	async function save() {
+		saving.value = true;
+
+		try {
+			await api.patch(getEndpoint(collection.value), {
+				keys: props.primaryKeys,
+				data: internalEdits.value,
+			});
+
+			emit('refresh');
+
+			internalActive.value = false;
+			internalEdits.value = {};
+		} catch (err: any) {
+			validationErrors.value = err.response.data.errors
+				.filter((err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code))
+				.map((err: APIError) => {
+					return err.extensions;
+				});
+
+			const otherErrors = err.response.data.errors.filter(
+				(err: APIError) => VALIDATION_TYPES.includes(err?.extensions?.code) === false
+			);
+
+			if (otherErrors.length > 0) {
+				otherErrors.forEach(unexpectedError);
 			}
+		} finally {
+			saving.value = false;
 		}
-	},
-});
+	}
+
+	function cancel() {
+		internalActive.value = false;
+		internalEdits.value = {};
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection.vue
@@ -19,12 +19,12 @@
 			@cancel="cancel"
 		>
 			<template #subtitle>
-				<v-breadcrumb :items="[{ name: collectionInfo.name, disabled: true }]" />
+				<v-breadcrumb :items="[{ name: collectionInfo!.name, disabled: true }]" />
 			</template>
 
 			<template #title-outer:prepend>
 				<v-button class="header-icon" rounded icon secondary disabled>
-					<v-icon :name="collectionInfo.icon" :color="collectionInfo.color" />
+					<v-icon :name="collectionInfo!.icon" :color="collectionInfo!.color" />
 				</v-button>
 			</template>
 
@@ -41,11 +41,11 @@
 			<div class="layout">
 				<component :is="`layout-${localLayout}`" v-bind="layoutState">
 					<template #no-results>
-						<v-info :title="t('item_count', 0)" :icon="collectionInfo.icon" center />
+						<v-info :title="t('item_count', 0)" :icon="collectionInfo!.icon" center />
 					</template>
 
 					<template #no-items>
-						<v-info :title="t('item_count', 0)" :icon="collectionInfo.icon" center />
+						<v-info :title="t('item_count', 0)" :icon="collectionInfo!.icon" center />
 					</template>
 				</component>
 			</div>
@@ -53,171 +53,144 @@
 	</component>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, ref, computed, toRefs, watch } from 'vue';
-import { Filter } from '@cairncms/types';
-import { usePreset } from '@/composables/use-preset';
-import { useCollection, useLayout } from '@cairncms/composables';
-import SearchInput from '@/views/private/components/search-input.vue';
+<script lang="ts" setup>
 import { useExtension } from '@/composables/use-extension';
+import { usePreset } from '@/composables/use-preset';
+import SearchInput from '@/views/private/components/search-input.vue';
+import { useCollection, useLayout } from '@cairncms/composables';
+import { Filter } from '@cairncms/types';
+import { computed, ref, toRefs, unref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	components: { SearchInput },
-	props: {
-		active: {
-			type: Boolean,
-			default: false,
-		},
-		selection: {
-			type: Array as PropType<(number | string)[]>,
-			default: () => [],
-		},
-		collection: {
-			type: String,
-			default: null,
-		},
-		multiple: {
-			type: Boolean,
-			default: false,
-		},
-		filter: {
-			type: Object as PropType<Filter>,
-			default: null,
-		},
+const props = withDefaults(
+	defineProps<{
+		active?: boolean;
+		selection?: (number | string)[];
+		collection: string;
+		multiple?: boolean;
+		filter?: Filter;
+	}>(),
+	{
+		selection: () => [],
+	}
+);
+
+const emit = defineEmits<{
+	(e: 'update:active', value: boolean): void;
+	(e: 'input', value: (number | string)[] | null): void;
+}>();
+
+const { t } = useI18n();
+
+const { save, cancel } = useActions();
+const { internalActive } = useActiveState();
+const { internalSelection, onSelect } = useSelection();
+
+const { collection } = toRefs(props);
+
+const { info: collectionInfo } = useCollection(collection);
+const { layout, layoutOptions, layoutQuery, search, filter: presetFilter } = usePreset(collection, ref(null), true);
+
+// This is a local copy of the layout. This means that we can sync it the layout without
+// having use-preset auto-save the values
+const localLayout = ref(layout.value || 'tabular');
+const localOptions = ref(layoutOptions.value);
+const localQuery = ref(layoutQuery.value);
+
+const currentLayout = useExtension('layout', localLayout);
+
+const layoutSelection = computed<any>({
+	get() {
+		return internalSelection.value;
 	},
-	emits: ['update:active', 'input'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const { save, cancel } = useActions();
-		const { internalActive } = useActiveState();
-		const { internalSelection, onSelect } = useSelection();
-
-		const { collection } = toRefs(props);
-
-		const { info: collectionInfo } = useCollection(collection);
-		const { layout, layoutOptions, layoutQuery, search, filter: presetFilter } = usePreset(collection, ref(null), true);
-
-		// This is a local copy of the layout. This means that we can sync it the layout without
-		// having use-preset auto-save the values
-		const localLayout = ref(layout.value || 'tabular');
-		const localOptions = ref(layoutOptions.value);
-		const localQuery = ref(layoutQuery.value);
-
-		const currentLayout = useExtension('layout', localLayout);
-
-		const layoutSelection = computed<any>({
-			get() {
-				return internalSelection.value;
-			},
-			set(newFilters) {
-				onSelect(newFilters);
-			},
-		});
-
-		const { layoutWrapper } = useLayout(layout);
-
-		const layoutFilter = computed({
-			get() {
-				if (!props.filter) return presetFilter.value;
-				if (!presetFilter.value) return props.filter;
-
-				return {
-					_and: [props.filter, presetFilter.value],
-				};
-			},
-			set(newFilter: Filter | null) {
-				presetFilter.value = newFilter;
-			},
-		});
-
-		return {
-			t,
-			save,
-			cancel,
-			internalActive,
-			layoutWrapper,
-			layoutSelection,
-			layoutFilter,
-			localLayout,
-			localOptions,
-			localQuery,
-			collectionInfo,
-			search,
-			presetFilter,
-			currentLayout,
-		};
-
-		function useActiveState() {
-			const localActive = ref(false);
-
-			const internalActive = computed({
-				get() {
-					return props.active === undefined ? localActive.value : props.active;
-				},
-				set(newActive: boolean) {
-					localActive.value = newActive;
-					emit('update:active', newActive);
-				},
-			});
-
-			return { internalActive };
-		}
-
-		function useSelection() {
-			const localSelection = ref<(string | number)[] | null>(null);
-
-			const internalSelection = computed({
-				get() {
-					if (localSelection.value === null) {
-						return props.selection;
-					}
-
-					return localSelection.value;
-				},
-				set(newSelection: (string | number)[]) {
-					localSelection.value = newSelection;
-				},
-			});
-
-			watch(
-				() => props.active,
-				() => {
-					localSelection.value = null;
-				}
-			);
-
-			return { internalSelection, onSelect };
-
-			function onSelect(newSelection: (string | number)[]) {
-				if (newSelection.length === 0) {
-					localSelection.value = [];
-					return;
-				}
-
-				if (props.multiple === true) {
-					localSelection.value = newSelection;
-				} else {
-					localSelection.value = [newSelection[newSelection.length - 1]];
-				}
-			}
-		}
-
-		function useActions() {
-			return { save, cancel };
-
-			function save() {
-				emit('input', internalSelection.value);
-				internalActive.value = false;
-			}
-
-			function cancel() {
-				internalActive.value = false;
-			}
-		}
+	set(newFilters) {
+		onSelect(newFilters);
 	},
 });
+
+const { layoutWrapper } = useLayout(layout);
+
+const layoutFilter = computed({
+	get() {
+		if (!props.filter) return presetFilter.value;
+		if (!presetFilter.value) return props.filter;
+
+		return {
+			_and: [props.filter, presetFilter.value],
+		};
+	},
+	set(newFilter: Filter | null) {
+		presetFilter.value = newFilter;
+	},
+});
+
+function useActiveState() {
+	const localActive = ref(false);
+
+	const internalActive = computed({
+		get() {
+			return props.active === undefined ? localActive.value : props.active;
+		},
+		set(newActive: boolean) {
+			localActive.value = newActive;
+			emit('update:active', newActive);
+		},
+	});
+
+	return { internalActive };
+}
+
+function useSelection() {
+	const localSelection = ref<(string | number)[] | null>(null);
+
+	const internalSelection = computed({
+		get() {
+			if (localSelection.value === null) {
+				return props.selection;
+			}
+
+			return localSelection.value;
+		},
+		set(newSelection: (string | number)[]) {
+			localSelection.value = newSelection;
+		},
+	});
+
+	watch(
+		() => props.active,
+		() => {
+			localSelection.value = null;
+		}
+	);
+
+	return { internalSelection, onSelect };
+
+	function onSelect(newSelection: (string | number)[]) {
+		if (newSelection.length === 0) {
+			localSelection.value = [];
+			return;
+		}
+
+		if (props.multiple === true) {
+			localSelection.value = newSelection;
+		} else {
+			localSelection.value = [newSelection[newSelection.length - 1]];
+		}
+	}
+}
+
+function useActions() {
+	return { save, cancel };
+
+	function save() {
+		emit('input', unref(internalSelection));
+		internalActive.value = false;
+	}
+
+	function cancel() {
+		internalActive.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/drawer-item.vue
+++ b/app/src/views/private/components/drawer-item.vue
@@ -79,23 +79,22 @@
 
 <script setup lang="ts">
 import api from '@/api';
-import FilePreview from '@/views/private/components/file-preview.vue';
-import { isEmpty, merge, set } from 'lodash';
-import { computed, ref, toRefs, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-
+import { useEditsGuard } from '@/composables/use-edits-guard';
 import { usePermissions } from '@/composables/use-permissions';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
+import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
+import FilePreview from '@/views/private/components/file-preview.vue';
 import { useCollection } from '@cairncms/composables';
 import { Field, Relation } from '@cairncms/types';
-import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
-import { useEditsGuard } from '@/composables/use-edits-guard';
-import { useRouter } from 'vue-router';
 import { getEndpoint } from '@cairncms/utils';
+import { isEmpty, merge, set } from 'lodash';
+import { computed, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
 interface Props {
 	collection: string;
@@ -368,11 +367,14 @@ function useRelation() {
 		if (!relationForField) return null;
 
 		if (relationForField.related_collection) return relationForField.related_collection;
-		if (relationForField.meta?.one_collection_field)
+
+		if (relationForField.meta?.one_collection_field) {
 			return (
-				props.edits[relationForField.meta.one_collection_field] ||
+				props.edits?.[relationForField.meta.one_collection_field] ||
 				initialValues.value?.[relationForField.meta.one_collection_field]
 			);
+		}
+
 		return null;
 	});
 

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -242,6 +242,7 @@ import FolderPicker from '@/views/private/components/folder-picker.vue';
 import { useCollection } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
 import { getEndpoint } from '@cairncms/utils';
+import type { AxiosProgressEvent } from 'axios';
 import { debounce } from 'lodash';
 import { computed, reactive, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -333,7 +334,7 @@ watch(
 
 const format = ref('csv');
 const location = ref('download');
-const folder = ref<string>();
+const folder = ref<string | null>(null);
 
 const lockedToFiles = computed(() => {
 	const toBeDownloaded = exportSettings.limit ?? itemCount.value;
@@ -460,8 +461,8 @@ function useUpload() {
 
 		try {
 			await api.post(`/utils/import/${collection.value}`, formData, {
-				onUploadProgress: (progressEvent: ProgressEvent) => {
-					const percentCompleted = Math.floor((progressEvent.loaded * 100) / progressEvent.total);
+				onUploadProgress: (progressEvent: AxiosProgressEvent) => {
+					const percentCompleted = Math.floor((progressEvent.loaded * 100) / progressEvent.total!);
 					progress.value = percentCompleted;
 					importing.value = percentCompleted === 100 ? true : false;
 				},

--- a/app/src/views/private/components/file-lightbox.vue
+++ b/app/src/views/private/components/file-lightbox.vue
@@ -23,9 +23,9 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import api from '@/api';
-import { computed, defineComponent, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import FilePreview from '@/views/private/components/file-preview.vue';
 import { nanoid } from 'nanoid';
@@ -40,73 +40,64 @@ type File = {
 	title: string;
 };
 
-export default defineComponent({
-	components: { FilePreview },
-	props: {
-		id: {
-			type: String,
-			required: true,
-		},
-		modelValue: {
-			type: Boolean,
-			default: undefined,
-		},
+const props = defineProps<{
+	id: string;
+	modelValue?: boolean;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: boolean): void;
+}>();
+
+const localActive = ref(false);
+
+const internalActive = computed({
+	get() {
+		return props.modelValue === undefined ? localActive.value : props.modelValue;
 	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const localActive = ref(false);
-
-		const internalActive = computed({
-			get() {
-				return props.modelValue === undefined ? localActive.value : props.modelValue;
-			},
-			set(newActive: boolean) {
-				localActive.value = newActive;
-				emit('update:modelValue', newActive);
-			},
-		});
-
-		const loading = ref(false);
-		const file = ref<File | null>(null);
-		const cacheBuster = ref(nanoid());
-
-		const fileSrc = computed(() => {
-			return getRootPath() + `assets/${props.id}?cache-buster=${cacheBuster.value}`;
-		});
-
-		watch(
-			[() => props.id, internalActive],
-			([newID, newActive]) => {
-				if (newActive && newID) {
-					fetchFile();
-				}
-			},
-			{ immediate: true }
-		);
-
-		return { internalActive, cacheBuster, loading, file, fileSrc };
-
-		async function fetchFile() {
-			cacheBuster.value = nanoid();
-
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/files/${props.id}`, {
-					params: {
-						fields: ['type', 'width', 'height', 'title'],
-					},
-				});
-
-				file.value = response.data.data;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
-		}
+	set(newActive: boolean) {
+		localActive.value = newActive;
+		emit('update:modelValue', newActive);
 	},
 });
+
+const loading = ref(false);
+const file = ref<File | null>(null);
+const cacheBuster = ref(nanoid());
+
+const fileSrc = computed(() => {
+	return getRootPath() + `assets/${props.id}?cache-buster=${cacheBuster.value}`;
+});
+
+watch(
+	[() => props.id, internalActive],
+	([newID, newActive]) => {
+		if (newActive && newID) {
+			fetchFile();
+		}
+	},
+	{ immediate: true }
+);
+
+async function fetchFile() {
+	cacheBuster.value = nanoid();
+
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/files/${props.id}`, {
+			params: {
+				fields: ['type', 'width', 'height', 'title'],
+			},
+		});
+
+		file.value = response.data.data;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/file-preview.vue
+++ b/app/src/views/private/components/file-preview.vue
@@ -17,14 +17,14 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
-import { readableMimeType } from '@/utils/readable-mime-type';
 import { getRootPath } from '@/utils/get-root-path';
+import { readableMimeType } from '@/utils/readable-mime-type';
+import { computed, ref } from 'vue';
 
 interface Props {
 	mime: string;
-	width?: number;
-	height?: number;
+	width?: number | null;
+	height?: number | null;
 	src: string;
 	title: string;
 	inModal?: boolean;
@@ -57,7 +57,7 @@ const type = computed<'image' | 'video' | 'audio' | string>(() => {
 const isSVG = computed(() => props.mime.includes('svg'));
 
 const maxHeight = computed(() => Math.min(props.height ?? 528, 528) + 'px');
-const isSmall = computed(() => props.height < 528);
+const isSmall = computed(() => props.height && props.height < 528);
 
 const authenticatedSrc = computed(() => getRootPath() + props.src);
 </script>

--- a/app/src/views/private/components/folder-picker-list-item.vue
+++ b/app/src/views/private/components/folder-picker-list-item.vue
@@ -5,7 +5,7 @@
 			clickable
 			:active="currentFolder === folder.id"
 			:disabled="disabled"
-			@click="clickHandler(folder.id)"
+			@click="clickHandler?.(folder.id)"
 		>
 			<v-list-item-icon><v-icon :name="currentFolder === folder.id ? 'folder_open' : 'folder'" /></v-list-item-icon>
 			<v-list-item-content>{{ folder.name }}</v-list-item-content>
@@ -15,7 +15,7 @@
 			clickable
 			:active="currentFolder === folder.id"
 			:disabled="disabled"
-			@click="clickHandler(folder.id)"
+			@click="clickHandler?.(folder.id)"
 		>
 			<template #activator>
 				<v-list-item-icon>
@@ -29,45 +29,25 @@
 				:folder="childFolder"
 				:current-folder="currentFolder"
 				:click-handler="clickHandler"
-				:disabled="disabledFolders.includes(childFolder.id)"
+				:disabled="disabledFolders?.includes(childFolder.id)"
 				:disabled-folders="disabledFolders"
 			/>
 		</v-list-group>
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
-
+<script lang="ts" setup>
 type Folder = {
 	id: string;
 	name: string;
 	children: Folder[];
 };
 
-export default defineComponent({
-	name: 'FolderPickerListItem',
-	props: {
-		folder: {
-			type: Object as PropType<Folder>,
-			required: true,
-		},
-		currentFolder: {
-			type: String,
-			default: null,
-		},
-		clickHandler: {
-			type: Function,
-			default: () => undefined,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		disabledFolders: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-	},
-});
+defineProps<{
+	folder: Folder;
+	currentFolder: string | null;
+	clickHandler?: (folderId: string) => void;
+	disabled?: boolean;
+	disabledFolders?: string[];
+}>();
 </script>

--- a/app/src/views/private/components/folder-picker.vue
+++ b/app/src/views/private/components/folder-picker.vue
@@ -24,7 +24,7 @@
 						:folder="folder"
 						:current-folder="modelValue"
 						:click-handler="(id) => $emit('update:modelValue', id)"
-						:disabled="disabledFolders.includes(folder.id)"
+						:disabled="disabledFolders?.includes(folder.id)"
 						:disabled-folders="disabledFolders"
 					/>
 				</v-list-group>
@@ -33,9 +33,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed, PropType } from 'vue';
+import { computed, ref } from 'vue';
 import api from '@/api';
 import FolderPickerListItem from './folder-picker-list-item.vue';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -52,104 +52,91 @@ type Folder = {
 	children: Folder[];
 };
 
-export default defineComponent({
-	components: { FolderPickerListItem },
-	props: {
-		disabledFolders: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
-		modelValue: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	disabledFolders?: string[];
+	modelValue: string | null;
+}>();
 
-		const loading = ref(false);
-		const folders = ref<FolderRaw[]>([]);
+defineEmits<{
+	(e: 'update:modelValue', value: string | null): void;
+}>();
 
-		const tree = computed<Folder[]>(() => {
-			return folders.value
-				.filter((folder) => folder.parent === null)
-				.map((folder) => {
-					return {
-						...folder,
-						children: getChildFolders(folder),
-					};
-				});
+const { t } = useI18n();
 
-			function getChildFolders(folder: FolderRaw): Folder[] {
-				return folders.value
-					.filter((childFolder) => {
-						return childFolder.parent === folder.id;
-					})
-					.map((childFolder) => {
-						return {
-							...childFolder,
-							children: getChildFolders(childFolder),
-						};
-					});
-			}
+const loading = ref(false);
+const folders = ref<FolderRaw[]>([]);
+
+const tree = computed<Folder[]>(() => {
+	return folders.value
+		.filter((folder) => folder.parent === null)
+		.map((folder) => {
+			return {
+				...folder,
+				children: getChildFolders(folder),
+			};
 		});
 
-		const shouldBeOpen: string[] = [];
-		const folder = folders.value.find((folder) => folder.id === props.modelValue);
-
-		if (folder && folder.parent) parseFolder(folder.parent);
-
-		const startOpenFolders = ['root'];
-
-		for (const folderID of shouldBeOpen) {
-			if (startOpenFolders.includes(folderID) === false) {
-				startOpenFolders.push(folderID);
-			}
-		}
-
-		const selectedFolder = computed(() => {
-			return folders.value.find((folder) => folder.id === props.modelValue) || {};
-		});
-
-		const openFolders = ref(startOpenFolders);
-
-		fetchFolders();
-
-		return { t, loading, folders, tree, selectedFolder, openFolders };
-
-		async function fetchFolders() {
-			if (folders.value.length > 0) return;
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/folders`, {
-					params: {
-						limit: -1,
-						sort: 'name',
-					},
-				});
-
-				folders.value = response.data.data;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		function parseFolder(id: string) {
-			if (!folders.value) return;
-			shouldBeOpen.push(id);
-
-			const folder = folders.value.find((folder) => folder.id === id);
-
-			if (folder && folder.parent) {
-				parseFolder(folder.parent);
-			}
-		}
-	},
+	function getChildFolders(folder: FolderRaw): Folder[] {
+		return folders.value
+			.filter((childFolder) => {
+				return childFolder.parent === folder.id;
+			})
+			.map((childFolder) => {
+				return {
+					...childFolder,
+					children: getChildFolders(childFolder),
+				};
+			});
+	}
 });
+
+const shouldBeOpen: string[] = [];
+const selectedFolder = folders.value.find((folder) => folder.id === props.modelValue);
+
+if (selectedFolder && selectedFolder.parent) parseFolder(selectedFolder.parent);
+
+const startOpenFolders = ['root'];
+
+for (const folderID of shouldBeOpen) {
+	if (startOpenFolders.includes(folderID) === false) {
+		startOpenFolders.push(folderID);
+	}
+}
+
+const openFolders = ref(startOpenFolders);
+
+fetchFolders();
+
+async function fetchFolders() {
+	if (folders.value.length > 0) return;
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/folders`, {
+			params: {
+				limit: -1,
+				sort: 'name',
+			},
+		});
+
+		folders.value = response.data.data;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		loading.value = false;
+	}
+}
+
+function parseFolder(id: string) {
+	if (!folders.value) return;
+	shouldBeOpen.push(id);
+
+	const folder = folders.value.find((folder) => folder.id === id);
+
+	if (folder && folder.parent) {
+		parseFolder(folder.parent);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/header-bar-actions.vue
+++ b/app/src/views/private/components/header-bar-actions.vue
@@ -22,22 +22,18 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref } from 'vue';
+<script lang="ts" setup>
+import { ref } from 'vue';
 
-export default defineComponent({
-	props: {
-		showSidebarToggle: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['toggle:sidebar'],
-	setup() {
-		const active = ref(false);
-		return { active };
-	},
-});
+defineProps<{
+	showSidebarToggle?: boolean;
+}>();
+
+defineEmits<{
+	(e: 'toggle:sidebar'): void;
+}>();
+
+const active = ref(false);
 </script>
 
 <style scoped>

--- a/app/src/views/private/components/header-bar.vue
+++ b/app/src/views/private/components/header-bar.vue
@@ -36,57 +36,46 @@
 	</header>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref, onMounted, onUnmounted } from 'vue';
+<script lang="ts" setup>
+import { ref, onMounted, onUnmounted } from 'vue';
 import HeaderBarActions from './header-bar-actions.vue';
 
-export default defineComponent({
-	components: { HeaderBarActions },
-	props: {
-		title: {
-			type: String,
-			default: null,
-		},
-		showSidebarToggle: {
-			type: Boolean,
-			default: false,
-		},
-		primaryActionIcon: {
-			type: String,
-			default: 'menu',
-		},
-		small: {
-			type: Boolean,
-			default: false,
-		},
-		shadow: {
-			type: Boolean,
-			default: true,
-		},
+withDefaults(
+	defineProps<{
+		title?: string;
+		showSidebarToggle?: boolean;
+		primaryActionIcon?: string;
+		small?: boolean;
+		shadow?: boolean;
+	}>(),
+	{
+		primaryActionIcon: 'menu',
+		shadow: true,
+	}
+);
+
+defineEmits<{
+	(e: 'primary'): void;
+	(e: 'toggle:sidebar'): void;
+}>();
+
+const headerEl = ref<Element>();
+
+const collapsed = ref(false);
+
+const observer = new IntersectionObserver(
+	([e]) => {
+		collapsed.value = e.boundingClientRect.y === -1;
 	},
-	emits: ['primary', 'toggle:sidebar'],
-	setup() {
-		const headerEl = ref<Element>();
+	{ threshold: [1] }
+);
 
-		const collapsed = ref(false);
+onMounted(() => {
+	observer.observe(headerEl.value as HTMLElement);
+});
 
-		const observer = new IntersectionObserver(
-			([e]) => {
-				collapsed.value = e.boundingClientRect.y === -1;
-			},
-			{ threshold: [1] }
-		);
-
-		onMounted(() => {
-			observer.observe(headerEl.value as HTMLElement);
-		});
-
-		onUnmounted(() => {
-			observer.disconnect();
-		});
-
-		return { headerEl, collapsed };
-	},
+onUnmounted(() => {
+	observer.disconnect();
 });
 </script>
 

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -85,7 +85,7 @@
 							<v-list-item-icon><v-icon name="crop_square" /></v-list-item-icon>
 							<v-list-item-content>{{ t('square') }}</v-list-item-content>
 						</v-list-item>
-						<v-list-item clickable :active="aspectRatio === NaN" @click="aspectRatio = NaN">
+						<v-list-item clickable :active="Number.isNaN(aspectRatio)" @click="aspectRatio = NaN">
 							<v-list-item-icon><v-icon name="crop_free" /></v-list-item-icon>
 							<v-list-item-content>{{ t('free') }}</v-list-item-content>
 						</v-list-item>
@@ -123,17 +123,16 @@
 	</v-drawer>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import api from '@/api';
-import { computed, defineComponent, nextTick, reactive, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-
 import { useSettingsStore } from '@/stores/settings';
 import { getRootPath } from '@/utils/get-root-path';
 import { unexpectedError } from '@/utils/unexpected-error';
 import Cropper from 'cropperjs';
 import throttle from 'lodash/throttle';
 import { nanoid } from 'nanoid/non-secure';
+import { computed, nextTick, reactive, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Image = {
 	type: string;
@@ -143,367 +142,337 @@ type Image = {
 	height: number;
 };
 
-export default defineComponent({
-	props: {
-		id: {
-			type: String,
-			required: true,
-		},
-		modelValue: {
-			type: Boolean,
-			default: undefined,
-		},
+const props = defineProps<{
+	id: string;
+	modelValue?: boolean;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: boolean): void;
+	(e: 'refresh'): void;
+}>();
+
+const { t, n } = useI18n();
+
+const settingsStore = useSettingsStore();
+
+const localActive = ref(false);
+
+const internalActive = computed({
+	get() {
+		return props.modelValue === undefined ? localActive.value : props.modelValue;
 	},
-	emits: ['update:modelValue', 'refresh'],
-	setup(props, { emit }) {
-		const { t, n } = useI18n();
-
-		const settingsStore = useSettingsStore();
-
-		const localActive = ref(false);
-
-		const internalActive = computed({
-			get() {
-				return props.modelValue === undefined ? localActive.value : props.modelValue;
-			},
-			set(newActive: boolean) {
-				localActive.value = newActive;
-				emit('update:modelValue', newActive);
-			},
-		});
-
-		const { loading, error, imageData, imageElement, save, saving, fetchImage, onImageLoad } = useImage();
-
-		const {
-			cropperInstance,
-			initCropper,
-			flip,
-			rotate,
-			reset,
-			aspectRatio,
-			aspectRatioIcon,
-			newDimensions,
-			dragMode,
-			cropping,
-		} = useCropper();
-
-		watch(internalActive, (isActive) => {
-			if (isActive === true) {
-				fetchImage();
-			} else {
-				if (cropperInstance.value) {
-					cropperInstance.value.destroy();
-				}
-
-				loading.value = false;
-				error.value = null;
-				imageData.value = null;
-			}
-		});
-
-		const randomId = ref<string>(nanoid());
-
-		const imageURL = computed(() => {
-			return `${getRootPath()}assets/${props.id}?${randomId.value}`;
-		});
-
-		const dimensionsString = computed(() => {
-			let output = '';
-			const isSVG = imageData.value?.type === 'image/svg+xml';
-
-			if (imageData.value) {
-				if (isSVG) {
-					output += 'SVG';
-				} else {
-					output += `${n(imageData.value.width ?? 0)}x${n(imageData.value.height ?? 0)}`;
-				}
-
-				if (imageData.value.width !== newDimensions.width || imageData.value.height !== newDimensions.height) {
-					if (isSVG) {
-						if (newDimensions.width || newDimensions.height) {
-							output += ` -> PNG ${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
-						} else {
-							output += ' -> PNG';
-						}
-					} else {
-						output += ` -> ${isSVG ? 'PNG ' : ''}${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
-					}
-				}
-			}
-
-			return output;
-		});
-
-		const customAspectRatios = settingsStore.settings?.custom_aspect_ratios ?? null;
-
-		return {
-			t,
-			n,
-			internalActive,
-			loading,
-			error,
-			imageData,
-			imageElement,
-			save,
-			onImageLoad,
-			flip,
-			rotate,
-			reset,
-			aspectRatio,
-			aspectRatioIcon,
-			saving,
-			imageURL,
-			newDimensions,
-			dragMode,
-			cropping,
-			setAspectRatio,
-			dimensionsString,
-			customAspectRatios,
-		};
-
-		function useImage() {
-			const loading = ref(false);
-			const error = ref(null);
-			const imageData = ref<Image | null>(null);
-			const saving = ref(false);
-
-			const imageElement = ref<HTMLImageElement | null>(null);
-
-			return {
-				loading,
-				error,
-				imageData,
-				saving,
-				fetchImage,
-				imageElement,
-				save,
-				onImageLoad,
-			};
-
-			async function fetchImage() {
-				try {
-					loading.value = true;
-
-					const response = await api.get(`/files/${props.id}`, {
-						params: {
-							fields: ['type', 'filesize', 'filename_download', 'width', 'height'],
-						},
-					});
-
-					imageData.value = response.data.data;
-				} catch (err: any) {
-					error.value = err;
-				} finally {
-					loading.value = false;
-				}
-			}
-
-			function save() {
-				saving.value = true;
-
-				cropperInstance.value
-					?.getCroppedCanvas({
-						imageSmoothingQuality: 'high',
-					})
-					.toBlob(async (blob) => {
-						if (blob === null) {
-							saving.value = false;
-							return;
-						}
-
-						const formData = new FormData();
-						formData.append('file', blob, imageData.value?.filename_download);
-
-						try {
-							await api.patch(`/files/${props.id}`, formData);
-							emit('refresh');
-							internalActive.value = false;
-							randomId.value = nanoid();
-						} catch (err: any) {
-							unexpectedError(err);
-						} finally {
-							saving.value = false;
-						}
-					}, imageData.value?.type);
-			}
-
-			async function onImageLoad() {
-				await nextTick();
-				initCropper();
-			}
-		}
-
-		function useCropper() {
-			const cropperInstance = ref<Cropper | null>(null);
-
-			const localAspectRatio = ref(NaN);
-
-			const newDimensions = reactive({
-				width: null as null | number,
-				height: null as null | number,
-			});
-
-			watch(imageData, () => {
-				if (!imageData.value) return;
-				localAspectRatio.value = imageData.value.width / imageData.value.height;
-				newDimensions.width = imageData.value.width;
-				newDimensions.height = imageData.value.height;
-			});
-
-			const aspectRatio = computed<number>({
-				get() {
-					return localAspectRatio.value;
-				},
-				set(newAspectRatio) {
-					localAspectRatio.value = newAspectRatio;
-					cropperInstance.value?.setAspectRatio(newAspectRatio);
-					cropperInstance.value?.crop();
-					dragMode.value = 'crop';
-				},
-			});
-
-			const aspectRatioIcon = computed(() => {
-				if (!imageData.value) return 'crop_original';
-
-				if (customAspectRatios) {
-					const customAspectRatio = customAspectRatios.find((customAR) => customAR.value == aspectRatio.value);
-					if (customAspectRatio) return 'crop_square';
-				}
-
-				switch (aspectRatio.value) {
-					case 16 / 9:
-						return 'crop_16_9';
-					case 3 / 2:
-						return 'crop_3_2';
-					case 5 / 4:
-						return 'crop_5_4';
-					case 7 / 5:
-						return 'crop_7_5';
-					case 1 / 1:
-						return 'crop_square';
-					case imageData.value.width / imageData.value.height:
-						return 'crop_original';
-					default:
-						return 'crop_free';
-				}
-			});
-
-			const localDragMode = ref<'move' | 'crop'>('move');
-
-			const dragMode = computed({
-				get() {
-					return localDragMode.value;
-				},
-				set(newMode: 'move' | 'crop') {
-					cropperInstance.value?.setDragMode(newMode);
-					localDragMode.value = newMode;
-
-					if (newMode === 'move') {
-						cropperInstance.value?.clear();
-						localCropping.value = false;
-					}
-				},
-			});
-
-			const localCropping = ref(false);
-
-			const cropping = computed({
-				get() {
-					return localCropping.value;
-				},
-				set(newCropping: boolean) {
-					if (newCropping === false) {
-						cropperInstance.value?.clear();
-					}
-
-					localCropping.value = newCropping;
-				},
-			});
-
-			return {
-				cropperInstance,
-				initCropper,
-				flip,
-				rotate,
-				reset,
-				aspectRatio,
-				aspectRatioIcon,
-				newDimensions,
-				dragMode,
-				cropping,
-			};
-
-			function initCropper() {
-				if (imageElement.value === null) return;
-
-				if (cropperInstance.value) {
-					cropperInstance.value.destroy();
-				}
-
-				localCropping.value = false;
-
-				cropperInstance.value = new Cropper(imageElement.value, {
-					autoCrop: false,
-					autoCropArea: 0.5,
-					toggleDragModeOnDblclick: false,
-					dragMode: 'move',
-					viewMode: 1,
-					crop: throttle((event) => {
-						if (!imageData.value) return;
-
-						if (cropping.value === false && (event.detail.width || event.detail.height)) {
-							cropping.value = true;
-						}
-
-						const newWidth = event.detail.width || imageData.value.width;
-						const newHeight = event.detail.height || imageData.value.height;
-
-						if (event.detail.rotate === 0 || event.detail.rotate === -180) {
-							newDimensions.width = Math.round(newWidth);
-							newDimensions.height = Math.round(newHeight);
-						} else {
-							newDimensions.height = Math.round(newWidth);
-							newDimensions.width = Math.round(newHeight);
-						}
-					}, 50),
-				});
-			}
-
-			function flip(type: 'horizontal' | 'vertical') {
-				if (type === 'vertical') {
-					if (cropperInstance.value?.getData().scaleX === -1) {
-						cropperInstance.value?.scaleX(1);
-					} else {
-						cropperInstance.value?.scaleX(-1);
-					}
-				}
-
-				if (type === 'horizontal') {
-					if (cropperInstance.value?.getData().scaleY === -1) {
-						cropperInstance.value?.scaleY(1);
-					} else {
-						cropperInstance.value?.scaleY(-1);
-					}
-				}
-			}
-
-			function rotate() {
-				cropperInstance.value?.rotate(-90);
-			}
-
-			function reset() {
-				cropperInstance.value?.reset();
-				dragMode.value = 'move';
-			}
-		}
-
-		function setAspectRatio() {
-			if (imageData.value) {
-				aspectRatio.value = imageData.value.width / imageData.value.height;
-			}
-		}
+	set(newActive: boolean) {
+		localActive.value = newActive;
+		emit('update:modelValue', newActive);
 	},
 });
+
+const { loading, error, imageData, imageElement, save, saving, fetchImage, onImageLoad } = useImage();
+
+const {
+	cropperInstance,
+	initCropper,
+	flip,
+	rotate,
+	reset,
+	aspectRatio,
+	aspectRatioIcon,
+	newDimensions,
+	dragMode,
+	cropping,
+} = useCropper();
+
+watch(internalActive, (isActive) => {
+	if (isActive === true) {
+		fetchImage();
+	} else {
+		if (cropperInstance.value) {
+			cropperInstance.value.destroy();
+		}
+
+		loading.value = false;
+		error.value = null;
+		imageData.value = null;
+	}
+});
+
+const randomId = ref<string>(nanoid());
+
+const imageURL = computed(() => {
+	return `${getRootPath()}assets/${props.id}?${randomId.value}`;
+});
+
+const dimensionsString = computed(() => {
+	let output = '';
+	const isSVG = imageData.value?.type === 'image/svg+xml';
+
+	if (imageData.value) {
+		if (isSVG) {
+			output += 'SVG';
+		} else {
+			output += `${n(imageData.value.width ?? 0)}x${n(imageData.value.height ?? 0)}`;
+		}
+
+		if (imageData.value.width !== newDimensions.width || imageData.value.height !== newDimensions.height) {
+			if (isSVG) {
+				if (newDimensions.width || newDimensions.height) {
+					output += ` -> PNG ${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
+				} else {
+					output += ' -> PNG';
+				}
+			} else {
+				output += ` -> ${isSVG ? 'PNG ' : ''}${n(newDimensions.width ?? 0)}x${n(newDimensions.height ?? 0)}`;
+			}
+		}
+	}
+
+	return output;
+});
+
+const customAspectRatios = settingsStore.settings?.custom_aspect_ratios ?? null;
+
+function useImage() {
+	const loading = ref(false);
+	const error = ref(null);
+	const imageData = ref<Image | null>(null);
+	const saving = ref(false);
+
+	const imageElement = ref<HTMLImageElement | null>(null);
+
+	return {
+		loading,
+		error,
+		imageData,
+		saving,
+		fetchImage,
+		imageElement,
+		save,
+		onImageLoad,
+	};
+
+	async function fetchImage() {
+		try {
+			loading.value = true;
+
+			const response = await api.get(`/files/${props.id}`, {
+				params: {
+					fields: ['type', 'filesize', 'filename_download', 'width', 'height'],
+				},
+			});
+
+			imageData.value = response.data.data;
+		} catch (err: any) {
+			error.value = err;
+		} finally {
+			loading.value = false;
+		}
+	}
+
+	function save() {
+		saving.value = true;
+
+		cropperInstance.value
+			?.getCroppedCanvas({
+				imageSmoothingQuality: 'high',
+			})
+			.toBlob(async (blob) => {
+				if (blob === null) {
+					saving.value = false;
+					return;
+				}
+
+				const formData = new FormData();
+				formData.append('file', blob, imageData.value?.filename_download);
+
+				try {
+					await api.patch(`/files/${props.id}`, formData);
+					emit('refresh');
+					internalActive.value = false;
+					randomId.value = nanoid();
+				} catch (err: any) {
+					unexpectedError(err);
+				} finally {
+					saving.value = false;
+				}
+			}, imageData.value?.type);
+	}
+
+	async function onImageLoad() {
+		await nextTick();
+		initCropper();
+	}
+}
+
+function useCropper() {
+	const cropperInstance = ref<Cropper | null>(null);
+
+	const localAspectRatio = ref(NaN);
+
+	const newDimensions = reactive({
+		width: null as null | number,
+		height: null as null | number,
+	});
+
+	watch(imageData, () => {
+		if (!imageData.value) return;
+		localAspectRatio.value = imageData.value.width / imageData.value.height;
+		newDimensions.width = imageData.value.width;
+		newDimensions.height = imageData.value.height;
+	});
+
+	const aspectRatio = computed<number>({
+		get() {
+			return localAspectRatio.value;
+		},
+		set(newAspectRatio) {
+			localAspectRatio.value = newAspectRatio;
+			cropperInstance.value?.setAspectRatio(newAspectRatio);
+			cropperInstance.value?.crop();
+			dragMode.value = 'crop';
+		},
+	});
+
+	const aspectRatioIcon = computed(() => {
+		if (!imageData.value) return 'crop_original';
+
+		if (customAspectRatios) {
+			const customAspectRatio = customAspectRatios.find((customAR) => customAR.value == aspectRatio.value);
+			if (customAspectRatio) return 'crop_square';
+		}
+
+		switch (aspectRatio.value) {
+			case 16 / 9:
+				return 'crop_16_9';
+			case 3 / 2:
+				return 'crop_3_2';
+			case 5 / 4:
+				return 'crop_5_4';
+			case 7 / 5:
+				return 'crop_7_5';
+			case 1 / 1:
+				return 'crop_square';
+			case imageData.value.width / imageData.value.height:
+				return 'crop_original';
+			default:
+				return 'crop_free';
+		}
+	});
+
+	const localDragMode = ref<'move' | 'crop'>('move');
+
+	const dragMode = computed({
+		get() {
+			return localDragMode.value;
+		},
+		set(newMode: 'move' | 'crop') {
+			cropperInstance.value?.setDragMode(newMode);
+			localDragMode.value = newMode;
+
+			if (newMode === 'move') {
+				cropperInstance.value?.clear();
+				localCropping.value = false;
+			}
+		},
+	});
+
+	const localCropping = ref(false);
+
+	const cropping = computed({
+		get() {
+			return localCropping.value;
+		},
+		set(newCropping: boolean) {
+			if (newCropping === false) {
+				cropperInstance.value?.clear();
+			}
+
+			localCropping.value = newCropping;
+		},
+	});
+
+	return {
+		cropperInstance,
+		initCropper,
+		flip,
+		rotate,
+		reset,
+		aspectRatio,
+		aspectRatioIcon,
+		newDimensions,
+		dragMode,
+		cropping,
+	};
+
+	function initCropper() {
+		if (imageElement.value === null) return;
+
+		if (cropperInstance.value) {
+			cropperInstance.value.destroy();
+		}
+
+		localCropping.value = false;
+
+		cropperInstance.value = new Cropper(imageElement.value as HTMLImageElement, {
+			autoCrop: false,
+			autoCropArea: 0.5,
+			toggleDragModeOnDblclick: false,
+			dragMode: 'move',
+			viewMode: 1,
+			crop: throttle((event) => {
+				if (!imageData.value) return;
+
+				if (cropping.value === false && (event.detail.width || event.detail.height)) {
+					cropping.value = true;
+				}
+
+				const newWidth = event.detail.width || imageData.value.width;
+				const newHeight = event.detail.height || imageData.value.height;
+
+				if (event.detail.rotate === 0 || event.detail.rotate === -180) {
+					newDimensions.width = Math.round(newWidth);
+					newDimensions.height = Math.round(newHeight);
+				} else {
+					newDimensions.height = Math.round(newWidth);
+					newDimensions.width = Math.round(newHeight);
+				}
+			}, 50),
+		});
+	}
+
+	function flip(type: 'horizontal' | 'vertical') {
+		if (type === 'vertical') {
+			if (cropperInstance.value?.getData().scaleX === -1) {
+				cropperInstance.value?.scaleX(1);
+			} else {
+				cropperInstance.value?.scaleX(-1);
+			}
+		}
+
+		if (type === 'horizontal') {
+			if (cropperInstance.value?.getData().scaleY === -1) {
+				cropperInstance.value?.scaleY(1);
+			} else {
+				cropperInstance.value?.scaleY(-1);
+			}
+		}
+	}
+
+	function rotate() {
+		cropperInstance.value?.rotate(-90);
+	}
+
+	function reset() {
+		cropperInstance.value?.reset();
+		dragMode.value = 'move';
+	}
+}
+
+function setAspectRatio() {
+	if (imageData.value) {
+		aspectRatio.value = imageData.value.width / imageData.value.height;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/layout-sidebar-detail.vue
+++ b/app/src/views/private/components/layout-sidebar-detail.vue
@@ -4,8 +4,8 @@
 			<div class="field">
 				<div class="type-label">{{ t('layout') }}</div>
 				<v-select v-model="layout" :items="layouts" item-text="name" item-value="id" item-icon="icon">
-					<template v-if="currentLayout.icon" #prepend>
-						<v-icon :name="currentLayout.icon" />
+					<template v-if="currentLayout!.icon" #prepend>
+						<v-icon :name="currentLayout!.icon" />
 					</template>
 				</v-select>
 			</div>
@@ -15,35 +15,35 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, computed } from 'vue';
-import { useSync } from '@cairncms/composables';
-import { useExtensions } from '@/extensions';
+<script lang="ts" setup>
 import { useExtension } from '@/composables/use-extension';
+import { useExtensions } from '@/extensions';
+import { useSync } from '@cairncms/composables';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: String,
-			default: 'tabular',
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = withDefaults(
+	defineProps<{
+		modelValue?: string;
+	}>(),
+	{
+		modelValue: 'tabular',
+	}
+);
 
-		const { layouts } = useExtensions();
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: string): void;
+}>();
 
-		const selectedLayout = useExtension('layout', props.modelValue);
-		const fallbackLayout = useExtension('layout', 'tabular');
-		const currentLayout = computed(() => selectedLayout.value ?? fallbackLayout.value);
+const { t } = useI18n();
 
-		const layout = useSync(props, 'modelValue', emit);
+const { layouts } = useExtensions();
 
-		return { t, currentLayout, layouts, layout };
-	},
-});
+const selectedLayout = useExtension('layout', props.modelValue);
+const fallbackLayout = useExtension('layout', 'tabular');
+const currentLayout = computed(() => selectedLayout.value ?? fallbackLayout.value);
+
+const layout = useSync(props, 'modelValue', emit);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/module-bar-avatar.vue
+++ b/app/src/views/private/components/module-bar-avatar.vue
@@ -50,60 +50,45 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useAppStore } from '@/stores/app';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
-import { storeToRefs } from 'pinia';
-import { Ref, computed, defineComponent, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { getRootPath } from '@/utils/get-root-path';
+import { User } from '@cairncms/types';
+import { storeToRefs } from 'pinia';
+import { Ref, computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const appStore = useAppStore();
-		const notificationsStore = useNotificationsStore();
+const appStore = useAppStore();
+const notificationsStore = useNotificationsStore();
 
-		const { notificationsDrawerOpen } = storeToRefs(appStore);
-		const { unread } = storeToRefs(notificationsStore);
+const { notificationsDrawerOpen } = storeToRefs(appStore);
+const { unread } = storeToRefs(notificationsStore);
 
-		const userStore = useUserStore();
+const userStore = useUserStore();
 
-		const signOutActive = ref(false);
+const signOutActive = ref(false);
 
-		const avatarURL = computed<string | null>(() => {
-			if (!userStore.currentUser || !('avatar' in userStore.currentUser) || !userStore.currentUser?.avatar) return null;
-			return `${getRootPath()}assets/${userStore.currentUser.avatar.id}?key=system-medium-cover`;
-		});
-
-		const avatarError: Ref<null | Event> = ref(null);
-
-		const userProfileLink = computed<string>(() => {
-			const id = userStore.currentUser?.id;
-			return `/users/${id}`;
-		});
-
-		const signOutLink = computed<string>(() => {
-			return `/logout`;
-		});
-
-		const userFullName = userStore.fullName ?? undefined;
-
-		return {
-			t,
-			userFullName,
-			avatarURL,
-			userProfileLink,
-			signOutActive,
-			signOutLink,
-			notificationsDrawerOpen,
-			unread,
-			avatarError,
-		};
-	},
+const avatarURL = computed<string | null>(() => {
+	if (!userStore.currentUser || !('avatar' in userStore.currentUser) || !userStore.currentUser?.avatar) return null;
+	return `${getRootPath()}assets/${userStore.currentUser.avatar.id}?key=system-medium-cover`;
 });
+
+const avatarError: Ref<null | Event> = ref(null);
+
+const userProfileLink = computed<string>(() => {
+	const id = (userStore.currentUser as User).id;
+	return `/users/${id}`;
+});
+
+const signOutLink = computed<string>(() => {
+	return `/logout`;
+});
+
+const userFullName = userStore.fullName ?? undefined;
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/module-bar-logo.vue
+++ b/app/src/views/private/components/module-bar-logo.vue
@@ -18,56 +18,44 @@
 	</component>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useRequestsStore } from '@/stores/requests';
 import { useSettingsStore } from '@/stores/settings';
-import { computed, defineComponent, ref, toRefs, watch } from 'vue';
+import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { getRootPath } from '@/utils/get-root-path';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const requestsStore = useRequestsStore();
-		const settingsStore = useSettingsStore();
+const requestsStore = useRequestsStore();
+const settingsStore = useSettingsStore();
 
-		const customLogoPath = computed<string | null>(() => {
-			if (settingsStore.settings === null) return null;
-			if (!settingsStore.settings?.project_logo) return null;
-			return `${getRootPath()}assets/${settingsStore.settings.project_logo}`;
-		});
-
-		const showLoader = ref(false);
-
-		const { queueHasItems } = toRefs(requestsStore);
-
-		watch(
-			() => queueHasItems.value,
-			(hasItems) => {
-				if (hasItems) showLoader.value = true;
-			}
-		);
-
-		const url = computed(() => settingsStore.settings?.project_url);
-
-		const urlTooltip = computed(() => {
-			return settingsStore.settings?.project_url ? t('view_project') : false;
-		});
-
-		return {
-			customLogoPath,
-			showLoader,
-			stopSpinnerIfQueueIsEmpty,
-			url,
-			urlTooltip,
-		};
-
-		function stopSpinnerIfQueueIsEmpty() {
-			if (queueHasItems.value === false) showLoader.value = false;
-		}
-	},
+const customLogoPath = computed<string | null>(() => {
+	if (settingsStore.settings === null) return null;
+	if (!settingsStore.settings?.project_logo) return null;
+	return `${getRootPath()}assets/${settingsStore.settings.project_logo}`;
 });
+
+const showLoader = ref(false);
+
+const { queueHasItems } = toRefs(requestsStore);
+
+watch(
+	() => queueHasItems.value,
+	(hasItems) => {
+		if (hasItems) showLoader.value = true;
+	}
+);
+
+const url = computed(() => settingsStore.settings?.project_url);
+
+const urlTooltip = computed(() => {
+	return settingsStore.settings?.project_url ? t('view_project') : false;
+});
+
+function stopSpinnerIfQueueIsEmpty() {
+	if (queueHasItems.value === false) showLoader.value = false;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/module-bar.vue
+++ b/app/src/views/private/components/module-bar.vue
@@ -28,8 +28,8 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from 'vue';
+<script lang="ts" setup>
+import { computed } from 'vue';
 import ModuleBarLogo from './module-bar-logo.vue';
 import ModuleBarAvatar from './module-bar-avatar.vue';
 import { useSettingsStore } from '@/stores/settings';
@@ -38,50 +38,40 @@ import { MODULE_BAR_DEFAULT } from '@/constants';
 import { omit } from 'lodash';
 import { useExtensions } from '@/extensions';
 
-export default defineComponent({
-	components: {
-		ModuleBarLogo,
-		ModuleBarAvatar,
-	},
-	setup() {
-		const settingsStore = useSettingsStore();
-		const { modules: registeredModules } = useExtensions();
+const settingsStore = useSettingsStore();
+const { modules: registeredModules } = useExtensions();
 
-		const registeredModuleIDs = computed(() => registeredModules.value.map((module) => module.id));
+const registeredModuleIDs = computed(() => registeredModules.value.map((module) => module.id));
 
-		const modules = computed(() => {
-			if (!settingsStore.settings) return [];
+const modules = computed(() => {
+	if (!settingsStore.settings) return [];
 
-			return (settingsStore.settings.module_bar ?? MODULE_BAR_DEFAULT)
-				.filter((modulePart) => {
-					if (modulePart.type === 'link') return true;
-					return modulePart.enabled && registeredModuleIDs.value.includes(modulePart.id);
-				})
-				.map((modulePart) => {
-					if (modulePart.type === 'link') {
-						const link = omit<Record<string, any>>(modulePart, ['url']);
+	return (settingsStore.settings.module_bar ?? MODULE_BAR_DEFAULT)
+		.filter((modulePart) => {
+			if (modulePart.type === 'link') return true;
+			return modulePart.enabled && registeredModuleIDs.value.includes(modulePart.id);
+		})
+		.map((modulePart) => {
+			if (modulePart.type === 'link') {
+				const link = omit<Record<string, any>>(modulePart, ['url']);
 
-						if (modulePart.url.startsWith('/')) {
-							link.to = modulePart.url;
-						} else {
-							link.href = modulePart.url;
-						}
+				if (modulePart.url.startsWith('/')) {
+					link.to = modulePart.url;
+				} else {
+					link.href = modulePart.url;
+				}
 
-						return translate(link);
-					}
+				return translate(link);
+			}
 
-					const module = registeredModules.value.find((module) => module.id === modulePart.id)!;
+			const module = registeredModules.value.find((module) => module.id === modulePart.id)!;
 
-					return {
-						...modulePart,
-						...registeredModules.value.find((module) => module.id === modulePart.id),
-						to: `/${module.id}`,
-					};
-				});
+			return {
+				...modulePart,
+				...registeredModules.value.find((module) => module.id === modulePart.id),
+				to: `/${module.id}`,
+			};
 		});
-
-		return { modules };
-	},
 });
 </script>
 

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -10,7 +10,7 @@
 				</v-card-text>
 				<v-card-actions>
 					<v-button v-if="notification.type === 'error' && admin && notification.code === 'UNKNOWN'" secondary>
-						<a target="_blank" href="https://github.com/CairnCMS/cairncms/issues/new?template=bug_report.yml">
+						<a target="_blank" href="https://github.com/CairnCMS/cairncms/issues/new">
 							{{ t('report_error') }}
 						</a>
 					</v-button>

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -9,7 +9,7 @@
 					<v-error v-if="notification.error" :error="notification.error" />
 				</v-card-text>
 				<v-card-actions>
-					<v-button v-if="notification.type === 'error' && admin && notification.code === 'UNKNOWN'" secondary>
+					<v-button v-if="notification.type === 'error' && isAdmin && notification.code === 'UNKNOWN'" secondary>
 						<a target="_blank" href="https://github.com/CairnCMS/cairncms/issues/new">
 							{{ t('report_error') }}
 						</a>
@@ -21,28 +21,22 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
-import { computed, defineComponent } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	setup() {
-		const { t } = useI18n();
+const { t } = useI18n();
 
-		const notificationsStore = useNotificationsStore();
-		const userStore = useUserStore();
+const notificationsStore = useNotificationsStore();
+const { isAdmin } = useUserStore();
 
-		const notifications = computed(() => notificationsStore.dialogs);
+const notifications = computed(() => notificationsStore.dialogs);
 
-		return { t, notifications, admin: userStore.isAdmin, done };
-
-		function done(id: string) {
-			notificationsStore.remove(id);
-		}
-	},
-});
+function done(id: string) {
+	notificationsStore.remove(id);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/notification-item.vue
+++ b/app/src/views/private/components/notification-item.vue
@@ -15,66 +15,34 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script lang="ts" setup>
 import { useNotificationsStore } from '@/stores/notifications';
 
-export default defineComponent({
-	props: {
-		id: {
-			type: String,
-			required: true,
-		},
-		title: {
-			type: String,
-			required: true,
-		},
-		text: {
-			type: String,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: null,
-		},
-		type: {
-			type: String,
-			default: 'info',
-			validator: (val: string) => ['info', 'success', 'warning', 'error'].includes(val),
-		},
-		tail: {
-			type: Boolean,
-			default: false,
-		},
-		dense: {
-			type: Boolean,
-			default: false,
-		},
-		showClose: {
-			type: Boolean,
-			default: false,
-		},
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		progress: {
-			type: Number,
-			default: undefined,
-		},
-	},
-	setup(props) {
-		const notificationsStore = useNotificationsStore();
+const props = withDefaults(
+	defineProps<{
+		id: string;
+		title: string;
+		text?: string;
+		icon?: string | null;
+		type?: 'info' | 'success' | 'warning' | 'error';
+		tail?: boolean;
+		dense?: boolean;
+		showClose?: boolean;
+		loading?: boolean;
+		progress?: number;
+	}>(),
+	{
+		type: 'info',
+	}
+);
 
-		return { close };
+const notificationsStore = useNotificationsStore();
 
-		function close() {
-			if (props.showClose === true) {
-				notificationsStore.remove(props.id);
-			}
-		}
-	},
-});
+function close() {
+	if (props.showClose === true) {
+		notificationsStore.remove(props.id);
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -52,161 +52,136 @@
 	</v-drawer>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useAppStore } from '@/stores/app';
-import { useUserStore } from '@/stores/user';
-import { useNotificationsStore } from '@/stores/notifications';
-import { useCollectionsStore } from '@/stores/collections';
-import { storeToRefs } from 'pinia';
-import { Notification } from '@cairncms/types';
+<script lang="ts" setup>
 import api from '@/api';
 import { Header as TableHeader } from '@/components/v-table/types';
-import { Item } from '@cairncms/types';
-import { useRouter } from 'vue-router';
-import { parseISO } from 'date-fns';
+import { useAppStore } from '@/stores/app';
+import { useCollectionsStore } from '@/stores/collections';
+import { useNotificationsStore } from '@/stores/notifications';
+import { useUserStore } from '@/stores/user';
 import { localizedFormatDistance } from '@/utils/localized-format-distance';
+import { Item, Notification } from '@cairncms/types';
+import { parseISO } from 'date-fns';
+import { storeToRefs } from 'pinia';
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
+const { t } = useI18n();
+const appStore = useAppStore();
+const userStore = useUserStore();
+const notificationsStore = useNotificationsStore();
+const collectionsStore = useCollectionsStore();
+
+const router = useRouter();
+
+const notifications = ref<Notification[]>([]);
+const loading = ref(false);
+const error = ref(null);
+const selection = ref([]);
+const tab = ref(['inbox']);
+
+const { notificationsDrawerOpen } = storeToRefs(appStore);
+
+const tableHeaders = ref<TableHeader[]>([
+	{
+		text: t('subject'),
+		value: 'subject',
+		sortable: false,
+		width: 300,
+		align: 'left',
+		description: null,
 	},
-	emits: ['update:modelValue'],
-	setup(props) {
-		const { t } = useI18n();
-		const appStore = useAppStore();
-		const userStore = useUserStore();
-		const notificationsStore = useNotificationsStore();
-		const collectionsStore = useCollectionsStore();
+	{
+		text: t('timestamp'),
+		value: 'timestampDistance',
+		sortable: false,
+		width: 180,
+		align: 'left',
+		description: null,
+	},
+]);
 
-		const router = useRouter();
+fetchNotifications();
 
-		const notifications = ref<Notification[]>([]);
-		const page = ref(0);
-		const loading = ref(false);
-		const error = ref(null);
-		const selection = ref([]);
-		const tab = ref(['inbox']);
+watch(tab, () => fetchNotifications());
 
-		const { notificationsDrawerOpen } = storeToRefs(appStore);
+async function fetchNotifications() {
+	loading.value = true;
 
-		const tableHeaders = ref<TableHeader[]>([
-			{
-				text: t('subject'),
-				value: 'subject',
-				sortable: false,
-				width: 300,
-				align: 'left',
-			},
-			{
-				text: t('timestamp'),
-				value: 'timestampDistance',
-				sortable: false,
-				width: 180,
-				align: 'left',
-			},
-		]);
-
-		fetchNotifications();
-
-		watch([() => props.modelValue, tab], () => fetchNotifications());
-
-		return {
-			tableHeaders,
-			t,
-			notificationsDrawerOpen,
-			page,
-			notifications,
-			loading,
-			error,
-			selection,
-			onRowClick,
-			toggleArchive,
-			tab,
-		};
-
-		async function fetchNotifications() {
-			loading.value = true;
-
-			try {
-				const response = await api.get('/notifications', {
-					params: {
-						filter: {
-							_and: [
-								{
-									recipient: {
-										_eq: userStore.currentUser!.id,
-									},
-								},
-								{
-									status: {
-										_eq: tab.value[0],
-									},
-								},
-							],
+	try {
+		const response = await api.get('/notifications', {
+			params: {
+				filter: {
+					_and: [
+						{
+							recipient: {
+								_eq: userStore.currentUser!.id,
+							},
 						},
-						fields: ['id', 'subject', 'collection', 'item', 'timestamp'],
-						sort: ['-timestamp'],
-					},
-				});
-
-				await notificationsStore.getUnreadCount();
-
-				const notificationsRaw = response.data.data as Notification[];
-
-				const notificationsWithRelative: (Notification & { timestampDistance: string })[] = [];
-
-				for (const notification of notificationsRaw) {
-					notificationsWithRelative.push({
-						...notification,
-						timestampDistance: localizedFormatDistance(parseISO(notification.timestamp), new Date(), {
-							addSuffix: true,
-						}),
-					});
-				}
-
-				notifications.value = notificationsWithRelative;
-			} catch (err: any) {
-				error.value = err;
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		async function toggleArchive() {
-			await api.patch('/notifications', {
-				keys: selection.value.map(({ id }) => id),
-				data: {
-					status: tab.value[0] === 'inbox' ? 'archived' : 'inbox',
+						{
+							status: {
+								_eq: tab.value[0],
+							},
+						},
+					],
 				},
+				fields: ['id', 'subject', 'collection', 'item', 'timestamp'],
+				sort: ['-timestamp'],
+			},
+		});
+
+		await notificationsStore.getUnreadCount();
+
+		const notificationsRaw = response.data.data as Notification[];
+
+		const notificationsWithRelative: (Notification & { timestampDistance: string })[] = [];
+
+		for (const notification of notificationsRaw) {
+			notificationsWithRelative.push({
+				...notification,
+				timestampDistance: localizedFormatDistance(parseISO(notification.timestamp), new Date(), {
+					addSuffix: true,
+				}),
 			});
-
-			await fetchNotifications();
-
-			selection.value = [];
 		}
 
-		function onRowClick({ item }: { item: Item; event: PointerEvent }) {
-			if (item.collection) {
-				const collection = collectionsStore.getCollection(item.collection);
+		notifications.value = notificationsWithRelative;
+	} catch (err: any) {
+		error.value = err;
+	} finally {
+		loading.value = false;
+	}
+}
 
-				if (collection?.meta?.singleton) {
-					router.push(`/content/${item.collection}`);
-				} else {
-					router.push(`/content/${item.collection}/${item.item}`);
-				}
-			} else if (String(item.item).startsWith('/')) {
-				router.push(item.item);
-			}
+async function toggleArchive() {
+	await api.patch('/notifications', {
+		keys: selection.value.map(({ id }) => id),
+		data: {
+			status: tab.value[0] === 'inbox' ? 'archived' : 'inbox',
+		},
+	});
 
-			notificationsDrawerOpen.value = false;
+	await fetchNotifications();
+
+	selection.value = [];
+}
+
+function onRowClick({ item }: { item: Item; event: PointerEvent }) {
+	if (item.collection) {
+		const collection = collectionsStore.getCollection(item.collection);
+
+		if (collection?.meta?.singleton) {
+			router.push(`/content/${item.collection}`);
+		} else {
+			router.push(`/content/${item.collection}/${item.item}`);
 		}
-	},
-});
+	} else if (String(item.item).startsWith('/')) {
+		router.push(item.item);
+	}
+
+	notificationsDrawerOpen.value = false;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/notifications-group.vue
+++ b/app/src/views/private/components/notifications-group.vue
@@ -3,8 +3,13 @@
 		<slot />
 		<notification-item
 			v-for="(notification, index) in queue"
+			:id="notification.id"
 			:key="notification.id"
-			v-bind="notification"
+			:title="notification.title"
+			:icon="notification.icon"
+			:type="notification.type"
+			:loading="notification.loading"
+			:progress="notification.progress"
 			:tail="index === queue.length - 1"
 			:dense="sidebarOpen === false"
 			:show-close="notification.persist === true && notification.closeable !== false"
@@ -12,26 +17,17 @@
 	</transition-group>
 </template>
 
-<script lang="ts">
-import { defineComponent, toRefs } from 'vue';
+<script lang="ts" setup>
 import { useNotificationsStore } from '@/stores/notifications';
+import { toRefs } from 'vue';
 import NotificationItem from './notification-item.vue';
 
-export default defineComponent({
-	components: { NotificationItem },
-	props: {
-		sidebarOpen: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup() {
-		const notificationsStore = useNotificationsStore();
-		const queue = toRefs(notificationsStore).queue;
+defineProps<{
+	sidebarOpen?: boolean;
+}>();
 
-		return { queue };
-	},
-});
+const notificationsStore = useNotificationsStore();
+const queue = toRefs(notificationsStore).queue;
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/notifications-preview.vue
+++ b/app/src/views/private/components/notifications-preview.vue
@@ -25,33 +25,26 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
+import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import SidebarButton from './sidebar-button.vue';
 import NotificationItem from './notification-item.vue';
 import { useNotificationsStore } from '@/stores/notifications';
 
-export default defineComponent({
-	components: { SidebarButton, NotificationItem },
-	props: {
-		sidebarOpen: {
-			type: Boolean,
-			default: false,
-		},
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup() {
-		const { t } = useI18n();
+defineProps<{
+	sidebarOpen?: boolean;
+	modelValue?: boolean;
+}>();
 
-		const notificationsStore = useNotificationsStore();
-		return { t, lastFour: notificationsStore.lastFour };
-	},
-});
+defineEmits<{
+	(e: 'update:modelValue', value: boolean): void;
+}>();
+
+const { t } = useI18n();
+
+const notificationsStore = useNotificationsStore();
+const { lastFour } = storeToRefs(notificationsStore);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/project-info.vue
+++ b/app/src/views/private/components/project-info.vue
@@ -7,20 +7,14 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from 'vue';
+<script lang="ts" setup>
+import { computed } from 'vue';
 import { useServerStore } from '@/stores/server';
 
-export default defineComponent({
-	setup() {
-		const serverStore = useServerStore();
+const serverStore = useServerStore();
 
-		const name = computed(() => serverStore.info?.project?.project_name);
-		const descriptor = computed(() => serverStore.info?.project?.project_descriptor);
-
-		return { name, descriptor };
-	},
-});
+const name = computed(() => serverStore.info?.project?.project_name);
+const descriptor = computed(() => serverStore.info?.project?.project_descriptor);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/refresh-sidebar-detail.vue
+++ b/app/src/views/private/components/refresh-sidebar-detail.vue
@@ -9,75 +9,72 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { computed, defineComponent, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: Number,
-			default: null,
-		},
+const props = defineProps<{
+	modelValue: number | null;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: number | null): void;
+	(e: 'refresh'): void;
+}>();
+
+const { t } = useI18n();
+
+const interval = computed<number | null>({
+	get() {
+		return props.modelValue;
 	},
-	emits: ['update:modelValue', 'refresh'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
-
-		const interval = computed<number | null>({
-			get() {
-				return props.modelValue;
-			},
-			set(newVal) {
-				emit('update:modelValue', newVal);
-			},
-		});
-
-		const activeInterval = ref<NodeJS.Timeout | null>(null);
-
-		watch(
-			interval,
-			(newInterval) => {
-				if (activeInterval.value !== null) {
-					clearInterval(activeInterval.value);
-				}
-
-				if (newInterval !== null && newInterval > 0) {
-					activeInterval.value = setInterval(() => {
-						emit('refresh');
-					}, newInterval * 1000);
-				}
-			},
-			{ immediate: true }
-		);
-
-		const items = computed(() => {
-			const intervals = [null, 10, 30, 60, 300];
-
-			return intervals.map((seconds) => {
-				if (seconds === null)
-					return {
-						text: t('no_refresh'),
-						value: null,
-					};
-
-				return seconds >= 60 && seconds % 60 === 0
-					? {
-							text: t('refresh_interval_minutes', { minutes: seconds / 60 }, seconds / 60),
-							value: seconds,
-					  }
-					: {
-							text: t('refresh_interval_seconds', { seconds }, seconds),
-							value: seconds,
-					  };
-			});
-		});
-
-		const active = computed(() => interval.value !== null);
-
-		return { t, active, interval, items };
+	set(newVal) {
+		emit('update:modelValue', newVal);
 	},
 });
+
+const activeInterval = ref<NodeJS.Timeout | null>(null);
+
+watch(
+	interval,
+	(newInterval) => {
+		if (activeInterval.value !== null) {
+			clearInterval(activeInterval.value);
+		}
+
+		if (newInterval !== null && newInterval > 0) {
+			activeInterval.value = setInterval(() => {
+				emit('refresh');
+			}, newInterval * 1000);
+		}
+	},
+	{ immediate: true }
+);
+
+const items = computed(() => {
+	const intervals = [null, 10, 30, 60, 300];
+
+	return intervals.map((seconds) => {
+		if (seconds === null) {
+			return {
+				text: t('no_refresh'),
+				value: null,
+			};
+		}
+
+		return seconds >= 60 && seconds % 60 === 0
+			? {
+					text: t('refresh_interval_minutes', { minutes: seconds / 60 }, seconds / 60),
+					value: seconds,
+			  }
+			: {
+					text: t('refresh_interval_seconds', { seconds }, seconds),
+					value: seconds,
+			  };
+	});
+});
+
+const active = computed(() => interval.value !== null);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/render-display.vue
+++ b/app/src/views/private/components/render-display.vue
@@ -19,51 +19,24 @@
 	</v-error-boundary>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useExtension } from '@/composables/use-extension';
-import { defineComponent } from 'vue';
+import { toRefs } from 'vue';
 
-export default defineComponent({
-	props: {
-		display: {
-			type: String,
-			default: null,
-		},
-		options: {
-			type: Object,
-			default: () => ({}),
-		},
-		interface: {
-			type: String,
-			default: null,
-		},
-		interfaceOptions: {
-			type: Object,
-			default: null,
-		},
-		value: {
-			type: [String, Number, Object, Array, Boolean],
-			default: null,
-		},
-		type: {
-			type: String,
-			required: true,
-		},
-		collection: {
-			type: String,
-			required: true,
-		},
-		field: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const displayInfo = useExtension('display', props.display);
+const props = defineProps<{
+	display: string | null;
+	options?: Record<string, unknown>;
+	interface?: string;
+	interfaceOptions?: Record<string, unknown>;
+	value?: string | number | boolean | Record<string, unknown> | unknown[];
+	type: string;
+	collection: string;
+	field: string;
+}>();
 
-		return { displayInfo };
-	},
-});
+const { display } = toRefs(props);
+
+const displayInfo = useExtension('display', display);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -77,9 +77,11 @@ const parts = computed(() =>
 function handleArray(fieldKeyBefore: string, fieldKeyAfter: string) {
 	const value = get(props.item, fieldKeyBefore);
 
-	const field =
-		fieldsStore.getField(props.collection, fieldKeyBefore) ||
-		props.fields?.find((field) => field.field === fieldKeyBefore);
+	let field: Field | null = props.fields?.find((field) => field.field === fieldKeyBefore) ?? null;
+
+	if (props.collection) {
+		field = fieldsStore.getField(props.collection, fieldKeyBefore);
+	}
 
 	if (value === undefined) return null;
 
@@ -87,7 +89,7 @@ function handleArray(fieldKeyBefore: string, fieldKeyAfter: string) {
 
 	const displayInfo = useExtension(
 		'display',
-		computed(() => field.meta?.display ?? null)
+		computed(() => field?.meta?.display ?? null)
 	);
 
 	let component = field.meta?.display;
@@ -111,8 +113,11 @@ function handleArray(fieldKeyBefore: string, fieldKeyAfter: string) {
 }
 
 function handleObject(fieldKey: string) {
-	const field =
-		fieldsStore.getField(props.collection, fieldKey) || props.fields?.find((field) => field.field === fieldKey);
+	let field: Field | null = props.fields?.find((field) => field.field === fieldKey) ?? null;
+
+	if (props.collection) {
+		field = fieldsStore.getField(props.collection, fieldKey);
+	}
 
 	/**
 	 * This is for cases where you are rendering a display template directly on
@@ -142,7 +147,7 @@ function handleObject(fieldKey: string) {
 
 	const displayInfo = useExtension(
 		'display',
-		computed(() => field.meta?.display ?? null)
+		computed(() => field?.meta?.display ?? null)
 	);
 
 	// If used display doesn't exist in the current project, return raw value

--- a/app/src/views/private/components/revision-item.vue
+++ b/app/src/views/private/components/revision-item.vue
@@ -7,7 +7,11 @@
 		<div class="content">
 			<span class="time">{{ time }}</span>
 			–
-			<user-popover v-if="revision.activity.user" class="user" :user="revision.activity.user.id">
+			<user-popover
+				v-if="revision.activity.user"
+				class="user"
+				:user="typeof revision.activity.user === 'string' ? revision.activity.user : revision.activity.user.id"
+			>
 				<span>{{ user }}</span>
 			</user-popover>
 
@@ -16,61 +20,53 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
+<script lang="ts" setup>
 import { Revision } from '@/types/revisions';
-import { format } from 'date-fns';
 import { userName } from '@/utils/user-name';
+import { format } from 'date-fns';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		revision: {
-			type: Object as PropType<Revision>,
-			required: true,
-		},
-		last: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['click'],
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	revision: Revision;
+	last?: boolean;
+}>();
 
-		const revisionCount = computed(() => {
-			return Object.keys(props.revision.delta).length;
-		});
+defineEmits<{
+	(e: 'click'): void;
+}>();
 
-		const headerMessage = computed(() => {
-			switch (props.revision.activity.action.toLowerCase()) {
-				case 'create':
-					return t('revision_delta_created');
-				case 'update':
-					return t('revision_delta_updated', revisionCount.value);
-				case 'delete':
-					return t('revision_delta_deleted');
-				case 'revert':
-					return t('revision_delta_reverted');
-				default:
-					return t('revision_delta_other');
-			}
-		});
+const { t } = useI18n();
 
-		const time = computed(() => {
-			return format(new Date(props.revision.activity.timestamp), String(t('date-fns_time')));
-		});
+const revisionCount = computed(() => {
+	return Object.keys(props.revision.delta).length;
+});
 
-		const user = computed(() => {
-			if (props.revision?.activity?.user && typeof props.revision.activity.user === 'object') {
-				return userName(props.revision.activity.user);
-			}
+const headerMessage = computed(() => {
+	switch (props.revision.activity.action.toLowerCase()) {
+		case 'create':
+			return t('revision_delta_created');
+		case 'update':
+			return t('revision_delta_updated', revisionCount.value);
+		case 'delete':
+			return t('revision_delta_deleted');
+		case 'revert':
+			return t('revision_delta_reverted');
+		default:
+			return t('revision_delta_other');
+	}
+});
 
-			return t('private_user');
-		});
+const time = computed(() => {
+	return format(new Date(props.revision.activity.timestamp), String(t('date-fns_time')));
+});
 
-		return { t, headerMessage, time, user };
-	},
+const user = computed(() => {
+	if (props.revision?.activity?.user && typeof props.revision.activity.user === 'object') {
+		return userName(props.revision.activity.user);
+	}
+
+	return t('private_user');
 });
 </script>
 

--- a/app/src/views/private/components/revisions-date-group.vue
+++ b/app/src/views/private/components/revisions-date-group.vue
@@ -13,12 +13,13 @@
 </template>
 
 <script lang="ts" setup>
+import { RevisionsByDate } from '@/types/revisions';
 import { ref } from 'vue';
 
 import RevisionItem from './revision-item.vue';
 
 interface Props {
-	group: Record<string, any>;
+	group: RevisionsByDate;
 }
 
 defineProps<Props>();

--- a/app/src/views/private/components/revisions-drawer-detail.vue
+++ b/app/src/views/private/components/revisions-drawer-detail.vue
@@ -12,11 +12,11 @@
 
 		<template v-else>
 			<template v-for="group in revisionsByDate" :key="group.date.toString()">
-				<RevisionsDateGroup :group="group" @click="openModal" />
+				<revisions-date-group :group="group" @click="openModal" />
 			</template>
 
 			<template v-if="page == pagesCount && !created">
-				<v-divider v-if="revisionsByDate.length > 0" />
+				<v-divider v-if="revisionsByDate!.length > 0" />
 
 				<div class="external">
 					{{ t('revision_delta_created_externally') }}

--- a/app/src/views/private/components/revisions-drawer-picker.vue
+++ b/app/src/views/private/components/revisions-drawer-picker.vue
@@ -22,76 +22,68 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed, watch, ref } from 'vue';
+<script lang="ts" setup>
 import { Revision } from '@/types/revisions';
-import { useSync } from '@cairncms/composables';
 import { localizedFormat } from '@/utils/localized-format';
 import { userName } from '@/utils/user-name';
+import { useSync } from '@cairncms/composables';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Option = {
 	text: string;
 	value: number;
 };
 
-export default defineComponent({
-	props: {
-		revisions: {
-			type: Array as PropType<Revision[]>,
-			required: true,
-		},
-		current: {
-			type: Number,
-			required: true,
-		},
-	},
-	emits: ['update:current'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	revisions: Revision[];
+	current: number | null;
+}>();
 
-		const internalCurrent = useSync(props, 'current', emit);
+const emit = defineEmits<{
+	(e: 'update:current', value: number): void;
+}>();
 
-		const options = ref<Option[] | null>(null);
+const { t } = useI18n();
 
-		watch(
-			() => props.revisions,
-			async () => {
-				const newOptions = [];
+const internalCurrent = useSync(props, 'current', emit);
 
-				for (const revision of props.revisions) {
-					const date = await getFormattedDate(revision);
-					let user = t('private_user');
+const options = ref<Option[]>([]);
 
-					if (typeof revision.activity.user === 'object') {
-						const userInfo = revision.activity.user;
-						user = userName(userInfo);
-					}
+watch(
+	() => props.revisions,
+	async () => {
+		const newOptions = [];
 
-					const text = String(t('revision_delta_by', { date, user }));
-					const value = revision.id;
-					newOptions.push({ text, value });
-				}
+		for (const revision of props.revisions) {
+			const date = await getFormattedDate(revision);
+			let user = t('private_user');
 
-				options.value = newOptions;
-			},
-			{ immediate: true }
-		);
+			if (typeof revision.activity.user === 'object') {
+				const userInfo = revision.activity.user;
+				user = userName(userInfo);
+			}
 
-		const selectedOption = computed(() => {
-			return options.value?.find((option) => option.value === internalCurrent.value);
-		});
-
-		return { internalCurrent, options, selectedOption };
-
-		async function getFormattedDate(revision: Revision) {
-			const date = localizedFormat(new Date(revision!.activity.timestamp), String(t('date-fns_date_short')));
-			const time = localizedFormat(new Date(revision!.activity.timestamp), String(t('date-fns_time')));
-
-			return `${date} (${time})`;
+			const text = String(t('revision_delta_by', { date, user }));
+			const value = revision.id;
+			newOptions.push({ text, value });
 		}
+
+		options.value = newOptions;
 	},
+	{ immediate: true }
+);
+
+const selectedOption = computed(() => {
+	return options.value.find((option) => option.value === internalCurrent.value);
 });
+
+async function getFormattedDate(revision: Revision) {
+	const date = localizedFormat(new Date(revision!.activity.timestamp), String(t('date-fns_date_short')));
+	const time = localizedFormat(new Date(revision!.activity.timestamp), String(t('date-fns_time')));
+
+	return `${date} (${time})`;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/revisions-drawer-preview.vue
+++ b/app/src/views/private/components/revisions-drawer-preview.vue
@@ -10,23 +10,15 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType } from 'vue';
 import { Revision } from '@/types/revisions';
 
-export default defineComponent({
-	props: {
-		revision: {
-			type: Object as PropType<Revision>,
-			required: true,
-		},
-	},
-	setup() {
-		const { t } = useI18n();
-		return { t };
-	},
-});
+defineProps<{
+	revision: Revision;
+}>();
+
+const { t } = useI18n();
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/revisions-drawer-updates-change.vue
+++ b/app/src/views/private/components/revisions-drawer-updates-change.vue
@@ -13,9 +13,9 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
+import { computed } from 'vue';
 import { ArrayChange } from 'diff';
 
 export type Change = {
@@ -26,47 +26,30 @@ export type Change = {
 	value: string;
 };
 
-export default defineComponent({
-	props: {
-		changes: {
-			type: Array as PropType<Change[] | ArrayChange<any>[]>,
-			required: true,
-		},
-		added: {
-			type: Boolean,
-			default: false,
-		},
-		deleted: {
-			type: Boolean,
-			default: false,
-		},
-		updated: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	changes: Change[] | ArrayChange<any>[];
+	added?: boolean;
+	deleted?: boolean;
+	updated?: boolean;
+}>();
 
-		const changesFiltered = computed(() => {
-			return (props.changes as Change[]).filter((change: any) => {
-				if (props.updated) return true;
+const { t } = useI18n();
 
-				if (props.added === true) {
-					return change.removed !== true;
-				}
+const changesFiltered = computed(() => {
+	return (props.changes as Change[]).filter((change: any) => {
+		if (props.updated) return true;
 
-				return change.added !== true;
-			});
-		});
+		if (props.added === true) {
+			return change.removed !== true;
+		}
 
-		// The whole value changed instead of parts, this should disable the highlighting
-		const wholeThing = computed(() => {
-			return props.changes.length === 2; // before/after
-		});
+		return change.added !== true;
+	});
+});
 
-		return { t, changesFiltered, wholeThing };
-	},
+// The whole value changed instead of parts, this should disable the highlighting
+const wholeThing = computed(() => {
+	return props.changes.length === 2; // before/after
 });
 </script>
 

--- a/app/src/views/private/components/revisions-drawer-updates.vue
+++ b/app/src/views/private/components/revisions-drawer-updates.vue
@@ -19,106 +19,90 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed } from 'vue';
-import { Revision } from '@/types/revisions';
+<script lang="ts" setup>
 import { useFieldsStore } from '@/stores/fields';
-import { diffWordsWithSpace, diffJson, diffArrays } from 'diff';
-import RevisionsDrawerUpdatesChange from './revisions-drawer-updates-change.vue';
+import { Revision } from '@/types/revisions';
+import { diffArrays, diffJson, diffWordsWithSpace } from 'diff';
 import { isEqual } from 'lodash';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import RevisionsDrawerUpdatesChange from './revisions-drawer-updates-change.vue';
 
-export default defineComponent({
-	components: { RevisionsDrawerUpdatesChange },
-	props: {
-		revision: {
-			type: Object as PropType<Revision>,
-			required: true,
-		},
-		revisions: {
-			type: Array as PropType<Revision[]>,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	revision: Revision;
+	revisions: Revision[];
+}>();
 
-		const fieldsStore = useFieldsStore();
+const { t } = useI18n();
 
-		const previousRevision = computed(() => {
-			const currentIndex = props.revisions.findIndex((revision) => revision.id === props.revision.id);
+const fieldsStore = useFieldsStore();
 
-			// This is assuming props.revisions is in chronological order from newest to oldest
-			return props.revisions[currentIndex + 1];
-		});
+const previousRevision = computed(() => {
+	const currentIndex = props.revisions.findIndex((revision) => revision.id === props.revision.id);
 
-		const changes = computed(() => {
-			if (!previousRevision.value) return null;
+	// This is assuming props.revisions is in chronological order from newest to oldest
+	return props.revisions[currentIndex + 1];
+});
 
-			const changedFields = Object.keys(props.revision.delta);
+const changes = computed(() => {
+	if (!previousRevision.value) return [];
 
-			return changedFields
-				.map((fieldKey) => {
-					const field = fieldsStore.getField(props.revision.collection, fieldKey);
-					const name = field?.name;
+	const changedFields = Object.keys(props.revision.delta);
 
-					if (!name) return null;
+	return changedFields
+		.map((fieldKey) => {
+			const field = fieldsStore.getField(props.revision.collection, fieldKey);
+			const name = field?.name;
 
-					const currentValue = props.revision.delta?.[fieldKey];
-					const previousValue = previousRevision.value.data?.[fieldKey];
+			if (!name) return null;
 
-					let changes;
-					let updated = false;
+			const currentValue = props.revision.delta?.[fieldKey];
+			const previousValue = previousRevision.value.data?.[fieldKey];
 
-					if (isEqual(currentValue, previousValue)) {
-						if (field?.meta?.special && field.meta.special.includes('conceal')) {
-							updated = true;
+			let changes;
+			let updated = false;
 
-							changes = [
-								{
-									updated: true,
-									value: currentValue,
-								},
-							];
-						} else {
-							return null;
-						}
-					} else if (
-						typeof previousValue === 'string' &&
-						typeof currentValue === 'string' &&
-						currentValue.length > 25
-					) {
-						changes = diffWordsWithSpace(previousValue, currentValue);
-					} else if (Array.isArray(previousValue) && Array.isArray(currentValue)) {
-						changes = diffArrays(previousValue, currentValue);
-					} else if (
-						previousValue &&
-						currentValue &&
-						typeof currentValue === 'object' &&
-						typeof currentValue === 'object'
-					) {
-						changes = diffJson(previousValue, currentValue);
-					} else {
-						// This is considering the whole thing a change
-						changes = [
-							{
-								removed: true,
-								value: previousValue,
-							},
-							{
-								added: true,
-								value: currentValue,
-							},
-						];
-					}
+			if (isEqual(currentValue, previousValue)) {
+				if (field?.meta?.special && field.meta.special.includes('conceal')) {
+					updated = true;
 
-					return { name, updated, changes };
-				})
-				.filter((change) => change);
-		});
+					changes = [
+						{
+							updated: true,
+							value: currentValue,
+						},
+					];
+				} else {
+					return null;
+				}
+			} else if (typeof previousValue === 'string' && typeof currentValue === 'string' && currentValue.length > 25) {
+				changes = diffWordsWithSpace(previousValue, currentValue);
+			} else if (Array.isArray(previousValue) && Array.isArray(currentValue)) {
+				changes = diffArrays(previousValue, currentValue);
+			} else if (
+				previousValue &&
+				currentValue &&
+				typeof currentValue === 'object' &&
+				typeof currentValue === 'object'
+			) {
+				changes = diffJson(previousValue, currentValue);
+			} else {
+				// This is considering the whole thing a change
+				changes = [
+					{
+						removed: true,
+						value: previousValue,
+					},
+					{
+						added: true,
+						value: currentValue,
+					},
+				];
+			}
 
-		return { t, changes, previousRevision };
-	},
+			return { name, updated, changes };
+		})
+		.filter((change) => change);
 });
 </script>
 

--- a/app/src/views/private/components/revisions-drawer.vue
+++ b/app/src/views/private/components/revisions-drawer.vue
@@ -40,101 +40,91 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, PropType, computed, ref, watchEffect } from 'vue';
-import { useSync } from '@cairncms/composables';
+<script lang="ts" setup>
 import { Revision } from '@/types/revisions';
+import { useSync } from '@cairncms/composables';
+import { isEqual } from 'lodash';
+import { computed, ref, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
 import RevisionsDrawerPicker from './revisions-drawer-picker.vue';
 import RevisionsDrawerPreview from './revisions-drawer-preview.vue';
 import RevisionsDrawerUpdates from './revisions-drawer-updates.vue';
-import { isEqual } from 'lodash';
 
-export default defineComponent({
-	components: { RevisionsDrawerPicker, RevisionsDrawerPreview, RevisionsDrawerUpdates },
-	props: {
-		revisions: {
-			type: Array as PropType<Revision[]>,
-			required: true,
-		},
-		current: {
-			type: [Number, String],
-			default: null,
-		},
-		active: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['revert', 'update:active', 'update:current'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	revisions: Revision[];
+	current: number | null;
+	active: boolean;
+}>();
 
-		const internalActive = useSync(props, 'active', emit);
-		const internalCurrent = useSync(props, 'current', emit);
+const emit = defineEmits<{
+	(e: 'revert', value: Record<string, unknown>): void;
+	(e: 'update:active', value: boolean): void;
+	(e: 'update:current', value: number | string): void;
+}>();
 
-		const currentTab = ref(['updates_made']);
+const { t } = useI18n();
 
-		const title = computed(() => {
-			return currentRevision.value?.activity.action === 'create' ? t('item_creation') : t('item_revision');
-		});
+const internalActive = useSync(props, 'active', emit);
+const internalCurrent = useSync(props, 'current', emit);
 
-		const currentRevision = computed(() => {
-			return props.revisions.find((revision) => revision.id === props.current);
-		});
+const currentTab = ref(['updates_made']);
 
-		const previousRevision = computed<Revision | undefined>(() => {
-			const currentIndex = props.revisions.findIndex((revision) => revision.id === props.current);
-
-			// This is assuming props.revisions is in chronological order from newest to oldest
-			return props.revisions[currentIndex + 1];
-		});
-
-		const tabs = computed(() => {
-			return currentRevision.value?.activity.action === 'create'
-				? [
-						{
-							text: t('creation_preview'),
-							value: 'revision_preview',
-						},
-				  ]
-				: [
-						{
-							text: t('updates_made'),
-							value: 'updates_made',
-						},
-						{
-							text: t('revision_preview'),
-							value: 'revision_preview',
-						},
-				  ];
-		});
-
-		const hasPastRevision = computed(() => {
-			return currentRevision.value?.activity.action !== 'create' ? true : false;
-		});
-
-		watchEffect(() => (currentTab.value = [tabs.value[0].value]));
-
-		return { t, internalActive, internalCurrent, title, currentRevision, currentTab, tabs, hasPastRevision, revert };
-
-		function revert() {
-			if (!currentRevision.value) return;
-
-			const revertToValues: Record<string, any> = {};
-
-			for (const [field, newValue] of Object.entries(currentRevision.value.delta)) {
-				const previousValue = previousRevision.value?.data[field] ?? null;
-				if (isEqual(newValue, previousValue)) continue;
-				revertToValues[field] = previousValue;
-			}
-
-			emit('revert', revertToValues);
-
-			internalActive.value = false;
-		}
-	},
+const title = computed(() => {
+	return currentRevision.value?.activity.action === 'create' ? t('item_creation') : t('item_revision');
 });
+
+const currentRevision = computed(() => {
+	return props.revisions.find((revision) => revision.id === props.current)!;
+});
+
+const previousRevision = computed<Revision | undefined>(() => {
+	const currentIndex = props.revisions.findIndex((revision) => revision.id === props.current);
+
+	// This is assuming props.revisions is in chronological order from newest to oldest
+	return props.revisions[currentIndex + 1];
+});
+
+const tabs = computed(() => {
+	return currentRevision.value?.activity.action === 'create'
+		? [
+				{
+					text: t('creation_preview'),
+					value: 'revision_preview',
+				},
+		  ]
+		: [
+				{
+					text: t('updates_made'),
+					value: 'updates_made',
+				},
+				{
+					text: t('revision_preview'),
+					value: 'revision_preview',
+				},
+		  ];
+});
+
+const hasPastRevision = computed(() => {
+	return currentRevision.value?.activity.action !== 'create';
+});
+
+watchEffect(() => (currentTab.value = [tabs.value[0].value]));
+
+function revert() {
+	if (!currentRevision.value) return;
+
+	const revertToValues: Record<string, any> = {};
+
+	for (const [field, newValue] of Object.entries(currentRevision.value.delta)) {
+		const previousValue = previousRevision.value?.data[field] ?? null;
+		if (isEqual(newValue, previousValue)) continue;
+		revertToValues[field] = previousValue;
+	}
+
+	emit('revert', revertToValues);
+
+	internalActive.value = false;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/save-options.vue
+++ b/app/src/views/private/components/save-options.vue
@@ -5,21 +5,21 @@
 		</template>
 
 		<v-list>
-			<v-list-item v-if="!disabledOptions.includes('save-and-stay')" clickable @click="$emit('save-and-stay')">
+			<v-list-item v-if="!disabledOptions?.includes('save-and-stay')" clickable @click="$emit('save-and-stay')">
 				<v-list-item-icon><v-icon name="check" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_stay') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item v-if="!disabledOptions.includes('save-and-add-new')" clickable @click="$emit('save-and-add-new')">
+			<v-list-item v-if="!disabledOptions?.includes('save-and-add-new')" clickable @click="$emit('save-and-add-new')">
 				<v-list-item-icon><v-icon name="add" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_and_create_new') }}</v-list-item-content>
 				<v-list-item-hint>{{ translateShortcut(['meta', 'shift', 's']) }}</v-list-item-hint>
 			</v-list-item>
-			<v-list-item v-if="!disabledOptions.includes('save-as-copy')" clickable @click="$emit('save-as-copy')">
+			<v-list-item v-if="!disabledOptions?.includes('save-as-copy')" clickable @click="$emit('save-as-copy')">
 				<v-list-item-icon><v-icon name="done_all" /></v-list-item-icon>
 				<v-list-item-content>{{ t('save_as_copy') }}</v-list-item-content>
 			</v-list-item>
-			<v-list-item v-if="!disabledOptions.includes('discard-and-stay')" clickable @click="$emit('discard-and-stay')">
+			<v-list-item v-if="!disabledOptions?.includes('discard-and-stay')" clickable @click="$emit('discard-and-stay')">
 				<v-list-item-icon><v-icon name="undo" /></v-list-item-icon>
 				<v-list-item-content>{{ t('discard_all_changes') }}</v-list-item-content>
 			</v-list-item>
@@ -27,25 +27,22 @@
 	</v-menu>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent } from 'vue';
 import { translateShortcut } from '@/utils/translate-shortcut';
 
-export default defineComponent({
-	props: {
-		disabledOptions: {
-			type: Array,
-			default: () => [],
-		},
-	},
-	emits: ['save-and-stay', 'save-and-add-new', 'save-as-copy', 'discard-and-stay'],
-	setup() {
-		const { t } = useI18n();
+defineProps<{
+	disabledOptions?: string[];
+}>();
 
-		return { t, translateShortcut };
-	},
-});
+defineEmits<{
+	(e: 'save-and-stay'): void;
+	(e: 'save-and-add-new'): void;
+	(e: 'save-as-copy'): void;
+	(e: 'discard-and-stay'): void;
+}>();
+
+const { t } = useI18n();
 </script>
 
 <style scoped>

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -42,134 +42,113 @@
 	</v-badge>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch, PropType, computed, inject, Ref } from 'vue';
+<script lang="ts" setup>
+import { useElementSize } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
 import { isObject } from 'lodash';
-import { useElementSize } from '@cairncms/composables';
+import { Ref, computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: String,
-			default: null,
-		},
-		collection: {
-			type: String,
-			required: true,
-		},
-		filter: {
-			type: Object as PropType<Filter>,
-			default: null,
-		},
+const props = defineProps<{
+	modelValue: string | null;
+	collection: string;
+	filter?: Filter | null;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: string | null): void;
+	(e: 'update:filter', value: Filter | null): void;
+}>();
+
+const { t } = useI18n();
+
+const input = ref<HTMLInputElement | null>(null);
+
+const active = ref(props.modelValue !== null);
+const filterActive = ref(false);
+const filterBorder = ref(false);
+
+const mainElement = inject<Ref<Element | undefined>>('main-element');
+const filterElement = ref<HTMLElement>();
+const { width: mainElementWidth } = useElementSize(mainElement!);
+const { width: filterElementWidth } = useElementSize(filterElement);
+
+watch(
+	[mainElementWidth, filterElementWidth],
+	() => {
+		if (!filterElement.value) return;
+
+		const searchElement = filterElement.value.parentElement!;
+		const minWidth = searchElement.offsetWidth - 4;
+
+		if (filterElementWidth.value > minWidth) {
+			filterElement.value.style.borderTopLeftRadius =
+				filterElementWidth.value > minWidth + 22 ? 22 + 'px' : filterElementWidth.value - minWidth + 'px';
+		} else {
+			filterElement.value.style.borderTopLeftRadius = '0px';
+		}
+
+		const headerElement = mainElement?.value?.firstElementChild;
+
+		if (!headerElement) return;
+
+		const maxWidth =
+			searchElement.getBoundingClientRect().right -
+			(headerElement.getBoundingClientRect().left +
+				Number(window.getComputedStyle(headerElement).paddingLeft.replace('px', '')));
+
+		filterElement.value.style.maxWidth = maxWidth > minWidth ? `${String(maxWidth)}px` : '0px';
 	},
-	emits: ['update:modelValue', 'update:filter'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+	{ immediate: true }
+);
 
-		const input = ref<HTMLInputElement | null>(null);
-
-		const active = ref(props.modelValue !== null);
-		const filterActive = ref(false);
-		const filterBorder = ref(false);
-
-		const mainElement = inject<Ref<Element | undefined>>('main-element');
-		const filterElement = ref<HTMLElement>();
-		const { width: mainElementWidth } = useElementSize(mainElement!);
-		const { width: filterElementWidth } = useElementSize(filterElement);
-
-		watch(
-			[mainElementWidth, filterElementWidth],
-			() => {
-				if (!filterElement.value) return;
-
-				const searchElement = filterElement.value.parentElement!;
-				const minWidth = searchElement.offsetWidth - 4;
-
-				if (filterElementWidth.value > minWidth) {
-					filterElement.value.style.borderTopLeftRadius =
-						filterElementWidth.value > minWidth + 22 ? 22 + 'px' : filterElementWidth.value - minWidth + 'px';
-				} else {
-					filterElement.value.style.borderTopLeftRadius = '0px';
-				}
-
-				const headerElement = mainElement?.value?.firstElementChild;
-
-				if (!headerElement) return;
-
-				const maxWidth =
-					searchElement.getBoundingClientRect().right -
-					(headerElement.getBoundingClientRect().left +
-						Number(window.getComputedStyle(headerElement).paddingLeft.replace('px', '')));
-
-				filterElement.value.style.maxWidth = maxWidth > minWidth ? `${String(maxWidth)}px` : '0px';
-			},
-			{ immediate: true }
-		);
-
-		watch(active, (newActive: boolean) => {
-			if (newActive === true && input.value !== null) {
-				input.value.focus();
-			}
-		});
-
-		const activeFilterCount = computed(() => {
-			if (!props.filter) return 0;
-
-			let filterOperators: string[] = [];
-
-			parseLevel(props.filter);
-
-			return filterOperators.length;
-
-			function parseLevel(level: Record<string, any>) {
-				for (const [key, value] of Object.entries(level)) {
-					if (key === '_and' || key === '_or') {
-						value.forEach(parseLevel);
-					} else if (key.startsWith('_')) {
-						filterOperators.push(key);
-					} else {
-						if (isObject(value)) {
-							parseLevel(value);
-						}
-					}
-				}
-			}
-		});
-
-		return {
-			t,
-			active,
-			disable,
-			input,
-			emitValue,
-			activeFilterCount,
-			filterActive,
-			onClickOutside,
-			filterBorder,
-			filterElement,
-		};
-
-		function onClickOutside(e: { path?: HTMLElement[]; composedPath?: () => HTMLElement[] }) {
-			const path = e.path || e.composedPath!();
-			if (path.some((el) => el?.classList?.contains('v-menu-content'))) return false;
-
-			return true;
-		}
-
-		function disable() {
-			active.value = false;
-			filterActive.value = false;
-		}
-
-		function emitValue() {
-			if (!input.value) return;
-			const value = input.value?.value;
-			emit('update:modelValue', value);
-		}
-	},
+watch(active, (newActive: boolean) => {
+	if (newActive === true && input.value !== null) {
+		input.value.focus();
+	}
 });
+
+const activeFilterCount = computed(() => {
+	if (!props.filter) return 0;
+
+	let filterOperators: string[] = [];
+
+	parseLevel(props.filter);
+
+	return filterOperators.length;
+
+	function parseLevel(level: Record<string, any>) {
+		for (const [key, value] of Object.entries(level)) {
+			if (key === '_and' || key === '_or') {
+				value.forEach(parseLevel);
+			} else if (key.startsWith('_')) {
+				filterOperators.push(key);
+			} else {
+				if (isObject(value)) {
+					parseLevel(value);
+				}
+			}
+		}
+	}
+});
+
+function onClickOutside(e: { path?: HTMLElement[]; composedPath?: () => HTMLElement[] }) {
+	const path = e.path || e.composedPath!();
+	if (path.some((el) => el?.classList?.contains('v-menu-content'))) return false;
+
+	return true;
+}
+
+function disable() {
+	active.value = false;
+	filterActive.value = false;
+}
+
+function emitValue() {
+	if (!input.value) return;
+	const value = input.value?.value;
+	emit('update:modelValue', value);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/share-item.vue
+++ b/app/src/views/private/components/share-item.vue
@@ -49,56 +49,53 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { format } from 'date-fns';
+<script setup lang="ts">
 import { isAllowed } from '@/utils/is-allowed';
+import { Share } from '@cairncms/types';
+import { format } from 'date-fns';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		share: {
-			type: Object,
-			required: true,
-		},
-	},
-	emits: ['copy', 'edit', 'invite', 'delete'],
-	setup(props) {
-		const { t, d } = useI18n();
+const props = defineProps<{
+	share: Share;
+}>();
 
-		const editAllowed = computed(() => {
-			return isAllowed('directus_shares', 'update', props.share);
-		});
+defineEmits<{
+	(e: 'copy'): void;
+	(e: 'edit'): void;
+	(e: 'invite'): void;
+	(e: 'delete'): void;
+}>();
 
-		const deleteAllowed = computed(() => {
-			return isAllowed('directus_shares', 'delete', props.share);
-		});
+const { t } = useI18n();
 
-		const usesLeft = computed(() => {
-			if (props.share.max_uses === null) return null;
-			return props.share.max_uses - props.share.times_used;
-		});
+const editAllowed = computed(() => {
+	return isAllowed('directus_shares', 'update', props.share);
+});
 
-		const status = computed(() => {
-			if (props.share.date_end && new Date(props.share.date_end) < new Date()) {
-				return 'expired';
-			}
+const deleteAllowed = computed(() => {
+	return isAllowed('directus_shares', 'delete', props.share);
+});
 
-			if (props.share.date_start && new Date(props.share.date_start) > new Date()) {
-				return 'upcoming';
-			}
+const usesLeft = computed(() => {
+	if (props.share.max_uses === null) return null;
+	return props.share.max_uses - props.share.times_used;
+});
 
-			return null;
-		});
+const status = computed(() => {
+	if (props.share.date_end && new Date(props.share.date_end) < new Date()) {
+		return 'expired';
+	}
 
-		const formattedTime = computed(() => {
-			return format(new Date(props.share.date_created), String(t('date-fns_date_short')));
-		});
+	if (props.share.date_start && new Date(props.share.date_start) > new Date()) {
+		return 'upcoming';
+	}
 
-		const confirmDelete = ref<string | null>(null);
+	return null;
+});
 
-		return { editAllowed, deleteAllowed, usesLeft, status, t, d, formattedTime, confirmDelete };
-	},
+const formattedTime = computed(() => {
+	return format(new Date(props.share.date_created), String(t('date-fns_date_short')));
 });
 </script>
 

--- a/app/src/views/private/components/shares-sidebar-detail.vue
+++ b/app/src/views/private/components/shares-sidebar-detail.vue
@@ -74,10 +74,9 @@
 	</sidebar-detail>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, computed } from 'vue';
-import DrawerItem from '@/views/private/components/drawer-item.vue';
+import { computed, ref } from 'vue';
 import { getRootPath } from '@/utils/get-root-path';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { Share } from '@cairncms/types';
@@ -85,179 +84,145 @@ import { useClipboard } from '@/composables/use-clipboard';
 
 import api from '@/api';
 import ShareItem from './share-item.vue';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
 
-export default defineComponent({
-	components: { ShareItem, DrawerItem },
-	props: {
-		collection: {
-			type: String,
-			required: true,
-		},
-		primaryKey: {
-			type: [String, Number],
-			required: true,
-		},
-		allowed: {
-			type: Boolean,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	collection: string;
+	primaryKey: string | number;
+	allowed: boolean;
+}>();
 
-		const { copyToClipboard } = useClipboard();
+const { t } = useI18n();
 
-		const shares = ref<Share[] | null>(null);
-		const count = ref(0);
-		const error = ref(null);
-		const loading = ref(false);
-		const deleting = ref(false);
-		const shareToEdit = ref<string | null>(null);
-		const shareToSend = ref<Share | null>(null);
-		const shareToDelete = ref<Share | null>(null);
-		const sending = ref(false);
-		const sendEmails = ref('');
+const { copyToClipboard } = useClipboard();
 
-		const sendPublicLink = computed(() => {
-			if (!shareToSend.value) return null;
-			return window.location.origin + getRootPath() + 'admin/shared/' + shareToSend.value.id;
+const shares = ref<Share[] | null>([]);
+const count = ref(0);
+const error = ref(null);
+const loading = ref(false);
+const deleting = ref(false);
+const shareToEdit = ref<string | null>(null);
+const shareToSend = ref<Share | null>(null);
+const shareToDelete = ref<Share | null>(null);
+const sending = ref(false);
+const sendEmails = ref('');
+
+const sendPublicLink = computed(() => {
+	if (!shareToSend.value) return null;
+	return window.location.origin + getRootPath() + 'admin/shared/' + shareToSend.value.id;
+});
+
+refresh();
+
+async function input(data: any) {
+	if (!data) return;
+
+	data.collection = props.collection;
+	data.item = props.primaryKey;
+
+	try {
+		if (shareToEdit.value === '+') {
+			await api.post('/shares', data);
+		} else {
+			await api.patch(`/shares/${shareToEdit.value}`, data);
+		}
+
+		await refresh();
+
+		shareToEdit.value = null;
+	} catch (error: any) {
+		unexpectedError(error);
+	}
+}
+
+async function copy(id: string) {
+	const url = window.location.origin + getRootPath() + 'admin/shared/' + id;
+	await copyToClipboard(url, { success: t('share_copy_link_success'), fail: t('share_copy_link_error') });
+}
+
+function select(id: string) {
+	shareToEdit.value = id;
+}
+
+function unselect() {
+	shareToEdit.value = null;
+}
+
+async function refresh() {
+	error.value = null;
+	loading.value = true;
+
+	try {
+		const response = await api.get(`/shares`, {
+			params: {
+				filter: {
+					_and: [
+						{
+							collection: {
+								_eq: props.collection,
+							},
+						},
+						{
+							item: {
+								_eq: props.primaryKey,
+							},
+						},
+					],
+				},
+				sort: 'name',
+			},
 		});
 
-		refresh();
+		count.value = response.data.data.length;
+		shares.value = response.data.data;
+	} catch (error: any) {
+		error.value = error;
+	} finally {
+		loading.value = false;
+	}
+}
 
-		return {
-			shareToDelete,
-			t,
-			shares,
-			loading,
-			error,
-			refresh,
-			count,
-			select,
-			unselect,
-			shareToEdit,
-			input,
-			copy,
-			shareToSend,
-			remove,
-			deleting,
-			sendPublicLink,
-			send,
-			sending,
-			sendEmails,
-		};
+async function remove() {
+	if (!shareToDelete.value) return;
 
-		async function input(data: any) {
-			if (!data) return;
+	deleting.value = true;
 
-			data.collection = props.collection;
-			data.item = props.primaryKey;
+	try {
+		await api.delete(`/shares/${shareToDelete.value.id}`);
+		await refresh();
+		shareToDelete.value = null;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		deleting.value = false;
+	}
+}
 
-			try {
-				if (shareToEdit.value === '+') {
-					await api.post('/shares', data);
-				} else {
-					await api.patch(`/shares/${shareToEdit.value}`, data);
-				}
+async function send() {
+	if (!shareToSend.value) return;
 
-				await refresh();
+	sending.value = true;
 
-				shareToEdit.value = null;
-			} catch (error: any) {
-				unexpectedError(error);
-			}
-		}
+	try {
+		const emailsParsed = sendEmails.value
+			.split(/,|\n/)
+			.filter((e) => e)
+			.map((email) => email.trim());
 
-		async function copy(id: string) {
-			const url = window.location.origin + getRootPath() + 'admin/shared/' + id;
-			await copyToClipboard(url, { success: t('share_copy_link_success'), fail: t('share_copy_link_error') });
-		}
+		await api.post('/shares/invite', {
+			emails: emailsParsed,
+			share: shareToSend.value.id,
+		});
 
-		function select(id: string) {
-			shareToEdit.value = id;
-		}
+		sendEmails.value = '';
 
-		function unselect() {
-			shareToEdit.value = null;
-		}
-
-		async function refresh() {
-			error.value = null;
-			loading.value = true;
-
-			try {
-				const response = await api.get(`/shares`, {
-					params: {
-						filter: {
-							_and: [
-								{
-									collection: {
-										_eq: props.collection,
-									},
-								},
-								{
-									item: {
-										_eq: props.primaryKey,
-									},
-								},
-							],
-						},
-						sort: 'name',
-					},
-				});
-
-				count.value = response.data.data.length;
-				shares.value = response.data.data;
-			} catch (error: any) {
-				error.value = error;
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		async function remove() {
-			if (!shareToDelete.value) return;
-
-			deleting.value = true;
-
-			try {
-				await api.delete(`/shares/${shareToDelete.value.id}`);
-				await refresh();
-				shareToDelete.value = null;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				deleting.value = false;
-			}
-		}
-
-		async function send() {
-			if (!shareToSend.value) return;
-
-			sending.value = true;
-
-			try {
-				const emailsParsed = sendEmails.value
-					.split(/,|\n/)
-					.filter((e) => e)
-					.map((email) => email.trim());
-
-				await api.post('/shares/invite', {
-					emails: emailsParsed,
-					share: shareToSend.value.id,
-				});
-
-				sendEmails.value = '';
-
-				shareToSend.value = null;
-			} catch (err: any) {
-				unexpectedError(err);
-			} finally {
-				sending.value = false;
-			}
-		}
-	},
-});
+		shareToSend.value = null;
+	} catch (err: any) {
+		unexpectedError(err);
+	} finally {
+		sending.value = false;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/sidebar-button.vue
+++ b/app/src/views/private/components/sidebar-button.vue
@@ -6,7 +6,7 @@
 		@click="$emit('click', $event)"
 	>
 		<div class="icon">
-			<v-icon :name="icon" />
+			<v-icon :name="icon!" />
 		</div>
 		<div v-if="sidebarOpen" class="title">
 			<slot />
@@ -14,33 +14,27 @@
 	</component>
 </template>
 
-<script lang="ts">
-import { defineComponent, toRefs } from 'vue';
+<script lang="ts" setup>
+import { toRefs } from 'vue';
 import { useAppStore } from '@/stores/app';
 
-export default defineComponent({
-	props: {
-		to: {
-			type: String,
-			default: null,
-		},
-		icon: {
-			type: String,
-			default: 'deployed_code',
-		},
-		active: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	emits: ['click'],
-	setup() {
-		const appStore = useAppStore();
-		const { sidebarOpen } = toRefs(appStore);
+withDefaults(
+	defineProps<{
+		to?: string;
+		icon?: string;
+		active?: boolean;
+	}>(),
+	{
+		icon: 'deployed_code',
+	}
+);
 
-		return { sidebarOpen };
-	},
-});
+defineEmits<{
+	(e: 'click', event: MouseEvent): void;
+}>();
+
+const appStore = useAppStore();
+const { sidebarOpen } = toRefs(appStore);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/sidebar-detail-group.vue
+++ b/app/src/views/private/components/sidebar-detail-group.vue
@@ -4,43 +4,33 @@
 	</v-item-group>
 </template>
 
-<script lang="ts">
-import { defineComponent, nextTick, ref, watch } from 'vue';
-export default defineComponent({
-	props: {
-		sidebarOpen: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		// By syncing the opened item here, we can force close the module once the sidebar closes
-		const openDetail = ref<string[]>([]);
+<script lang="ts" setup>
+import { nextTick, ref, watch } from 'vue';
 
-		const mandatory = ref(false);
+const props = defineProps<{
+	sidebarOpen?: boolean;
+}>();
 
-		watch(
-			() => props.sidebarOpen,
-			async (newOpenState) => {
-				if (newOpenState === false) {
-					openDetail.value = [];
-				} else {
-					// Ensures the first item in the sidebar is automatically opened whenever the sidebar opens.
-					mandatory.value = true;
-					await nextTick();
+// By syncing the opened item here, we can force close the module once the sidebar closes
+const openDetail = ref<string[]>([]);
 
-					// Still allow the user to manually close it afterwards
-					mandatory.value = false;
-				}
-			}
-		);
+const mandatory = ref(false);
 
-		return {
-			openDetail,
-			mandatory,
-		};
-	},
-});
+watch(
+	() => props.sidebarOpen,
+	async (newOpenState) => {
+		if (newOpenState === false) {
+			openDetail.value = [];
+		} else {
+			// Ensures the first item in the sidebar is automatically opened whenever the sidebar opens.
+			mandatory.value = true;
+			await nextTick();
+
+			// Still allow the user to manually close it afterwards
+			mandatory.value = false;
+		}
+	}
+);
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/sidebar-detail.vue
+++ b/app/src/views/private/components/sidebar-detail.vue
@@ -26,41 +26,25 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, toRefs } from 'vue';
+<script lang="ts" setup>
+import { toRefs } from 'vue';
 import { useAppStore } from '@/stores/app';
 import { useGroupable } from '@cairncms/composables';
 
-export default defineComponent({
-	props: {
-		icon: {
-			type: String,
-			required: true,
-		},
-		title: {
-			type: String,
-			required: true,
-		},
-		badge: {
-			type: [Boolean, String, Number],
-			default: null,
-		},
-		close: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup(props) {
-		const { active, toggle } = useGroupable({
-			value: props.title,
-			group: 'sidebar-detail',
-		});
+const props = defineProps<{
+	icon: string;
+	title: string;
+	badge?: boolean | string | number;
+	close?: boolean;
+}>();
 
-		const appStore = useAppStore();
-		const { sidebarOpen } = toRefs(appStore);
-		return { active, toggle, sidebarOpen };
-	},
+const { active, toggle } = useGroupable({
+	value: props.title,
+	group: 'sidebar-detail',
 });
+
+const appStore = useAppStore();
+const { sidebarOpen } = toRefs(appStore);
 </script>
 
 <style>

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -22,87 +22,79 @@
 			</v-avatar>
 			<div class="data">
 				<div class="name type-title">{{ userName(data) }}</div>
-				<div class="status-role" :class="data.status">{{ t(data.status) }} {{ data.role.name }}</div>
+				<div class="status-role" :class="data!.status">{{ t(data.status) }} {{ data.role.name }}</div>
 				<div class="email">{{ data.email }}</div>
 			</div>
 		</div>
 	</v-menu>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import api from '@/api';
 import { userName } from '@/utils/user-name';
 import { User } from '@cairncms/types';
-import { computed, defineComponent, onUnmounted, ref, watch } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
-export default defineComponent({
-	props: {
-		user: {
-			type: String,
-			required: true,
-		},
-	},
-	setup(props) {
-		const { t } = useI18n();
+const props = defineProps<{
+	user: string;
+}>();
 
-		const router = useRouter();
+const { t } = useI18n();
 
-		const loading = ref(false);
-		const error = ref(null);
-		const data = ref<User | null>(null);
+const router = useRouter();
 
-		const avatarSrc = computed(() => {
-			if (data.value === null) return null;
+const loading = ref(false);
+const error = ref(null);
+const data = ref<User | null>(null);
 
-			if (data.value.avatar?.id) {
-				return `/assets/${data.value.avatar.id}?key=system-medium-cover`;
-			}
+const avatarSrc = computed(() => {
+	if (data.value === null) return null;
 
-			return null;
-		});
+	if (data.value.avatar?.id) {
+		return `/assets/${data.value.avatar.id}?key=system-medium-cover`;
+	}
 
-		const active = ref(false);
-
-		watch(active, () => {
-			if (active.value === true && data.value === null && loading.value === false) {
-				fetchUser();
-			}
-		});
-
-		onUnmounted(() => {
-			loading.value = false;
-			error.value = null;
-			data.value = null;
-		});
-
-		return { t, loading, error, data, active, avatarSrc, userName, navigateToUser };
-
-		async function fetchUser() {
-			loading.value = true;
-			error.value = null;
-
-			try {
-				const response = await api.get(`/users/${props.user}`, {
-					params: {
-						fields: ['id', 'first_name', 'last_name', 'avatar.id', 'role.name', 'status', 'email'],
-					},
-				});
-
-				data.value = response.data.data;
-			} catch (err: any) {
-				error.value = err;
-			} finally {
-				loading.value = false;
-			}
-		}
-
-		function navigateToUser() {
-			if (data.value) router.push(`/users/${data.value.id}`);
-		}
-	},
+	return null;
 });
+
+const active = ref(false);
+
+watch(active, () => {
+	if (active.value === true && data.value === null && loading.value === false) {
+		fetchUser();
+	}
+});
+
+onUnmounted(() => {
+	loading.value = false;
+	error.value = null;
+	data.value = null;
+});
+
+async function fetchUser() {
+	loading.value = true;
+	error.value = null;
+
+	try {
+		const response = await api.get(`/users/${props.user}`, {
+			params: {
+				fields: ['id', 'first_name', 'last_name', 'avatar.id', 'role.name', 'status', 'email'],
+			},
+		});
+
+		data.value = response.data.data;
+	} catch (err: any) {
+		error.value = err;
+	} finally {
+		loading.value = false;
+	}
+}
+
+function navigateToUser() {
+	if (data.value) router.push(`/users/${data.value.id}`);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/users-invite.vue
+++ b/app/src/views/private/components/users-invite.vue
@@ -19,8 +19,8 @@
 					</div>
 					<v-notice v-if="uniqueValidationErrors.length > 0" class="field" type="danger">
 						<div v-for="(err, i) in uniqueValidationErrors" :key="i">
-							<template v-if="err.extensions.invalid">
-								{{ t('email_already_invited', { email: err.extensions.invalid }) }}
+							<template v-if="(err as any).extensions.invalid">
+								{{ t('email_already_invited', { email: (err as any).extensions.invalid }) }}
 							</template>
 							<template v-else-if="i === 0">
 								{{ t('validationError.unique') }}
@@ -40,99 +40,91 @@
 	</v-dialog>
 </template>
 
-<script lang="ts">
-import { useI18n } from 'vue-i18n';
-import { defineComponent, ref, watch } from 'vue';
+<script lang="ts" setup>
 import api from '@/api';
-import { PUBLIC_ROLE_ID } from '@cairncms/constants';
-import { unexpectedError } from '@/utils/unexpected-error';
 import { APIError } from '@/types/error';
+import { unexpectedError } from '@/utils/unexpected-error';
+import { PUBLIC_ROLE_ID } from '@cairncms/constants';
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	props: {
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
-		role: {
-			type: String,
-			default: null,
-		},
-	},
-	emits: ['update:modelValue'],
-	setup(props, { emit }) {
-		const { t } = useI18n();
+const props = defineProps<{
+	modelValue: boolean;
+	role?: string;
+}>();
 
-		const emails = ref<string>('');
-		const roles = ref<Record<string, any>[]>([]);
-		const roleSelected = ref<string | null>(props.role);
-		const loading = ref(false);
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: boolean): void;
+}>();
 
-		const uniqueValidationErrors = ref([]);
+const { t } = useI18n();
 
-		watch(
-			() => props.modelValue,
-			() => {
-				loadRoles();
-			}
+const emails = ref<string>('');
+const roles = ref<Record<string, any>[]>([]);
+const roleSelected = ref<string | undefined>(props.role);
+const loading = ref(false);
+
+const uniqueValidationErrors = ref([]);
+
+watch(
+	() => props.modelValue,
+	() => {
+		loadRoles();
+	}
+);
+
+async function inviteUsers() {
+	loading.value = true;
+
+	try {
+		const emailsParsed = emails.value
+			.split(/,|\n/)
+			.filter((e) => e)
+			.map((email) => email.trim());
+
+		await api.post('/users/invite', {
+			email: emailsParsed,
+			role: roleSelected.value,
+		});
+
+		emails.value = '';
+		emit('update:modelValue', false);
+	} catch (err: any) {
+		uniqueValidationErrors.value = err?.response?.data?.errors?.filter((error: APIError) => {
+			return error.extensions?.code === 'RECORD_NOT_UNIQUE';
+		});
+
+		const otherErrors = err?.response?.data?.errors?.filter(
+			(err: APIError) => err?.extensions?.code !== 'RECORD_NOT_UNIQUE'
 		);
 
-		return { t, emails, inviteUsers, roles, roleSelected, loading, uniqueValidationErrors };
-
-		async function inviteUsers() {
-			loading.value = true;
-
-			try {
-				const emailsParsed = emails.value
-					.split(/,|\n/)
-					.filter((e) => e)
-					.map((email) => email.trim());
-
-				await api.post('/users/invite', {
-					email: emailsParsed,
-					role: roleSelected.value,
-				});
-
-				emails.value = '';
-				emit('update:modelValue', false);
-			} catch (err: any) {
-				uniqueValidationErrors.value = err?.response?.data?.errors?.filter((error: APIError) => {
-					return error.extensions?.code === 'RECORD_NOT_UNIQUE';
-				});
-
-				const otherErrors = err?.response?.data?.errors?.filter(
-					(err: APIError) => err?.extensions?.code !== 'RECORD_NOT_UNIQUE'
-				);
-
-				if (otherErrors.length > 0) {
-					otherErrors.forEach((err: APIError) => unexpectedError(err));
-				}
-			} finally {
-				loading.value = false;
-			}
+		if (otherErrors.length > 0) {
+			otherErrors.forEach((err: APIError) => unexpectedError(err));
 		}
+	} finally {
+		loading.value = false;
+	}
+}
 
-		async function loadRoles() {
-			const response = await api.get('/roles', {
-				params: {
-					sort: 'name',
-					fields: ['id', 'name'],
-				},
-			});
+async function loadRoles() {
+	const response = await api.get('/roles', {
+		params: {
+			sort: 'name',
+			fields: ['id', 'name'],
+		},
+	});
 
-			roles.value = response.data.data
-				.filter((role: Record<string, any>) => role.id !== PUBLIC_ROLE_ID)
-				.map((role: Record<string, any>) => ({
-					text: role.name,
-					value: role.id,
-				}));
+	roles.value = response.data.data
+		.filter((role: Record<string, any>) => role.id !== PUBLIC_ROLE_ID)
+		.map((role: Record<string, any>) => ({
+			text: role.name,
+			value: role.id,
+		}));
 
-			if (roles.value.length > 0 && roleSelected.value === null) {
-				roleSelected.value = roles.value[0].value;
-			}
-		}
-	},
-});
+	if (roles.value.length > 0 && roleSelected.value === null) {
+		roleSelected.value = roles.value[0].value;
+	}
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -2,10 +2,18 @@
 	<div class="public-view" :class="{ branded: isBranded }">
 		<div class="container" :class="{ wide }">
 			<div class="title-box">
-				<div v-if="info?.project?.project_logo" class="logo" :style="{ backgroundColor: info?.project.project_color }">
+				<div
+					v-if="info?.project?.project_logo"
+					class="logo"
+					:style="info?.project.project_color ? { backgroundColor: info.project.project_color } : {}"
+				>
 					<v-image :src="logoURL" :alt="info?.project.project_name || 'Logo'" />
 				</div>
-				<div v-else class="logo" :style="{ backgroundColor: info?.project?.project_color }">
+				<div
+					v-else
+					class="logo"
+					:style="info?.project?.project_color ? { backgroundColor: info.project.project_color } : {}"
+				>
 					<img src="./logo-dark.svg" alt="CairnCMS" class="cairncms-logo" />
 				</div>
 				<div class="title">
@@ -150,7 +158,7 @@ const hasCustomBackground = computed(() => {
 });
 
 const artStyles = computed(() => {
-	if (!hasCustomBackground.value) return null;
+	if (!hasCustomBackground.value) return {};
 
 	const url = getRootPath() + `assets/${info.value!.project?.public_background}`;
 

--- a/app/src/views/shared/shared-view.vue
+++ b/app/src/views/shared/shared-view.vue
@@ -5,17 +5,21 @@
 				<div class="container">
 					<div class="title-box">
 						<div
-							v-if="serverInfo?.project.project_logo"
+							v-if="serverInfo?.project?.project_logo"
 							class="logo"
-							:style="{ backgroundColor: serverInfo?.project.project_color }"
+							:style="serverInfo?.project?.project_color ? { backgroundColor: serverInfo.project.project_color } : {}"
 						>
-							<img :src="logoURL" :alt="serverInfo?.project.project_name || 'Logo'" />
+							<img :src="logoURL!" :alt="serverInfo?.project.project_name || 'Logo'" />
 						</div>
-						<div v-else class="logo" :style="{ backgroundColor: serverInfo?.project.project_color }">
+						<div
+							v-else
+							class="logo"
+							:style="serverInfo?.project?.project_color ? { backgroundColor: serverInfo.project.project_color } : {}"
+						>
 							<img src="../../assets/logo.svg" alt="CairnCMS" class="cairncms-logo" />
 						</div>
 						<div class="title">
-							<p class="subtitle">{{ serverInfo?.project.project_name }}</p>
+							<p class="subtitle">{{ serverInfo?.project?.project_name }}</p>
 							<slot name="title">
 								<h1 class="type-title">{{ title ?? t('share_access_page') }}</h1>
 							</slot>
@@ -33,43 +37,27 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from 'vue';
+<script lang="ts" setup>
 import { useServerStore } from '@/stores/server';
-import { storeToRefs } from 'pinia';
-import { useI18n } from 'vue-i18n';
 import { getRootPath } from '@/utils/get-root-path';
+import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-export default defineComponent({
-	name: 'SharedView',
-	props: {
-		title: {
-			type: String,
-			default: null,
-		},
-		inline: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	setup() {
-		const serverStore = useServerStore();
+defineProps<{
+	title?: string;
+	inline?: boolean;
+}>();
 
-		const { info } = storeToRefs(serverStore);
+const serverStore = useServerStore();
 
-		const { t } = useI18n();
+const { info: serverInfo } = storeToRefs(serverStore);
 
-		const logoURL = computed<string | null>(() => {
-			if (!serverStore.info?.project?.project_logo) return null;
-			return getRootPath() + `assets/${serverStore.info.project?.project_logo}`;
-		});
+const { t } = useI18n();
 
-		return {
-			serverInfo: info,
-			t,
-			logoURL,
-		};
-	},
+const logoURL = computed<string | null>(() => {
+	if (!serverStore.info?.project?.project_logo) return null;
+	return getRootPath() + `assets/${serverStore.info.project?.project_logo}`;
 });
 </script>
 

--- a/packages/composables/src/use-custom-selection.test.ts
+++ b/packages/composables/src/use-custom-selection.test.ts
@@ -1,0 +1,31 @@
+import { expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useCustomSelectionMultiple } from './use-custom-selection.js';
+
+test('editing a previously unselected custom value does not append it to the selection', () => {
+	const currentValues = ref(['a', 'b']);
+	const items = ref<any[]>([]);
+	const emit = vi.fn();
+
+	const { otherValues, addOtherValue, setOtherValue } = useCustomSelectionMultiple(currentValues, items, emit);
+
+	addOtherValue();
+
+	const newRow = otherValues.value[otherValues.value.length - 1];
+	setOtherValue(newRow!.key, 'c');
+
+	expect(emit).toHaveBeenLastCalledWith(['a', 'b']);
+});
+
+test('editing a selected custom value replaces it in the selection', () => {
+	const currentValues = ref(['a', 'b']);
+	const items = ref<any[]>([]);
+	const emit = vi.fn();
+
+	const { otherValues, setOtherValue } = useCustomSelectionMultiple(currentValues, items, emit);
+
+	const rowForA = otherValues.value.find((o) => o.value === 'a');
+	setOtherValue(rowForA!.key, 'x');
+
+	expect(emit).toHaveBeenLastCalledWith(['b', 'x']);
+});

--- a/packages/composables/src/use-custom-selection.ts
+++ b/packages/composables/src/use-custom-selection.ts
@@ -118,9 +118,11 @@ export function useCustomSelectionMultiple(
 				return otherValue;
 			});
 
-			const newEmitValue = [...valueWithoutPrevious, newValue];
-
-			emit(newEmitValue);
+			if (valueWithoutPrevious.length === currentValues.value?.length) {
+				emit(valueWithoutPrevious);
+			} else {
+				emit([...valueWithoutPrevious, newValue]);
+			}
 		}
 	}
 }

--- a/tests/blackbox/routes/items/relational-presets.test.ts
+++ b/tests/blackbox/routes/items/relational-presets.test.ts
@@ -1,0 +1,124 @@
+import { getUrl } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import request from 'supertest';
+
+// The preset path is only exercised under a non-admin accountability (admin bypasses
+// the permission system), so this test creates its own non-admin role rather than
+// reusing the admin-capable TESTS_FLOW role.
+
+const parentCollection = 'test_items_relational_presets_parent';
+const childCollection = 'test_items_relational_presets_child';
+const adminToken = common.USER.ADMIN.TOKEN;
+const presetUserToken = 'RelationalPresetTestToken';
+
+describe('Relational field presets on item create', () => {
+	const roleId = {} as Record<string, string>;
+	const userId = {} as Record<string, string>;
+
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			await common.CreateCollection(vendor, { collection: parentCollection });
+			await common.CreateCollection(vendor, { collection: childCollection });
+			await common.CreateField(vendor, { collection: parentCollection, field: 'name', type: 'string' });
+			await common.CreateField(vendor, { collection: childCollection, field: 'name', type: 'string' });
+
+			await common.CreateFieldO2M(vendor, {
+				collection: parentCollection,
+				field: 'children',
+				otherCollection: childCollection,
+				otherField: 'parent_id',
+				primaryKeyType: 'integer',
+			});
+
+			const role = await request(getUrl(vendor))
+				.post('/roles')
+				.send({ name: 'Relational Preset Test Role', admin_access: false, app_access: true })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			roleId[vendor] = role.body.data.id;
+
+			const user = await request(getUrl(vendor))
+				.post('/users')
+				.send({
+					email: `relational-preset-${vendor}@tests.com`,
+					password: 'RelationalPresetPassword',
+					token: presetUserToken,
+					role: roleId[vendor],
+					status: 'active',
+				})
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			userId[vendor] = user.body.data.id;
+
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({
+					role: roleId[vendor],
+					collection: parentCollection,
+					action: 'create',
+					fields: ['*'],
+					presets: { children: { create: [{ name: 'Preset child' }] } },
+				})
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// Read permission so the create response carries the new primary key.
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({ role: roleId[vendor], collection: parentCollection, action: 'read', fields: ['*'] })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// `fields: ['*']` so the nested create can write the parent foreign key on the child.
+			await request(getUrl(vendor))
+				.post('/permissions')
+				.send({ role: roleId[vendor], collection: childCollection, action: 'create', fields: ['*'] })
+				.set('Authorization', `Bearer ${adminToken}`);
+		}
+	}, 300000);
+
+	afterAll(async () => {
+		for (const vendor of vendors) {
+			await request(getUrl(vendor))
+				.delete(`/collections/${childCollection}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			await request(getUrl(vendor))
+				.delete(`/collections/${parentCollection}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			// Delete the user before the role so it is never left orphaned with role = null.
+			if (userId[vendor]) {
+				await request(getUrl(vendor))
+					.delete(`/users/${userId[vendor]}`)
+					.set('Authorization', `Bearer ${adminToken}`);
+			}
+
+			if (roleId[vendor]) {
+				await request(getUrl(vendor))
+					.delete(`/roles/${roleId[vendor]}`)
+					.set('Authorization', `Bearer ${adminToken}`);
+			}
+		}
+	});
+
+	it.each(vendors)('%s applies a relational O2M preset to nested children on create', async (vendor) => {
+		const created = await request(getUrl(vendor))
+			.post(`/items/${parentCollection}`)
+			.send({ name: 'Parent created without children in the payload' })
+			.set('Authorization', `Bearer ${presetUserToken}`);
+
+		expect(created.statusCode).toBe(200);
+
+		const parentId = created.body.data.id;
+
+		const readBack = await request(getUrl(vendor))
+			.get(`/items/${parentCollection}/${parentId}`)
+			.query({ fields: '*,children.*' })
+			.set('Authorization', `Bearer ${adminToken}`);
+
+		expect(readBack.statusCode).toBe(200);
+		expect(readBack.body.data.children).toHaveLength(1);
+		expect(readBack.body.data.children[0].name).toBe('Preset child');
+		expect(readBack.body.data.children[0].parent_id).toBe(parentId);
+	});
+});

--- a/tests/blackbox/routes/items/relational-presets.test.ts
+++ b/tests/blackbox/routes/items/relational-presets.test.ts
@@ -88,15 +88,11 @@ describe('Relational field presets on item create', () => {
 
 			// Delete the user before the role so it is never left orphaned with role = null.
 			if (userId[vendor]) {
-				await request(getUrl(vendor))
-					.delete(`/users/${userId[vendor]}`)
-					.set('Authorization', `Bearer ${adminToken}`);
+				await request(getUrl(vendor)).delete(`/users/${userId[vendor]}`).set('Authorization', `Bearer ${adminToken}`);
 			}
 
 			if (roleId[vendor]) {
-				await request(getUrl(vendor))
-					.delete(`/roles/${roleId[vendor]}`)
-					.set('Authorization', `Bearer ${adminToken}`);
+				await request(getUrl(vendor)).delete(`/roles/${roleId[vendor]}`).set('Authorization', `Bearer ${adminToken}`);
 			}
 		}
 	});

--- a/tests/blackbox/routes/permissions/cache-purge.test.ts
+++ b/tests/blackbox/routes/permissions/cache-purge.test.ts
@@ -1,0 +1,143 @@
+import config, { Env, getUrl, paths } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import { awaitDirectusConnection } from '@utils/await-connection';
+import { ChildProcess, spawn } from 'child_process';
+import { cloneDeep } from 'lodash';
+import request from 'supertest';
+
+// SQLite cannot safely share a single file across multiple instances, and this
+// test spawns a dedicated cache-configured instance alongside the default one.
+const supportedVendors = vendors.filter((vendor) => vendor !== 'sqlite3');
+const describeFn = supportedVendors.length > 0 ? describe : describe.skip;
+
+const collection = 'test_perms_cache_purge';
+const cacheStatusHeader = 'x-cache-status';
+const adminToken = common.USER.ADMIN.TOKEN;
+const roleId = common.ROLE.TESTS_FLOW.ID;
+
+describeFn('Permissions cache purging', () => {
+	const instances = {} as { [vendor: string]: ChildProcess };
+	const envs = {} as { [vendor: string]: Env };
+
+	beforeAll(async () => {
+		const promises = [];
+
+		for (const vendor of supportedVendors) {
+			const env = cloneDeep(config.envs);
+			env[vendor].CACHE_ENABLED = 'true';
+			env[vendor].CACHE_AUTO_PURGE = 'false';
+			env[vendor].CACHE_STORE = 'memory';
+			env[vendor].CACHE_STATUS_HEADER = cacheStatusHeader;
+			env[vendor].CACHE_NAMESPACE = 'cairncms-perms-cache-purge';
+
+			const port = Number(env[vendor]!.PORT) + 150;
+			env[vendor]!.PORT = String(port);
+
+			instances[vendor] = spawn('node', ['--no-node-snapshot', paths.cli, 'start'], {
+				cwd: paths.cwd,
+				env: env[vendor],
+			});
+
+			envs[vendor] = env;
+			promises.push(awaitDirectusConnection(port));
+		}
+
+		await Promise.all(promises);
+
+		for (const vendor of supportedVendors) {
+			await common.CreateCollection(vendor, { collection, env: envs[vendor] });
+		}
+	}, 300000);
+
+	afterAll(() => {
+		for (const vendor of supportedVendors) {
+			instances[vendor]!.kill();
+		}
+	});
+
+	async function primeCache(vendor: string, env: Env) {
+		await request(getUrl(vendor, env)).post('/utils/cache/clear').set('Authorization', `Bearer ${adminToken}`);
+		await request(getUrl(vendor, env)).get(`/items/${collection}`).set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	function readItems(vendor: string, env: Env) {
+		return request(getUrl(vendor, env)).get(`/items/${collection}`).set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	function createPermission(vendor: string, env: Env, action: string) {
+		return request(getUrl(vendor, env))
+			.post('/permissions')
+			.send({ role: roleId, collection, action })
+			.set('Authorization', `Bearer ${adminToken}`);
+	}
+
+	describe('GET /items response cache', () => {
+		it.each(supportedVendors)('%s serves a cached item response as a HIT when nothing changes', async (vendor) => {
+			const env = envs[vendor]!;
+
+			await primeCache(vendor, env);
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('HIT');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is created', async (vendor) => {
+			const env = envs[vendor]!;
+
+			await primeCache(vendor, env);
+
+			const created = await createPermission(vendor, env, 'read');
+			expect(created.statusCode).toBe(200);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is updated', async (vendor) => {
+			const env = envs[vendor]!;
+
+			const created = await createPermission(vendor, env, 'create');
+			expect(created.statusCode).toBe(200);
+			const permissionId = created.body.data.id;
+
+			await primeCache(vendor, env);
+
+			const updated = await request(getUrl(vendor, env))
+				.patch(`/permissions/${permissionId}`)
+				.send({ action: 'update' })
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			expect(updated.statusCode).toBe(200);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+
+		it.each(supportedVendors)('%s purges the cached item response after a permission is deleted', async (vendor) => {
+			const env = envs[vendor]!;
+
+			const created = await createPermission(vendor, env, 'delete');
+			expect(created.statusCode).toBe(200);
+			const permissionId = created.body.data.id;
+
+			await primeCache(vendor, env);
+
+			const deleted = await request(getUrl(vendor, env))
+				.delete(`/permissions/${permissionId}`)
+				.set('Authorization', `Bearer ${adminToken}`);
+
+			expect(deleted.statusCode).toBeLessThan(300);
+
+			const response = await readItems(vendor, env);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -15,6 +15,7 @@ exports.list = {
 		{ testFilePath: '/schema/timezone/timezone-changed-node-tz-asia.test.ts' },
 		{ testFilePath: '/logger/redact.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
+		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/assets/format.test.ts' },
 		{ testFilePath: '/routes/assets/read.test.ts' },
 		{ testFilePath: '/routes/assets/limit.test.ts' },

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -16,6 +16,7 @@ exports.list = {
 		{ testFilePath: '/logger/redact.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
+		{ testFilePath: '/routes/items/relational-presets.test.ts' },
 		{ testFilePath: '/routes/assets/format.test.ts' },
 		{ testFilePath: '/routes/assets/read.test.ts' },
 		{ testFilePath: '/routes/assets/limit.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Display and export code could fail to resolve values that were fetched under generated aliases which showed up in layouts that render display templates, including calendar templates, when requested fields collided on the same base field name.

This PR updates alias handling so fields are only aliased when a collision exists, and all affected consumers resolve values through one shared alias-aware accessor. This fixes aliased field values in display templates, tabular display rendering, and CSV export.

### Testing / verification

Added tests covering:
- alias metadata for fields with no collisions
- alias metadata for fields with collisions
- alias-aware value lookup for non-aliased fields
- alias-aware value lookup for aliased nested fields
- display template rendering when values were fetched under aliased keys

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
