### PR TITLE
Accept multipart schema-diff uploads on /schema/apply

### DIFF
--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -7,7 +7,7 @@ import { InvalidPayloadException, UnsupportedMediaTypeException } from '../excep
 import logger from '../logger.js';
 import { respond } from '../middleware/respond.js';
 import { SchemaService } from '../services/schema.js';
-import type { Snapshot } from '../types/index.js';
+import type { Snapshot, SnapshotDiffWithHash } from '../types/index.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getVersionedHash } from '../utils/get-versioned-hash.js';
 
@@ -24,24 +24,19 @@ router.get(
 	respond
 );
 
-router.post(
-	'/apply',
-	asyncHandler(async (req, _res, next) => {
-		const service = new SchemaService({ accountability: req.accountability });
-		await service.apply(req.body);
-		return next();
-	}),
-	respond
-);
-
 const schemaMultipartHandler: RequestHandler = (req, res, next) => {
 	if (req.is('application/json')) {
-		if (Object.keys(req.body).length === 0) throw new InvalidPayloadException(`No data was included in the body`);
-		res.locals['uploadedSnapshot'] = req.body;
+		if (Object.keys(req.body).length === 0) {
+			throw new InvalidPayloadException(`No data was included in the body`);
+		}
+
+		res.locals['upload'] = req.body;
 		return next();
 	}
 
-	if (!req.is('multipart/form-data')) throw new UnsupportedMediaTypeException(`Unsupported Content-Type header`);
+	if (!req.is('multipart/form-data')) {
+		throw new UnsupportedMediaTypeException(`Unsupported Content-Type header`);
+	}
 
 	const headers = req.headers['content-type']
 		? req.headers
@@ -53,7 +48,7 @@ const schemaMultipartHandler: RequestHandler = (req, res, next) => {
 	const busboy = Busboy({ headers });
 
 	let isFileIncluded = false;
-	let uploadedSnapshot: Snapshot | null = null;
+	let upload: any | null = null;
 
 	busboy.on('file', async (_, fileStream, { mimeType }) => {
 		if (isFileIncluded) return next(new InvalidPayloadException(`More than one file was included in the body`));
@@ -67,23 +62,25 @@ const schemaMultipartHandler: RequestHandler = (req, res, next) => {
 
 			if (mimeType === 'application/json') {
 				try {
-					uploadedSnapshot = parseJSON(uploadedString);
+					upload = parseJSON(uploadedString);
 				} catch (err: any) {
 					logger.warn(err);
-					throw new InvalidPayloadException('Invalid JSON schema snapshot');
+					throw new InvalidPayloadException('The provided JSON is invalid.');
 				}
 			} else {
 				try {
-					uploadedSnapshot = (await loadYaml(uploadedString)) as Snapshot;
+					upload = await loadYaml(uploadedString);
 				} catch (err: any) {
 					logger.warn(err);
-					throw new InvalidPayloadException('Invalid YAML schema snapshot');
+					throw new InvalidPayloadException('The provided YAML is invalid.');
 				}
 			}
 
-			if (!uploadedSnapshot) throw new InvalidPayloadException(`No file was included in the body`);
+			if (!upload) {
+				throw new InvalidPayloadException(`No file was included in the body`);
+			}
 
-			res.locals['uploadedSnapshot'] = uploadedSnapshot;
+			res.locals['upload'] = upload;
 
 			return next();
 		} catch (error: any) {
@@ -105,14 +102,25 @@ router.post(
 	asyncHandler(schemaMultipartHandler),
 	asyncHandler(async (req, res, next) => {
 		const service = new SchemaService({ accountability: req.accountability });
-		const snapshot: Snapshot = res.locals['uploadedSnapshot'];
-
+		const snapshot: Snapshot = res.locals['upload'];
 		const currentSnapshot = await service.snapshot();
 		const snapshotDiff = await service.diff(snapshot, { currentSnapshot, force: 'force' in req.query });
 		if (!snapshotDiff) return next();
 
 		const currentSnapshotHash = getVersionedHash(currentSnapshot);
 		res.locals['payload'] = { data: { hash: currentSnapshotHash, diff: snapshotDiff } };
+		return next();
+	}),
+	respond
+);
+
+router.post(
+	'/apply',
+	asyncHandler(schemaMultipartHandler),
+	asyncHandler(async (req, res, next) => {
+		const service = new SchemaService({ accountability: req.accountability });
+		const diff: SnapshotDiffWithHash = res.locals['upload'];
+		await service.apply(diff);
 		return next();
 	}),
 	respond

--- a/docs/api/system-collections/schema-and-modeling.md
+++ b/docs/api/system-collections/schema-and-modeling.md
@@ -104,7 +104,7 @@ Three endpoints snapshot, diff, and apply the entire data model across deploymen
 
 These are admin-only and operator-facing rather than per-row CRUD. The two-step diff/apply pattern (with a hash handoff between calls) protects against a third party changing the schema between when the diff was computed and when it is applied. See [Schema as code](/docs/manage/schema-as-code/) for the full reference, including the snapshot file format, the version and vendor portability checks, the hash mechanism, and the relationship with the `cairncms schema snapshot` and `cairncms schema apply` CLI commands.
 
-The endpoints take and return JSON by default. `POST /schema/diff` also accepts YAML and JSON snapshot files as multipart uploads so the same workflow works against snapshot files committed to a repo without parsing them client-side.
+The endpoints take and return JSON by default. `POST /schema/diff` also accepts YAML and JSON snapshot files as multipart uploads so the same workflow works against snapshot files committed to a repo without parsing them client-side. `POST /schema/apply` accepts the same two shapes for its diff payload — the `{ hash, diff }` JSON returned by `/schema/diff` in the request body, or the same payload as a JSON or YAML file via `multipart/form-data`.
 
 ## GraphQL
 

--- a/docs/manage/schema-as-code.md
+++ b/docs/manage/schema-as-code.md
@@ -117,7 +117,7 @@ For pipelines that cannot shell into a container, the same workflow is exposed a
 
 - **`GET /schema/snapshot`** — returns the current snapshot as JSON. Equivalent to `cairncms schema snapshot --format json` to stdout.
 - **`POST /schema/diff`** — accepts a snapshot (JSON in the body, or YAML/JSON as multipart form upload), returns `{ hash, diff }`. The hash is a fingerprint of the current database snapshot at the moment the diff was computed.
-- **`POST /schema/apply`** — accepts the `{ hash, diff }` payload from the diff endpoint and applies the diff. The hash is re-checked against the current state; if the database has changed since the diff was produced, the apply is rejected.
+- **`POST /schema/apply`** — accepts the `{ hash, diff }` payload from the diff endpoint (JSON in the body, or YAML/JSON as multipart form upload) and applies the diff. The hash is re-checked against the current state. If the database has changed since the diff was produced, the apply is rejected.
 
 The two-step diff/apply flow is the safety net for HTTP. Between the moment you compute the diff and the moment you apply it, another admin or an automated process might have changed the schema. The hash check catches that and forces a re-diff.
 

--- a/packages/specs/src/paths/schema/apply.yaml
+++ b/packages/specs/src/paths/schema/apply.yaml
@@ -1,18 +1,22 @@
 post:
   summary: Apply Schema Difference
   description:
-    Update the instance's schema by passing the diff previously retrieved via `/schema/diff` endpoint in the request
-    body. This endpoint is only available to admin users.
+    Update the instance's schema by passing the diff previously retrieved via `/schema/diff` endpoint in the JSON
+    request body or a JSON/YAML file. This endpoint is only available to admin users.
   operationId: schemaApply
   requestBody:
     required: true
     content:
       application/json:
         schema:
+          $ref: '../../openapi.yaml#/components/schemas/Diff'
+      multipart/form-data:
+        schema:
           type: object
           properties:
-            data:
-              $ref: '../../openapi.yaml#/components/schemas/Diff'
+            file:
+              type: string
+              format: binary
   responses:
     '204':
       description: Successful request

--- a/tests/blackbox/routes/schema/schema.test.ts
+++ b/tests/blackbox/routes/schema/schema.test.ts
@@ -321,13 +321,12 @@ describe('Schema Snapshots', () => {
 			);
 		});
 
-		describe('applies empty snapshot', () => {
+		describe('applies an empty snapshot via multipart/form-data with an application/json content-type', () => {
 			it.each(vendors)(
 				'%s',
 				async (vendor) => {
 					expect(snapshotsCacheEmpty[vendor]).toBeDefined();
 
-					// Action
 					const responseDiff = await request(getUrl(vendor))
 						.post('/schema/diff')
 						.send(snapshotsCacheEmpty[vendor])
@@ -336,11 +335,12 @@ describe('Schema Snapshots', () => {
 
 					const response = await request(getUrl(vendor))
 						.post('/schema/apply')
-						.send(responseDiff.body.data)
-						.set('Content-type', 'application/json')
+						.attach('file', Buffer.from(JSON.stringify(responseDiff.body.data)), {
+							contentType: 'application/json',
+							filename: 'diff.json',
+						})
 						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
-					// Assert
 					expect(response.statusCode).toEqual(204);
 				},
 				1200000
@@ -359,13 +359,12 @@ describe('Schema Snapshots', () => {
 			});
 		});
 
-		describe('applies a snapshot (YAML)', () => {
+		describe('applies a snapshot (YAML) with multipart/form-data requests', () => {
 			it.each(vendors)(
 				'%s',
 				async (vendor) => {
 					expect(snapshotsCacheOriginalYaml[vendor]).toBeDefined();
 
-					// Action
 					const responseDiff = await request(getUrl(vendor))
 						.post('/schema/diff')
 						.attach('file', Buffer.from(snapshotsCacheOriginalYaml[vendor]))
@@ -373,11 +372,9 @@ describe('Schema Snapshots', () => {
 
 					const response = await request(getUrl(vendor))
 						.post('/schema/apply')
-						.send(responseDiff.body.data)
-						.set('Content-type', 'application/json')
+						.attach('file', Buffer.from(JSON.stringify(responseDiff.body.data)))
 						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
 
-					// Assert
 					expect(response.statusCode).toEqual(204);
 				},
 				1200000


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Allows `/schema/apply` to accept schema diff files as multipart uploads, so both steps of the HTTP schema-as-code flow can work with uploaded files instead of requiring apply to use a raw JSON request body.

This also corrects the OpenAPI schema for `/schema/apply` so the documented JSON request body matches the actual unwrapped `{ hash, diff }` payload.

### Testing / verification

Added blackbox coverage for:
- applying a schema diff through the existing JSON request-body path
- applying a schema diff through multipart upload with an `application/json` file part
- applying a schema diff through multipart upload using the YAML fallback path
- preserving the existing schema apply state transitions across original and empty snapshots

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
