### PR TITLE
Add Cache toggle to webhook-triggered Flows

### DIFF
--- a/api/src/controllers/flows.ts
+++ b/api/src/controllers/flows.ts
@@ -18,7 +18,7 @@ router.use(useCollection('directus_flows'));
 const webhookFlowHandler = asyncHandler(async (req, res, next) => {
 	const flowManager = getFlowManager();
 
-	const result = await flowManager.runWebhookFlow(
+	const { result, cacheEnabled } = await flowManager.runWebhookFlow(
 		`${req.method}-${req.params['pk']}`,
 		{
 			path: req.path,
@@ -32,6 +32,10 @@ const webhookFlowHandler = asyncHandler(async (req, res, next) => {
 			schema: req.schema,
 		}
 	);
+
+	if (!cacheEnabled) {
+		res.locals['cache'] = false;
+	}
 
 	res.locals['payload'] = result;
 	return next();

--- a/api/src/flows.ts
+++ b/api/src/flows.ts
@@ -136,7 +136,11 @@ class FlowManager {
 		return handler(data, context);
 	}
 
-	public async runWebhookFlow(id: string, data: unknown, context: Record<string, unknown>): Promise<unknown> {
+	public async runWebhookFlow(
+		id: string,
+		data: unknown,
+		context: Record<string, unknown>
+	): Promise<{ result: unknown; cacheEnabled: boolean }> {
 		if (!(id in this.webhookFlowHandlers)) {
 			logger.warn(`Couldn't find webhook or manual triggered flow with id "${id}"`);
 			throw new exceptions.ForbiddenException();
@@ -235,23 +239,32 @@ class FlowManager {
 
 				this.operationFlowHandlers[flow.id] = handler;
 			} else if (flow.trigger === 'webhook') {
-				const handler = (data: unknown, context: Record<string, unknown>) => {
+				const method = flow.options?.['method'] ?? 'GET';
+
+				const handler = async (data: unknown, context: Record<string, unknown>) => {
+					let cacheEnabled = true;
+
+					if (method === 'GET') {
+						cacheEnabled = flow.options['cacheEnabled'] !== false;
+					}
+
 					if (flow.options['async']) {
 						this.executeFlow(flow, data, context);
-						return undefined;
+						return { result: undefined, cacheEnabled };
 					} else {
-						return this.executeFlow(flow, data, context);
+						return { result: await this.executeFlow(flow, data, context), cacheEnabled };
 					}
 				};
-
-				const method = flow.options?.['method'] ?? 'GET';
 
 				// Default return to $last for webhooks
 				flow.options['return'] = flow.options['return'] ?? '$last';
 
 				this.webhookFlowHandlers[`${method}-${flow.id}`] = handler;
 			} else if (flow.trigger === 'manual') {
-				const handler = (data: unknown, context: Record<string, unknown>) => this._runManualFlow(flow, data, context);
+				const handler = async (data: unknown, context: Record<string, unknown>) => ({
+					result: await this._runManualFlow(flow, data, context),
+					cacheEnabled: true,
+				});
 
 				// Default return to $last for manual
 				flow.options['return'] = '$last';

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2136,3 +2136,4 @@ operations:
     parallel: Parallel
     batch: Batch
     batch_size: Batch Size
+    cache: Cache

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -197,7 +197,7 @@ export function getTriggers() {
 					copyable: true,
 				},
 			],
-			options: ({ async }) => [
+			options: ({ async, method }) => [
 				{
 					field: 'method',
 					name: t('triggers.webhook.method'),
@@ -253,6 +253,19 @@ export function getTriggers() {
 							allowOther: true,
 						},
 						hidden: async,
+					},
+				},
+				{
+					field: 'cacheEnabled',
+					name: '$t:operations.trigger.cache',
+					type: 'boolean',
+					meta: {
+						width: 'half',
+						hidden: method && method !== 'GET',
+						interface: 'toggle',
+					},
+					schema: {
+						default_value: true,
 					},
 				},
 			],

--- a/docs/api/system-collections/flows.md
+++ b/docs/api/system-collections/flows.md
@@ -69,6 +69,8 @@ Content-Type: application/json
 
 The response body is the result of the last operation in the chain unless the flow's `options.return` is set to a different operation key. If the flow's `options.async` is `true`, the request returns immediately and the operations run in the background; otherwise the request waits for the chain to complete.
 
+`options.cacheEnabled` defaults to `true` and only takes effect when `method` is `GET`; setting it to `false` prevents new responses for that flow from being stored in the response cache. It does not invalidate entries that are already cached. With `CACHE_AUTO_PURGE=true` (the value the bootstrap installer writes for new projects) updating the flow clears the response cache as a side effect, so the new setting applies on the next request. With `CACHE_AUTO_PURGE=false` (the in-code default) a previously cached response continues to serve until its TTL expires or the cache is cleared with `POST /utils/cache/clear`.
+
 **Manual flows** also resolve through `/flows/trigger/<flow-id>` but require POST and a body that names the target collection:
 
 ```http

--- a/docs/guides/flows/triggers.md
+++ b/docs/guides/flows/triggers.md
@@ -36,8 +36,11 @@ Configuration:
 - **Method** — GET or POST
 - **Asynchronous** — if enabled, the trigger responds immediately and the flow runs in the background. If disabled, the flow runs to completion before responding.
 - **Response Body** — what to return when not asynchronous (the value of `$last`, the entire data chain, or a specific operation key)
+- **Cache** — for GET only; when off, new responses for this flow are not stored in the response cache. The setting is hidden for POST because POST never hits the response cache.
 
 The full URL appears in the trigger panel after the flow is saved. Treat this URL as private; anyone with it can invoke the flow.
+
+The Cache toggle controls future writes, not lookups. If `CACHE_AUTO_PURGE=true` (the value the CairnCMS Docker bootstrap sets in new projects' env files) saving the flow clears the response cache, so flipping the toggle takes effect on the next request. If `CACHE_AUTO_PURGE=false` (the in-code default) a previously cached response for this flow continues to serve until its TTL expires or the cache is cleared explicitly via the admin endpoint; only then does the toggle suppress new writes.
 
 For the broader pattern, see the [Webhooks](/docs/guides/flows/webhooks/) page.
 

--- a/tests/blackbox/routes/flows/webhook.test.ts
+++ b/tests/blackbox/routes/flows/webhook.test.ts
@@ -1,0 +1,340 @@
+import config, { Env, getUrl, paths } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import request from 'supertest';
+import { awaitDirectusConnection } from '@utils/await-connection';
+import { ChildProcess, spawn } from 'child_process';
+import knex from 'knex';
+import type { Knex } from 'knex';
+import { cloneDeep } from 'lodash';
+import { sleep } from '@utils/sleep';
+
+describe('/flows', () => {
+	const databases = new Map<string, Knex>();
+	const directusInstances = {} as { [vendor: string]: ChildProcess };
+	const envs = {} as { [vendor: string]: Env };
+
+	beforeAll(async () => {
+		const promises = [];
+
+		for (const vendor of vendors) {
+			databases.set(vendor, knex(config.knexConfig[vendor]!));
+
+			const env = cloneDeep(config.envs);
+			env[vendor].CACHE_ENABLED = 'true';
+			env[vendor].CACHE_STORE = 'memory';
+			env[vendor].CACHE_AUTO_PURGE = 'false';
+
+			const newServerPort = Number(env[vendor]!.PORT) + 150;
+			env[vendor]!.PORT = String(newServerPort);
+
+			const server = spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: env[vendor] });
+
+			directusInstances[vendor] = server;
+			envs[vendor] = env;
+
+			promises.push(awaitDirectusConnection(newServerPort));
+		}
+
+		await Promise.all(promises);
+	}, 180000);
+
+	afterAll(async () => {
+		for (const [vendor, connection] of databases) {
+			directusInstances[vendor].kill();
+			await connection.destroy();
+		}
+	});
+
+	describe('Webhook Trigger', () => {
+		describe('cacheEnabled works for GET', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const env = envs[vendor];
+
+				const payloadFlowCreate = {
+					name: 'webhook flow',
+					icon: 'bolt',
+					color: null,
+					description: null,
+					status: 'active',
+					accountability: null,
+					trigger: 'webhook',
+					options: {},
+				};
+
+				const payloadOperationCreate = {
+					position_x: 19,
+					position_y: 1,
+					name: 'Get epoch milliseconds',
+					key: 'op_exev',
+					type: 'exec',
+					options: { code: 'module.exports = async function() { return { epoch: Date.now() }; }' },
+				};
+
+				const flowId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send(payloadFlowCreate)
+				).body.data.id;
+
+				const flowCacheEnabledId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send({
+							...payloadFlowCreate,
+							name: 'webhook flow cache disabled',
+							options: { ...payloadFlowCreate.options, cacheEnabled: true },
+						})
+				).body.data.id;
+
+				const flowCacheDisabledId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send({
+							...payloadFlowCreate,
+							name: 'webhook flow cache enabled',
+							options: { ...payloadFlowCreate.options, cacheEnabled: false },
+						})
+				).body.data.id;
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowId } });
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowCacheEnabledId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowCacheEnabledId } });
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowCacheDisabledId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowCacheDisabledId } });
+
+				const responseDefault = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+				const responseCacheEnabled = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowCacheEnabledId}`);
+				const responseCacheDisabled = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowCacheDisabledId}`);
+
+				await sleep(100);
+
+				const responseDefault2 = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+				const responseCacheEnabled2 = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowCacheEnabledId}`);
+				const responseCacheDisabled2 = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowCacheDisabledId}`);
+
+				expect(responseDefault.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheEnabled.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheDisabled.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseDefault2.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheEnabled.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheDisabled2.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+
+				expect(responseDefault.body).toEqual(responseDefault2.body);
+				expect(responseCacheEnabled.body).toEqual(responseCacheEnabled2.body);
+				expect(responseCacheDisabled.body).not.toEqual(responseCacheDisabled2.body);
+			});
+		});
+
+		describe('ignores cacheEnabled for POST', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const env = envs[vendor];
+
+				const payloadFlowCreate = {
+					name: 'POST webhook flow',
+					icon: 'bolt',
+					color: null,
+					description: null,
+					status: 'active',
+					accountability: null,
+					trigger: 'webhook',
+					options: { method: 'POST' },
+				};
+
+				const payloadOperationCreate = {
+					position_x: 19,
+					position_y: 1,
+					name: 'Get epoch milliseconds',
+					key: 'op_exev',
+					type: 'exec',
+					options: { code: 'module.exports = async function() { return { epoch: Date.now() }; }' },
+				};
+
+				const flowId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send(payloadFlowCreate)
+				).body.data.id;
+
+				const flowCacheEnabledId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send({
+							...payloadFlowCreate,
+							name: 'POST webhook flow cache enabled',
+							options: { ...payloadFlowCreate.options, cacheEnabled: false },
+						})
+				).body.data.id;
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowId } });
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowCacheEnabledId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowCacheEnabledId } });
+
+				const responseDefault = await request(getUrl(vendor, env)).post(`/flows/trigger/${flowId}`);
+				const responseCacheEnabled = await request(getUrl(vendor, env)).post(`/flows/trigger/${flowCacheEnabledId}`);
+
+				await sleep(100);
+
+				const responseDefault2 = await request(getUrl(vendor, env)).post(`/flows/trigger/${flowId}`);
+				const responseCacheEnabled2 = await request(getUrl(vendor, env)).post(`/flows/trigger/${flowCacheEnabledId}`);
+
+				expect(responseDefault.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheEnabled.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseDefault2.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheEnabled2.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+
+				expect(responseDefault.body).not.toEqual(responseDefault2.body);
+				expect(responseCacheEnabled.body).not.toEqual(responseCacheEnabled2.body);
+			});
+		});
+
+		describe('manual trigger payload survives the cache envelope unwrap', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const env = envs[vendor];
+
+				const payloadFlowCreate = {
+					name: 'manual flow envelope regression',
+					icon: 'bolt',
+					color: null,
+					description: null,
+					status: 'active',
+					accountability: null,
+					trigger: 'manual',
+					options: { collections: ['directus_files'], requireSelection: false },
+				};
+
+				const payloadOperationCreate = {
+					position_x: 19,
+					position_y: 1,
+					name: 'Get epoch milliseconds',
+					key: 'op_exev',
+					type: 'exec',
+					options: { code: 'module.exports = async function() { return { epoch: Date.now() }; }' },
+				};
+
+				const flowId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send(payloadFlowCreate)
+				).body.data.id;
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowId } });
+
+				const response = await request(getUrl(vendor, env))
+					.post(`/flows/trigger/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ collection: 'directus_files' });
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+			});
+		});
+
+		describe('flipping cacheEnabled off does not evict an existing cached entry when CACHE_AUTO_PURGE is false', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const env = envs[vendor];
+
+				const payloadFlowCreate = {
+					name: 'stale-hit demonstration flow',
+					icon: 'bolt',
+					color: null,
+					description: null,
+					status: 'active',
+					accountability: null,
+					trigger: 'webhook',
+					options: {},
+				};
+
+				const payloadOperationCreate = {
+					position_x: 19,
+					position_y: 1,
+					name: 'Get epoch milliseconds',
+					key: 'op_exev',
+					type: 'exec',
+					options: { code: 'module.exports = async function() { return { epoch: Date.now() }; }' },
+				};
+
+				const flowId = (
+					await request(getUrl(vendor, env))
+						.post('/flows')
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+						.query({ fields: ['id'] })
+						.send(payloadFlowCreate)
+				).body.data.id;
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ operation: { ...payloadOperationCreate, flow: flowId } });
+
+				const responseInitial = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+
+				await sleep(100);
+
+				const responseCacheHit = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+
+				await request(getUrl(vendor, env))
+					.patch(`/flows/${flowId}`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.send({ options: { cacheEnabled: false } });
+
+				await sleep(100);
+
+				const responseAfterFlip = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+
+				await request(getUrl(vendor, env))
+					.post('/utils/cache/clear')
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+				await sleep(100);
+
+				const responseAfterClear = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+
+				await sleep(100);
+
+				const responseFresh = await request(getUrl(vendor, env)).get(`/flows/trigger/${flowId}`);
+
+				expect(responseInitial.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseCacheHit.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseAfterFlip.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseAfterClear.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+				expect(responseFresh.body).toEqual(expect.objectContaining({ epoch: expect.any(Number) }));
+
+				expect(responseInitial.body).toEqual(responseCacheHit.body);
+				expect(responseAfterFlip.body).toEqual(responseInitial.body);
+				expect(responseAfterClear.body).not.toEqual(responseInitial.body);
+				expect(responseFresh.body).not.toEqual(responseAfterClear.body);
+			});
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -14,6 +14,7 @@ exports.list = {
 		{ testFilePath: '/schema/timezone/timezone-changed-node-tz-america.test.ts' },
 		{ testFilePath: '/schema/timezone/timezone-changed-node-tz-asia.test.ts' },
 		{ testFilePath: '/logger/redact.test.ts' },
+		{ testFilePath: '/routes/flows/webhook.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/items/relational-presets.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds a `Cache` toggle for GET webhook-triggered Flows so operators can prevent dynamic flow responses from being stored in the response cache. The toggle defaults to the existing behavior, is hidden for POST webhook flows, and is documented as controlling future cache writes rather than evicting entries that were already cached.

### Testing / verification

Added blackbox coverage for:
- default GET webhook flows returning the same cached response across repeated requests
- GET webhook flows with `cacheEnabled: false` returning fresh responses across repeated requests
- POST webhook flows remaining uncached regardless of the cache option
- cached GET responses continuing to serve after the toggle is flipped off when `CACHE_AUTO_PURGE=false`, then returning fresh responses after an explicit cache clear
- manual trigger responses still returning the operation payload through the shared trigger route envelope

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
