### PR TITLE
Drop unused dynamic-import workaround from the extensions SDK config …

### DIFF
--- a/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/helpers/load-config.ts
@@ -5,8 +5,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import type { Config } from '../../types.js';
 
-// This is needed to work around Typescript always transpiling import() to require() for CommonJS targets.
-const _import = new Function('url', 'return import(url)');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default async function loadConfig(): Promise<Config> {
@@ -14,7 +12,7 @@ export default async function loadConfig(): Promise<Config> {
 		const fileName = `extension.config.${ext}`;
 
 		if (await fse.pathExists(fileName)) {
-			const configFile = await _import(pathToRelativeUrl(path.resolve(fileName), __dirname));
+			const configFile = await import(pathToRelativeUrl(path.resolve(fileName), __dirname));
 
 			return configFile.default;
 		}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Removes an obsolete CJS-era dynamic-import workaround from the extensions SDK config loader.

### Testing / verification

The existing extension create/build test matrix covers:
- `.js`, `.mjs`, and `.cjs` extension config files loading through the real config loader
- generated app, api, and hybrid extensions building successfully after the direct `import(...)` change

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
