### PR TITLE
Accept offset=0 in query sanitization

### DIFF
--- a/api/src/utils/sanitize-query.test.ts
+++ b/api/src/utils/sanitize-query.test.ts
@@ -182,12 +182,26 @@ describe('offset', () => {
 		expect(sanitizedQuery.offset).toBe(1);
 	});
 
-	test('should ignore zero', () => {
+	test('should accept zero', () => {
 		const offset = 0;
 
 		const sanitizedQuery = sanitizeQuery({ offset });
 
-		expect(sanitizedQuery.offset).toBeUndefined();
+		expect(sanitizedQuery.offset).toBe(0);
+	});
+
+	test('should accept string zero', () => {
+		const offset = '0';
+
+		const sanitizedQuery = sanitizeQuery({ offset });
+
+		expect(sanitizedQuery.offset).toBe(0);
+	});
+
+	test('should accept zero in a deep sub-query', () => {
+		const sanitizedQuery = sanitizeQuery({ deep: { translations: { _offset: 0 } } });
+
+		expect(sanitizedQuery.deep).toEqual({ translations: { _offset: 0 } });
 	});
 });
 

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -36,7 +36,7 @@ export function sanitizeQuery(rawQuery: Record<string, any>, accountability?: Ac
 		query.filter = sanitizeFilter(rawQuery['filter'], accountability || null);
 	}
 
-	if (rawQuery['offset']) {
+	if (rawQuery['offset'] !== undefined) {
 		query.offset = sanitizeOffset(rawQuery['offset']);
 	}
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Query sanitization dropped `offset=0` because the offset guard treated numeric zero as absent which also affected deep query options such as `_offset=0`, where zero is a valid value and should be preserved. This PR preserves zero offsets during query sanitization. Numeric `0` and string `'0'` now both sanitize to `0`, including inside deep sub-queries.

### Testing / verification

Added tests covering:
- top-level `offset: 0` is preserved
- top-level `offset: '0'` sanitizes to `0`
- deep `_offset: 0` is preserved in the sanitized deep query

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
