### PR TITLE
Close the database connection when bootstrap finishes

### DIFF
--- a/api/src/cli/commands/bootstrap/index.ts
+++ b/api/src/cli/commands/bootstrap/index.ts
@@ -48,6 +48,7 @@ export default async function bootstrap({ skipAdminInit }: { skipAdminInit?: boo
 		await runMigrations(database, 'latest');
 	}
 
+	await database.destroy();
 	logger.info('Done');
 	process.exit(0);
 }


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Closes the bootstrap command's database connection before the process exits.

### Testing / verification

Verification performed:
- `pnpm exec eslint api/src/cli/commands/bootstrap/index.ts`
- `pnpm --filter @cairncms/api build`
- `pnpm --dir api exec vitest run`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
