### PR TITLE
Chore/extension build cleanup

### DIFF
--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -2,6 +2,7 @@ import {
 	APP_EXTENSION_TYPES,
 	APP_SHARED_DEPS,
 	HYBRID_EXTENSION_TYPES,
+	JAVASCRIPT_FILE_EXTS,
 	NESTED_EXTENSION_TYPES,
 } from '@cairncms/constants';
 import * as sharedExceptions from '@cairncms/exceptions';
@@ -299,15 +300,14 @@ class ExtensionManager {
 
 		const localExtensionUrls = NESTED_EXTENSION_TYPES.flatMap((type) => {
 			const typeDir = path.posix.join(extensionDirUrl, pluralize(type));
-			const fileExts = ['js', 'mjs', 'cjs'];
 
 			if (isIn(type, HYBRID_EXTENSION_TYPES)) {
 				return [
-					path.posix.join(typeDir, '*', `app.{${fileExts.join()}}`),
-					path.posix.join(typeDir, '*', `api.{${fileExts.join()}}`),
+					path.posix.join(typeDir, '*', `app.{${JAVASCRIPT_FILE_EXTS.join()}}`),
+					path.posix.join(typeDir, '*', `api.{${JAVASCRIPT_FILE_EXTS.join()}}`),
 				];
 			} else {
-				return path.posix.join(typeDir, '*', `index.{${fileExts.join()}}`);
+				return path.posix.join(typeDir, '*', `index.{${JAVASCRIPT_FILE_EXTS.join()}}`);
 			}
 		});
 

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -2,6 +2,7 @@
 	"name": "@cairncms/composables",
 	"version": "1.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,6 +2,7 @@
 	"name": "@cairncms/constants",
 	"version": "1.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch"

--- a/packages/constants/src/files.ts
+++ b/packages/constants/src/files.ts
@@ -1,0 +1,1 @@
+export const JAVASCRIPT_FILE_EXTS = ['js', 'mjs', 'cjs'] as const;

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,6 +1,7 @@
 export * from './activity.js';
 export * from './extensions.js';
 export * from './fields.js';
+export * from './files.js';
 export * from './injection.js';
 export * from './regex.js';
 export * from './roles.js';

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -2,6 +2,7 @@
 	"name": "@cairncms/exceptions",
 	"version": "1.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --build",
 		"dev": "tsc --watch",

--- a/packages/extensions-sdk/create-build.test.ts
+++ b/packages/extensions-sdk/create-build.test.ts
@@ -1,11 +1,10 @@
-import { EXTENSION_LANGUAGES } from '@cairncms/constants';
+import { EXTENSION_LANGUAGES, JAVASCRIPT_FILE_EXTS } from '@cairncms/constants';
 import { execa } from 'execa';
 import fse from 'fs-extra';
 import { resolve } from 'node:path';
 import { afterAll, expect, test } from 'vitest';
 import { create } from './src/cli/index.js';
 import { languageToShort } from './src/cli/utils/languages.js';
-import { CONFIG_FILE_NAMES } from './src/cli/commands/helpers/load-config.js';
 
 const testPrefix = `temp-extension`;
 
@@ -33,7 +32,7 @@ function getConfigFileContent(configFileName: string) {
 // Test one extension from each of app/api/hybrid extensions, and each config file names
 test.each(
 	['interface', 'endpoint', 'operation'].map((extensionType, index) => {
-		return { extensionType, configFileName: CONFIG_FILE_NAMES[index] };
+		return { extensionType, configFileName: `extension.config.${JAVASCRIPT_FILE_EXTS[index]}` };
 	})
 )(
 	`create and build new $extensionType extension with $configFileName config file`,
@@ -69,5 +68,5 @@ test.each(
 		}
 	},
 	// Bump up timeout duration as the build process can take slightly longer to complete
-	20000
+	30_000
 );

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -592,7 +592,7 @@ function getRollupOptions({
 			languages.includes('typescript') ? esbuild({ include: /\.tsx?$/, sourceMap: sourcemap }) : null,
 			mode === 'browser' ? styles() : null,
 			...plugins,
-			nodeResolve({ browser: mode === 'browser' }),
+			nodeResolve({ browser: mode === 'browser', preferBuiltins: mode === 'node' }),
 			commonjs({ esmExternals: mode === 'browser', sourceMap: sourcemap }),
 			json(),
 			replace({
@@ -603,6 +603,11 @@ function getRollupOptions({
 			}),
 			minify ? terser() : null,
 		],
+		onwarn(warning, warn) {
+			if (warning.code === 'CIRCULAR_DEPENDENCY' && warning.ids?.every((id) => /\bnode_modules\b/.test(id))) return;
+
+			warn(warning);
+		},
 	};
 }
 

--- a/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
@@ -1,17 +1,18 @@
+import { JAVASCRIPT_FILE_EXTS } from '@cairncms/constants';
 import { pathToRelativeUrl } from '@cairncms/utils/node';
 import fse from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { Config } from '../../types.js';
 
-export const CONFIG_FILE_NAMES = ['extension.config.js', 'extension.config.mjs', 'extension.config.cjs'];
-
 // This is needed to work around Typescript always transpiling import() to require() for CommonJS targets.
 const _import = new Function('url', 'return import(url)');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default async function loadConfig(): Promise<Config> {
-	for (const fileName of CONFIG_FILE_NAMES) {
+	for (const ext of JAVASCRIPT_FILE_EXTS) {
+		const fileName = `extension.config.${ext}`;
+
 		if (await fse.pathExists(fileName)) {
 			const configFile = await _import(pathToRelativeUrl(path.resolve(fileName), __dirname));
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,7 @@
 	"name": "@cairncms/utils",
 	"version": "1.0.0",
 	"type": "module",
+	"sideEffects": false,
 	"scripts": {
 		"build": "tsc --project browser/tsconfig.json && tsc --project node/tsconfig.json && tsc --project shared/tsconfig.json",
 		"dev": "concurrently \"tsc --watch --project browser/tsconfig.json\" \"tsc --watch --project node/tsconfig.json\" \"tsc --watch --project shared/tsconfig.json\"",


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Cleans up extension build plumbing by sharing the JavaScript file-extension list, reducing noisy Rollup warnings, and marking side-effect-free shared packages for better tree-shaking.

### Testing / verification

Added coverage through the existing extension create/build test matrix:
- config filenames are derived from the shared JavaScript extension list
- `.js`, `.mjs`, and `.cjs` extension config files still load during generated extension builds
- generated app, api, and hybrid extensions still build successfully

Verified the shared package `sideEffects` declarations against the published source modules:
- no side-effect-only modules
- no global mutation, runtime registration, polyfills, I/O, logging, or env mutation at module scope
- no package required a narrowed side-effects allowlist

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
