### PR TITLE
Reject non-decimal strings from numeric field search

### DIFF
--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -306,6 +306,35 @@ describe('applySearch — conceal-field exclusion (GHSA-8jpw-gpr4-8cmh)', () => 
 	});
 });
 
+describe('applySearch — numeric field accepts only decimal values', () => {
+	it.each(['0x56071c902718e681e274DB0AaC9B4Ed2d027924d', '0b11111', '0.42e3', 'Infinity', '42.000'])(
+		'does not match %s against a numeric field',
+		async (value) => {
+			const dbQuery = makeBuilder();
+			const accountability = makeAccountability({ permissions: [makePermission(['rank'])] });
+
+			await applySearch(makeSchema(), dbQuery, value, 'notes', accountability);
+
+			const { sql } = dbQuery.toSQL();
+
+			expect(sql).not.toContain('rank');
+			expect(sql).toContain('1 = 0');
+		}
+	);
+
+	it.each(['1234', '-128', '12.34'])('matches decimal %s against a numeric field', async (value) => {
+		const dbQuery = makeBuilder();
+		const accountability = makeAccountability({ permissions: [makePermission(['rank'])] });
+
+		await applySearch(makeSchema(), dbQuery, value, 'notes', accountability);
+
+		const { sql, bindings } = dbQuery.toSQL();
+
+		expect(sql).toContain('rank');
+		expect(bindings).toContain(Number(value));
+	});
+});
+
 describe('applySort — unknown column validation', () => {
 	function callApplySort(sort: string[]) {
 		const dbQuery = makeBuilder();

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -831,7 +831,7 @@ export async function applySearch(
 			} else if (['bigInteger', 'integer', 'decimal', 'float'].includes(field.type)) {
 				const number = Number(searchQuery);
 
-				if (!isNaN(number)) {
+				if (validateNumber(searchQuery, number)) {
 					this.orWhere({ [`${collection}.${name}`]: number });
 					emitted = true;
 				}
@@ -845,6 +845,13 @@ export async function applySearch(
 			this.whereRaw('1 = 0');
 		}
 	});
+}
+
+function validateNumber(value: string, parsed: number) {
+	if (isNaN(parsed) || !Number.isFinite(parsed)) return false;
+	// casting parsed value back to string should be equal the original value
+	// (prevent unintended number parsing, e.g. String(7) !== "0b111")
+	return String(parsed) === value;
 }
 
 const VALUE_DERIVING_AGGREGATE_OPS = new Set(['min', 'max', 'sum', 'sumDistinct', 'avg', 'avgDistinct']);


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents non-decimal search strings that JavaScript can parse as numbers, such as `0b11111`, `0x1F`, `Infinity`, or `42.000`, from matching numeric fields.

### Testing / verification

Added tests covering:
- non-decimal parseable values do not search the permitted numeric field
- non-decimal parseable values collapse to a forced-false predicate when no other permitted searchable field matches
- plain decimal values still search the permitted numeric field with the expected numeric binding

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
