### PR TITLE
Stop resolvePreset from mutating input.transforms

### DIFF
--- a/api/src/utils/transformations.test.ts
+++ b/api/src/utils/transformations.test.ts
@@ -1,0 +1,168 @@
+import { expect, test, describe } from 'vitest';
+import { maybeExtractFormat, resolvePreset } from './transformations.js';
+import type { File } from '../types/files.js';
+import type { Transformation, TransformationParams } from '../types/assets.js';
+
+const inputFile: File = {
+	id: '43a15f67-84a7-4e07-880d-e46a9f33c542',
+	storage: 'local',
+	filename_disk: 'test',
+	filename_download: 'test',
+	title: null,
+	type: null,
+	folder: null,
+	uploaded_by: null,
+	uploaded_on: new Date(),
+	charset: null,
+	filesize: 123,
+	width: null,
+	height: null,
+	duration: null,
+	embed: null,
+	description: null,
+	location: null,
+	tags: null,
+	metadata: null,
+};
+
+describe('resolvePreset', () => {
+	test('does not mutate input.transforms on a single call', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			format: 'jpg',
+			transforms: [
+				[
+					'resize',
+					{
+						width: 64,
+						height: 64,
+						fit: 'cover',
+					},
+				],
+			],
+		};
+
+		resolvePreset(inputData, inputFile);
+
+		expect(inputData.transforms).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+				},
+			],
+		]);
+	});
+
+	test('does not accumulate transforms in input across repeated calls', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			format: 'jpg',
+			transforms: [
+				[
+					'resize',
+					{
+						width: 64,
+						height: 64,
+						fit: 'cover',
+					},
+				],
+			],
+		};
+
+		resolvePreset(inputData, inputFile);
+		resolvePreset(inputData, inputFile);
+		resolvePreset(inputData, inputFile);
+
+		expect(inputData.transforms).toHaveLength(1);
+
+		expect(inputData.transforms).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+				},
+			],
+		]);
+	});
+
+	test('Add toFormat transformation', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			format: 'jpg',
+			quality: 80,
+			transforms: [
+				[
+					'resize',
+					{
+						width: 64,
+						height: 64,
+						fit: 'cover',
+					},
+				],
+			],
+		};
+
+		const output = resolvePreset(inputData, inputFile);
+
+		expect(output).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+				},
+			],
+			['toFormat', 'jpg', { quality: 80 }],
+		]);
+	});
+
+	test('Add resize transformation', () => {
+		const inputData: TransformationParams = {
+			key: 'system-small-cover',
+			width: 64,
+			height: 64,
+			fit: 'cover',
+		};
+
+		const output = resolvePreset(inputData, inputFile);
+
+		expect(output).toStrictEqual([
+			[
+				'resize',
+				{
+					width: 64,
+					height: 64,
+					fit: 'cover',
+					withoutEnlargement: undefined,
+				},
+			],
+		]);
+	});
+});
+
+describe('maybeExtractFormat', () => {
+	test('get last format', () => {
+		const inputTransformations: Transformation[] = [
+			['toFormat', 'jpg', { quality: 80 }],
+			['toFormat', 'webp', { quality: 80 }],
+		];
+
+		const output = maybeExtractFormat(inputTransformations);
+
+		expect(output).toBe('webp');
+	});
+
+	test('get undefined', () => {
+		const inputTransformations: Transformation[] = [];
+
+		const output = maybeExtractFormat(inputTransformations);
+
+		expect(output).toBe(undefined);
+	});
+});

--- a/api/src/utils/transformations.ts
+++ b/api/src/utils/transformations.ts
@@ -1,7 +1,7 @@
 import type { File, Transformation, TransformationParams } from '../types/index.js';
 
 export function resolvePreset(input: TransformationParams, file: File): Transformation[] {
-	const transforms = input.transforms ?? [];
+	const transforms = input.transforms ? [...input.transforms] : [];
 
 	if (input.format || input.quality)
 		transforms.push([


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents generated asset transforms from being appended back into caller-provided transform presets.

### Testing / verification

Added tests covering:
- `resolvePreset` does not mutate `input.transforms` on a single call
- repeated `resolvePreset` calls with the same input do not accumulate duplicate transforms
- existing format, resize, and format-extraction behavior remains unchanged

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
