### PR TITLE
Load .cjs and .mjs custom migrations

### DIFF
--- a/api/src/database/migrations/run-custom-cjs-mjs.test.ts
+++ b/api/src/database/migrations/run-custom-cjs-mjs.test.ts
@@ -1,0 +1,121 @@
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { MockedFunction } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { WIRED_TMP, CUSTOM_DIR } = vi.hoisted(() => {
+	const wt = `/tmp/cairncms-cjs-mjs-wired-${process.pid}-${Date.now()}`;
+	return { WIRED_TMP: wt, CUSTOM_DIR: `${wt}/migrations` };
+});
+
+vi.mock('../../env.js', () => {
+	const env = { EXTENSIONS_PATH: WIRED_TMP };
+	return { default: env, getEnv: () => env, refreshEnv: () => undefined };
+});
+
+vi.mock('../../cache.js', () => ({ flushCaches: vi.fn().mockResolvedValue(undefined) }));
+
+import getModuleDefault from '../../utils/get-module-default.js';
+import run, { CUSTOM_MIGRATION_FILE_PATTERN } from './run.js';
+
+describe('CUSTOM_MIGRATION_FILE_PATTERN', () => {
+	it.each(['custom.js', '20260524A-test.cjs', '20260524B-test.mjs', 'a.cjs', 'b.mjs'])('accepts %s', (name) => {
+		expect(CUSTOM_MIGRATION_FILE_PATTERN.test(name)).toBe(true);
+	});
+
+	it.each(['custom.json', '20260524A-test.ts', '20260524A-test.txt', '20260524A-test.js.bak', 'README.md'])(
+		'rejects %s',
+		(name) => {
+			expect(CUSTOM_MIGRATION_FILE_PATTERN.test(name)).toBe(false);
+		}
+	);
+});
+
+describe('getModuleDefault normalises CJS and ESM custom-migration module shapes', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(path.join(tmpdir(), 'cairncms-mod-shape-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('extracts up and down from a CJS (.cjs) module', async () => {
+		const file = path.join(tmp, `cjs-${Date.now()}.cjs`);
+
+		writeFileSync(file, "module.exports = { up: async () => 'up-cjs', down: async () => 'down-cjs' };\n");
+
+		const mod: any = getModuleDefault(await import(`file://${file}`));
+
+		expect(await mod.up()).toBe('up-cjs');
+		expect(await mod.down()).toBe('down-cjs');
+	});
+
+	it('extracts up and down from an ESM (.mjs) module', async () => {
+		const file = path.join(tmp, `mjs-${Date.now()}.mjs`);
+
+		writeFileSync(
+			file,
+			"export async function up() { return 'up-mjs'; }\nexport async function down() { return 'down-mjs'; }\n"
+		);
+
+		const mod: any = getModuleDefault(await import(`file://${file}`));
+
+		expect(await mod.up()).toBe('up-mjs');
+		expect(await mod.down()).toBe('down-mjs');
+	});
+});
+
+describe('run() applies a .cjs custom migration via the up and down direction paths', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(() => {
+		mkdirSync(CUSTOM_DIR, { recursive: true });
+
+		writeFileSync(
+			path.join(CUSTOM_DIR, '00000001A-cjs-wired.cjs'),
+			'function build() { return { up: async () => {}, down: async () => {} }; }\nmodule.exports = build();\n'
+		);
+	});
+
+	afterAll(() => {
+		rmSync(WIRED_TMP, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	it('applies the .cjs migration via run("up") in the test environment', async () => {
+		tracker.on.select('directus_migrations').response([]);
+		tracker.on.insert('directus_migrations').response(['ok']);
+
+		await expect(run(db, 'up', false)).resolves.toBeUndefined();
+
+		const inserts = tracker.history.insert;
+		expect(inserts.length).toBeGreaterThan(0);
+		expect(inserts[0]!.bindings).toEqual(expect.arrayContaining(['00000001A']));
+	});
+
+	it('rolls back the .cjs migration via run("down") in the test environment', async () => {
+		tracker.on
+			.select('directus_migrations')
+			.response([{ version: '00000001A', name: 'Cjs Wired', timestamp: '2026-01-01 00:00:00' }]);
+
+		tracker.on.delete('directus_migrations').response(['ok']);
+
+		await expect(run(db, 'down', false)).resolves.toBeUndefined();
+	});
+});

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -9,8 +9,11 @@ import { flushCaches } from '../../cache.js';
 import env from '../../env.js';
 import logger from '../../logger.js';
 import type { Migration } from '../../types/index.js';
+import getModuleDefault from '../../utils/get-module-default.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const CUSTOM_MIGRATION_FILE_PATTERN = /\.(c|m)?js$/;
 
 export default async function run(database: Knex, direction: 'up' | 'down' | 'latest', log = true): Promise<void> {
 	let migrationFiles = await fse.readdir(__dirname);
@@ -21,7 +24,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 		((await fse.pathExists(customMigrationsPath)) && (await fse.readdir(customMigrationsPath))) || [];
 
 	migrationFiles = migrationFiles.filter((file: string) => /^[0-9]+[A-Z]-[^.]+\.(?:js|ts)$/.test(file));
-	customMigrationFiles = customMigrationFiles.filter((file: string) => file.endsWith('.js'));
+	customMigrationFiles = customMigrationFiles.filter((file: string) => CUSTOM_MIGRATION_FILE_PATTERN.test(file));
 
 	const completedMigrations = await database.select<Migration[]>('*').from('directus_migrations').orderBy('version');
 
@@ -70,7 +73,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 			throw Error('Nothing to upgrade');
 		}
 
-		const { up } = await import(`file://${nextVersion.file}`);
+		const { up } = getModuleDefault(await import(`file://${nextVersion.file}`));
 
 		if (log) {
 			logger.info(`Applying ${nextVersion.name}...`);
@@ -95,7 +98,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 			throw new Error("Couldn't find migration");
 		}
 
-		const { down } = await import(`file://${migration.file}`);
+		const { down } = getModuleDefault(await import(`file://${migration.file}`));
 
 		if (log) {
 			logger.info(`Undoing ${migration.name}...`);
@@ -113,7 +116,7 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 		for (const migration of migrations) {
 			if (migration.completed === false) {
 				needsCacheFlush = true;
-				const { up } = await import(`file://${migration.file}`);
+				const { up } = getModuleDefault(await import(`file://${migration.file}`));
 
 				if (log) {
 					logger.info(`Applying ${migration.name}...`);

--- a/docs/develop/custom-migrations.md
+++ b/docs/develop/custom-migrations.md
@@ -30,24 +30,34 @@ Place migration files under the configured extensions folder:
 
 ```
 <EXTENSIONS_PATH>/migrations/
-├── 20260101A-add-orders-index.js
-└── 20260205A-backfill-tenant-ids.js
+├── 20260101A-add-orders-index.mjs
+└── 20260205A-backfill-tenant-ids.cjs
 ```
 
 Custom migration files must:
 
-- be plain JavaScript (`.js`); the loader does not pick up `.ts` files for custom migrations
+- be JavaScript, with one of these extensions: `.js`, `.cjs`, or `.mjs` (the loader does not pick up `.ts` files for custom migrations)
 - start with a unique version prefix, separated from the description by a dash
 
 CairnCMS's built-in migrations use the format `<YYYYMMDD><LETTER>-<description>.ts`, where the letter disambiguates multiple migrations on the same date (`A`, `B`, `C`, …). Following the same convention for custom migrations is recommended, because it puts custom and built-in migrations in a sensible chronological order and avoids version collisions.
 
 The version (the part before the first `-`) must be unique across all migrations, built-in and custom combined. CairnCMS refuses to start if it detects two migrations with the same version key.
 
+## Module format
+
+The file extension determines how Node loads the migration:
+
+- **`.mjs`** is always treated as an ECMAScript module (ESM). Use `export async function up` and `export async function down`.
+- **`.cjs`** is always treated as CommonJS. Use `module.exports = { up, down }`.
+- **`.js`** follows the nearest `package.json` `"type"` field. Without `"type": "module"` Node loads the file as CommonJS; with it, as ESM. ESM syntax in a `.js` file in a project whose `package.json` does not declare `"type": "module"` raises a `SyntaxError` at load time.
+
+Prefer the explicit `.mjs` or `.cjs` extension when the surrounding `package.json` context is not under your control, so the migration's module shape is unambiguous.
+
 ## Migration file structure
 
 Each migration exports an `up` function and a `down` function. Both receive a Knex instance:
 
-```js
+```mjs
 export async function up(knex) {
   await knex.schema.createTable('audit_log', (table) => {
     table.increments('id');
@@ -109,9 +119,9 @@ The bootstrap process also uses this table to decide whether the database is ful
 
 A migration that adds a `tenant_id` column to an existing `orders` collection and indexes it.
 
-`<EXTENSIONS_PATH>/migrations/20260301A-add-orders-tenant-id.js`:
+`<EXTENSIONS_PATH>/migrations/20260301A-add-orders-tenant-id.mjs`:
 
-```js
+```mjs
 export async function up(knex) {
   await knex.schema.alterTable('orders', (table) => {
     table.string('tenant_id', 36);


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Allows custom migrations to be loaded from `.cjs` and `.mjs` files, not only `.js` files.

### Testing / verification

Added tests covering:
- custom migration discovery accepts `.js`, `.cjs`, and `.mjs`
- custom migration discovery rejects unrelated extensions
- CommonJS and ESM migration module shapes both expose callable `up` and `down` functions
- `.cjs` custom migrations run through `migrate:up` and `migrate:down`

### Docs
- documented `.js`, `.cjs`, and `.mjs` custom migration support
- clarified `.js` follows the nearest `package.json` `type` field
- updated examples to use explicit `.mjs` filenames for ESM syntax

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
