### PR TITLE
Add folder navigation to file and image selector interfaces

### DIFF
--- a/app/src/components/register.ts
+++ b/app/src/components/register.ts
@@ -5,6 +5,7 @@ import SidebarDetail from '@/views/private/components/sidebar-detail.vue';
 import UserPopover from '@/views/private/components/user-popover.vue';
 import ValueNull from '@/views/private/components/value-null.vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import { App } from 'vue';
@@ -48,6 +49,7 @@ import VListItemContent from './v-list-item-content.vue';
 import VListItemHint from './v-list-item-hint.vue';
 import VListItemIcon from './v-list-item-icon.vue';
 import VMenu from './v-menu.vue';
+import VNav from './v-nav.vue';
 import VNotice from './v-notice.vue';
 import VOverlay from './v-overlay.vue';
 import VPagination from './v-pagination.vue';
@@ -110,6 +112,7 @@ export function registerComponents(app: App): void {
 	app.component('VListItem', VListItem);
 	app.component('VList', VList);
 	app.component('VMenu', VMenu);
+	app.component('VNav', VNav);
 	app.component('VDrawer', VDrawer);
 	app.component('VNotice', VNotice);
 	app.component('VOverlay', VOverlay);
@@ -147,6 +150,7 @@ export function registerComponents(app: App): void {
 	app.component('UserPopover', UserPopover);
 	app.component('ValueNull', ValueNull);
 	app.component('DrawerCollection', DrawerCollection);
+	app.component('DrawerFiles', DrawerFiles);
 	app.component('DrawerItem', DrawerItem);
 	app.component('DrawerBatch', DrawerBatch);
 }

--- a/app/src/components/v-drawer.vue
+++ b/app/src/components/v-drawer.vue
@@ -20,9 +20,11 @@
 			<div class="content">
 				<v-overlay v-if="$slots.sidebar" absolute />
 
-				<nav v-if="$slots.sidebar" class="sidebar">
-					<slot name="sidebar" />
-				</nav>
+				<v-nav v-if="$slots.sidebar" class="sidebar" :resizeable="sidebarResizeable" :max-width="sidebarMaxWidth">
+					<div class="sidebar-content">
+						<slot name="sidebar" />
+					</div>
+				</v-nav>
 
 				<main ref="mainEl" class="main">
 					<header-bar
@@ -71,13 +73,15 @@ import { useI18n } from 'vue-i18n';
 import { ref, computed, provide } from 'vue';
 import HeaderBar from '@/views/private/components/header-bar.vue';
 import { i18n } from '@/lang';
+import VNav from './v-nav.vue';
 
-interface Props {
+export interface Props {
 	title: string;
 	subtitle?: string | null;
 	modelValue?: boolean;
 	persistent?: boolean;
 	icon?: string;
+	sidebarResizeable?: boolean;
 	sidebarLabel?: string;
 	cancelable?: boolean;
 	headerShadow?: boolean;
@@ -104,6 +108,9 @@ const localActive = ref(false);
 const mainEl = ref<Element>();
 
 provide('main-element', mainEl);
+
+// Half of the space of the drawer (856 / 2 = 428)
+const sidebarMaxWidth = 428;
 
 const internalActive = computed({
 	get() {
@@ -133,9 +140,14 @@ body {
 	background-color: var(--background-page);
 
 	.cancel {
+		display: none;
 		position: absolute;
 		top: 32px;
 		left: -76px;
+
+		@media (min-width: 960px) {
+			display: inline-flex;
+		}
 	}
 
 	.spacer {
@@ -172,14 +184,18 @@ body {
 
 			@media (min-width: 960px) {
 				position: relative;
-				z-index: 2;
 				display: block;
-				flex-basis: 220px;
 				flex-shrink: 0;
 				width: 220px;
 				height: 100%;
 				height: auto;
 				background-color: var(--background-normal);
+			}
+
+			.sidebar-content {
+				height: 100%;
+				overflow-x: hidden;
+				overflow-y: auto;
 			}
 		}
 
@@ -214,6 +230,8 @@ body {
 }
 
 .mobile-sidebar {
+	position: relative;
+	z-index: 2;
 	margin: var(--content-padding);
 
 	nav {

--- a/app/src/components/v-nav.vue
+++ b/app/src/components/v-nav.vue
@@ -1,0 +1,128 @@
+<template>
+	<nav ref="navEl">
+		<slot />
+
+		<div
+			v-if="resizeable"
+			class="resize-handle"
+			:class="{ active: handleHover }"
+			@pointerenter="handleHover = true"
+			@pointerleave="handleHover = false"
+			@pointerdown.self="onResizeHandlePointerDown"
+			@dblclick="resetNavWidth"
+		/>
+	</nav>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { useEventListener } from '@/composables/use-event-listener';
+import { debounce } from 'lodash';
+
+const props = defineProps<{
+	resizeable?: boolean;
+	minWidth?: number;
+	maxWidth?: number;
+	width?: number;
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:width', value: number): void;
+}>();
+
+const navEl = ref<HTMLElement>();
+const minWidth = ref<number>(0);
+const handleHover = ref<boolean>(false);
+const dragging = ref<boolean>(false);
+const dragStartX = ref<number>(0);
+const dragStartWidth = ref<number>(0);
+const currentWidth = ref<number | null>(null);
+const rafId = ref<number | null>(null);
+
+onMounted(() => {
+	minWidth.value = props.minWidth ? props.minWidth : navEl.value?.offsetWidth || 0;
+
+	if (props.width && navEl.value) navEl.value.style.width = `${props.width}px`;
+});
+
+useEventListener(window, 'pointermove', onPointerMove);
+useEventListener(window, 'pointerup', onPointerUp);
+
+watch(
+	currentWidth,
+	debounce((newVal) => {
+		emit('update:width', newVal);
+	}, 300)
+);
+
+function onResizeHandlePointerDown(event: PointerEvent) {
+	dragging.value = true;
+	dragStartX.value = event.pageX;
+
+	if (navEl.value) {
+		dragStartWidth.value = navEl.value.offsetWidth;
+	}
+}
+
+function resetNavWidth() {
+	currentWidth.value = minWidth.value;
+
+	if (navEl.value) {
+		navEl.value.style.width = `${currentWidth.value}px`;
+	}
+}
+
+function onPointerMove(event: PointerEvent) {
+	if (!dragging.value) return;
+
+	rafId.value = window.requestAnimationFrame(() => {
+		currentWidth.value = Math.max(minWidth.value, dragStartWidth.value + (event.pageX - dragStartX.value));
+		if (props.maxWidth && currentWidth.value >= props.maxWidth) currentWidth.value = props.maxWidth;
+
+		if (currentWidth.value > minWidth.value && currentWidth.value <= minWidth.value + 10) {
+			currentWidth.value = minWidth.value; // Snap when nearing min width
+		}
+
+		if (navEl.value) {
+			navEl.value.style.width = `${currentWidth.value}px`;
+		}
+	});
+}
+
+function onPointerUp() {
+	if (!dragging.value) return;
+
+	dragging.value = false;
+
+	if (rafId.value) {
+		window.cancelAnimationFrame(rafId.value);
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.resize-handle {
+	position: absolute;
+	top: 0;
+	right: -2px;
+	bottom: 0;
+	width: 4px;
+	background-color: var(--primary);
+	cursor: ew-resize;
+	opacity: 0;
+	transition: opacity var(--fast) var(--transition);
+	transition-delay: 0;
+	user-select: none;
+	touch-action: none;
+	z-index: 6;
+
+	&:hover,
+	&:active {
+		opacity: 1;
+	}
+
+	&.active {
+		transition-delay: var(--slow);
+	}
+}
+</style>

--- a/app/src/components/v-upload.vue
+++ b/app/src/components/v-upload.vue
@@ -56,11 +56,10 @@
 			<p class="type-label">{{ t(fromUser ? 'drag_file_here' : 'choose_from_library') }}</p>
 
 			<template v-if="fromUrl !== false || fromLibrary !== false">
-				<drawer-collection
-					collection="directus_files"
+				<drawer-files
 					:active="activeDialog === 'choose'"
 					:multiple="multiple"
-					:filter="filterByFolder"
+					:folder="folder"
 					@update:active="activeDialog = null"
 					@input="setSelection"
 				/>
@@ -97,8 +96,7 @@ import emitter, { Events } from '@/events';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { uploadFile } from '@/utils/upload-file';
 import { uploadFiles } from '@/utils/upload-files';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
-import { Filter } from '@cairncms/types';
+import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -133,11 +131,6 @@ const { url, isValidURL, loading: urlLoading, importFromURL } = useURLImport();
 const { setSelection } = useSelection();
 const activeDialog = ref<'choose' | 'url' | null>(null);
 const input = ref<HTMLInputElement>();
-
-const filterByFolder = computed(() => {
-	if (!props.folder) return undefined;
-	return { folder: { id: { _eq: props.folder } } } as Filter;
-});
 
 function validFiles(files: FileList) {
 	if (files.length === 0) return false;

--- a/app/src/composables/use-folders.ts
+++ b/app/src/composables/use-folders.ts
@@ -23,6 +23,8 @@ type UsableFolders = {
 	openFolders: Ref<string[] | null>;
 };
 
+export const openFoldersInitial = ['root'];
+
 let loading: Ref<boolean> | null = null;
 let folders: Ref<Folder[] | null> | null = null;
 let nestedFolders: Ref<Folder[] | null> | null = null;
@@ -35,7 +37,7 @@ export function useFolders(): UsableFolders {
 	if (folders === null) folders = ref<Folder[] | null>(null);
 	if (nestedFolders === null) nestedFolders = ref<Folder[] | null>(null);
 	if (error === null) error = ref(null);
-	if (openFolders === null) openFolders = ref(['root']);
+	if (openFolders === null) openFolders = ref(openFoldersInitial);
 
 	if (folders.value === null && loading.value === false) {
 		fetchFolders();

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -111,11 +111,10 @@
 			</v-card>
 		</v-dialog>
 
-		<drawer-collection
+		<drawer-files
 			v-if="activeDialog === 'choose'"
-			collection="directus_files"
+			:folder="folder"
 			:active="activeDialog === 'choose'"
-			:filter="filterByFolder"
 			@update:active="activeDialog = null"
 			@input="setSelection"
 		/>
@@ -153,9 +152,8 @@ import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getAssetUrl } from '@/utils/get-asset-url';
 import { readableMimeType } from '@/utils/readable-mime-type';
 import { unexpectedError } from '@/utils/unexpected-error';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
-import { Filter } from '@cairncms/types';
 import { computed, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -201,11 +199,6 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 const { t } = useI18n();
 
 const activeDialog = ref<'upload' | 'choose' | 'url' | null>(null);
-
-const filterByFolder = computed(() => {
-	if (!props.folder) return undefined;
-	return { folder: { id: { _eq: props.folder } } } as Filter;
-});
 
 const fileExtension = computed(() => {
 	if (file.value === null) return null;

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -102,11 +102,11 @@
 			</template>
 		</drawer-item>
 
-		<drawer-collection
+		<drawer-files
 			v-if="!disabled"
 			v-model:active="selectModalActive"
 			:collection="relationInfo.relatedCollection.collection"
-			:selection="selectedPrimaryKeys"
+			:folder="folder"
 			:filter="customFilter"
 			multiple
 			@input="onSelect"
@@ -132,7 +132,7 @@ import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/compo
 import { useRelationPermissionsM2M } from '@/composables/use-relation-permissions';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { getAssetUrl } from '@/utils/get-asset-url';
-import DrawerCollection from '@/views/private/components/drawer-collection.vue';
+import DrawerFiles from '@/views/private/components/drawer-files.vue';
 import DrawerItem from '@/views/private/components/drawer-item.vue';
 import { Filter } from '@cairncms/types';
 import { getFieldsFromTemplate } from '@cairncms/utils';
@@ -366,19 +366,11 @@ function getFilename(junctionRow: Record<string, any>) {
 }
 
 const customFilter = computed(() => {
+	if (!relationInfo.value) return;
+
 	const filter: Filter = {
 		_and: [],
 	};
-
-	if (props.folder) {
-		filter._and.push({
-			folder: {
-				id: { _eq: props.folder },
-			},
-		});
-	}
-
-	if (!relationInfo.value) return filter;
 
 	const reverseRelation = `$FOLLOW(${relationInfo.value.junctionCollection.collection},${relationInfo.value.junctionField.field})`;
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -451,6 +451,7 @@ checksum: Checksum
 owner: Owner
 edited_by: Edited by
 folder: Folder
+folders: Folders
 zoom: Zoom
 download: Download
 open: Open

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -6,9 +6,9 @@
 		v-model:selection="selection"
 		v-model:layout-options="layoutOptions"
 		v-model:layout-query="layoutQuery"
-		:filter="mergeFilters(filter, folderTypeFilter)"
+		:filter="mergeFilters(filter, folderFilter)"
 		:filter-user="filter"
-		:filter-system="folderTypeFilter"
+		:filter-system="folderFilter"
 		:search="search"
 		collection="directus_files"
 		:reset-preset="resetPreset"
@@ -116,7 +116,7 @@
 			</template>
 
 			<template #navigation>
-				<files-navigation :current-folder="folder" />
+				<files-navigation :current-folder="folder" :current-special="special" />
 			</template>
 
 			<component :is="`layout-${layout}`" v-bind="layoutState">
@@ -173,7 +173,7 @@
 				<export-sidebar-detail
 					collection="directus_files"
 					:layout-query="layoutQuery"
-					:filter="mergeFilters(filter, folderTypeFilter)"
+					:filter="mergeFilters(filter, folderFilter)"
 					:search="search"
 					@refresh="refresh"
 				/>
@@ -201,19 +201,18 @@ import { usePermissionsStore } from '@/stores/permissions';
 import { useUserStore } from '@/stores/user';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { uploadFiles } from '@/utils/upload-files';
+import { getFolderFilter } from '@/utils/get-folder-filter';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import FolderPicker from '@/views/private/components/folder-picker.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
 import { useLayout } from '@cairncms/composables';
-import { Filter } from '@cairncms/types';
 import { mergeFilters } from '@cairncms/utils';
-import { subDays } from 'date-fns';
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRouter } from 'vue-router';
 import AddFolder from '../components/add-folder.vue';
-import FilesNavigation from '../components/navigation.vue';
+import FilesNavigation from '@/views/private/components/files-navigation.vue';
 
 type Item = {
 	[field: string]: any;
@@ -245,50 +244,8 @@ const { confirmDelete, deleting, batchDelete, batchEditActive } = useBatch();
 
 const { breadcrumb, title } = useBreadcrumb();
 
-const folderTypeFilter = computed(() => {
-	const filterParsed: Filter = {
-		_and: [
-			{
-				type: {
-					_nnull: true,
-				},
-			},
-		],
-	};
-
-	if (props.special === null) {
-		if (props.folder !== null) {
-			filterParsed._and.push({
-				folder: {
-					_eq: props.folder,
-				},
-			});
-		} else {
-			filterParsed._and.push({
-				folder: {
-					_null: true,
-				},
-			});
-		}
-	}
-
-	if (props.special === 'mine' && userStore.currentUser) {
-		filterParsed._and.push({
-			uploaded_by: {
-				_eq: userStore.currentUser.id,
-			},
-		});
-	}
-
-	if (props.special === 'recent') {
-		filterParsed._and.push({
-			uploaded_on: {
-				_gt: subDays(new Date(), 5).toISOString(),
-			},
-		});
-	}
-
-	return filterParsed;
+const folderFilter = computed(() => {
+	return getFolderFilter(props.folder, props.special, userStore?.currentUser?.id);
 });
 
 const { layoutWrapper } = useLayout(layout);

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -201,7 +201,7 @@ import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import FileInfoSidebarDetail from '../components/file-info-sidebar-detail.vue';
-import FilesNavigation from '../components/navigation.vue';
+import FilesNavigation from '@/views/private/components/files-navigation.vue';
 import ReplaceFile from '../components/replace-file.vue';
 import FilesNotFound from './not-found.vue';
 

--- a/app/src/modules/files/routes/not-found.vue
+++ b/app/src/modules/files/routes/not-found.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import FilesNavigation from '../components/navigation.vue';
+import FilesNavigation from '@/views/private/components/files-navigation.vue';
 
 const { t } = useI18n();
 </script>

--- a/app/src/types/folders.ts
+++ b/app/src/types/folders.ts
@@ -1,0 +1,3 @@
+export type SpecialFolder = 'all' | 'mine' | 'recent';
+
+export type FolderTarget = { folder?: string; special?: never } | { special?: SpecialFolder; folder?: never };

--- a/app/src/utils/get-folder-filter.test.ts
+++ b/app/src/utils/get-folder-filter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+import { getFolderFilter } from './get-folder-filter';
+
+const TYPE_FILTER = { type: { _nnull: true } };
+
+describe('getFolderFilter', () => {
+	test('with no folder and no special, scopes to root files', () => {
+		expect(getFolderFilter()).toEqual({
+			_and: [TYPE_FILTER, { folder: { _null: true } }],
+		});
+	});
+
+	test('with a folder and no special, scopes to that folder', () => {
+		expect(getFolderFilter('folder-id-123')).toEqual({
+			_and: [TYPE_FILTER, { folder: { _eq: 'folder-id-123' } }],
+		});
+	});
+
+	test('with special="all", returns only the type filter', () => {
+		expect(getFolderFilter(undefined, 'all')).toEqual({
+			_and: [TYPE_FILTER],
+		});
+	});
+
+	test('with special="mine" and a current user, adds an uploaded_by filter', () => {
+		expect(getFolderFilter(undefined, 'mine', 'user-id-456')).toEqual({
+			_and: [TYPE_FILTER, { uploaded_by: { _eq: 'user-id-456' } }],
+		});
+	});
+
+	test('with special="mine" but no current user, returns only the type filter', () => {
+		expect(getFolderFilter(undefined, 'mine')).toEqual({
+			_and: [TYPE_FILTER],
+		});
+	});
+
+	test('with special="recent", adds an uploaded_on filter for the last 5 days', () => {
+		vi.useFakeTimers();
+
+		try {
+			vi.setSystemTime(new Date('2026-05-25T12:00:00.000Z'));
+
+			expect(getFolderFilter(undefined, 'recent')).toEqual({
+				_and: [TYPE_FILTER, { uploaded_on: { _gt: '2026-05-20T12:00:00.000Z' } }],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/app/src/utils/get-folder-filter.ts
+++ b/app/src/utils/get-folder-filter.ts
@@ -1,0 +1,49 @@
+import { SpecialFolder } from '@/types/folders';
+import { Filter } from '@cairncms/types';
+import { subDays } from 'date-fns';
+
+export function getFolderFilter(folder?: string, special?: SpecialFolder, currentUserId?: string): Filter {
+	const filterParsed: Filter = {
+		_and: [
+			{
+				type: {
+					_nnull: true,
+				},
+			},
+		],
+	};
+
+	if (!special) {
+		if (folder) {
+			filterParsed._and.push({
+				folder: {
+					_eq: folder,
+				},
+			});
+		} else {
+			filterParsed._and.push({
+				folder: {
+					_null: true,
+				},
+			});
+		}
+	}
+
+	if (special === 'mine' && currentUserId) {
+		filterParsed._and.push({
+			uploaded_by: {
+				_eq: currentUserId,
+			},
+		});
+	}
+
+	if (special === 'recent') {
+		filterParsed._and.push({
+			uploaded_on: {
+				_gt: subDays(new Date(), 5).toISOString(),
+			},
+		});
+	}
+
+	return filterParsed;
+}

--- a/app/src/views/private/components/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection.vue
@@ -5,7 +5,9 @@
 		v-model:selection="layoutSelection"
 		v-model:layout-options="localOptions"
 		v-model:layout-query="localQuery"
-		:filter="layoutFilter"
+		:filter="mergeFilters(presetFilter, filter)"
+		:filter-user="presetFilter"
+		:filter-system="filter"
 		:search="search"
 		:collection="collection"
 		select-mode
@@ -16,8 +18,13 @@
 			:title="t('select_item')"
 			:small-header="currentLayout?.smallHeader"
 			:header-shadow="currentLayout?.headerShadow"
+			v-bind="drawerProps"
 			@cancel="cancel"
 		>
+			<template v-for="(_, slot) of $slots" #[slot]="scope">
+				<slot :name="slot" v-bind="scope" />
+			</template>
+
 			<template #subtitle>
 				<v-breadcrumb :items="[{ name: collectionInfo!.name, disabled: true }]" />
 			</template>
@@ -61,6 +68,8 @@ import { useCollection, useLayout } from '@cairncms/composables';
 import { Filter } from '@cairncms/types';
 import { computed, ref, toRefs, unref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import type { Props as VDrawerProps } from '@/components/v-drawer.vue';
+import { mergeFilters } from '@cairncms/utils';
 
 const props = withDefaults(
 	defineProps<{
@@ -69,6 +78,7 @@ const props = withDefaults(
 		collection: string;
 		multiple?: boolean;
 		filter?: Filter;
+		drawerProps?: VDrawerProps;
 	}>(),
 	{
 		selection: () => [],
@@ -109,20 +119,6 @@ const layoutSelection = computed<any>({
 });
 
 const { layoutWrapper } = useLayout(layout);
-
-const layoutFilter = computed({
-	get() {
-		if (!props.filter) return presetFilter.value;
-		if (!presetFilter.value) return props.filter;
-
-		return {
-			_and: [props.filter, presetFilter.value],
-		};
-	},
-	set(newFilter: Filter | null) {
-		presetFilter.value = newFilter;
-	},
-});
 
 function useActiveState() {
 	const localActive = ref(false);

--- a/app/src/views/private/components/drawer-files.vue
+++ b/app/src/views/private/components/drawer-files.vue
@@ -1,0 +1,58 @@
+<template>
+	<drawer-collection
+		v-bind="$attrs"
+		:collection="collection"
+		:drawer-props="drawerProps"
+		:filter="mergeFilters(filter, folderFilter)"
+	>
+		<template v-if="!folder" #sidebar>
+			<files-navigation
+				:custom-target-handler="onFolderChange"
+				:current-folder="currentFolder"
+				:current-special="currentSpecial"
+				local-open-folders
+				actions-disabled
+			/>
+		</template>
+	</drawer-collection>
+</template>
+
+<script setup lang="ts">
+import { useUserStore } from '@/stores/user';
+import FilesNavigation from '@/views/private/components/files-navigation.vue';
+import { getFolderFilter } from '@/utils/get-folder-filter';
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { FolderTarget, SpecialFolder } from '@/types/folders';
+import { Filter } from '@cairncms/types';
+import { mergeFilters } from '@cairncms/utils';
+
+const props = withDefaults(defineProps<{ collection?: string; folder?: string; filter?: Filter }>(), {
+	collection: 'directus_files',
+});
+
+const { t } = useI18n();
+
+const drawerProps = {
+	sidebarLabel: t('folders'),
+};
+
+const currentFolder = ref<string | undefined>(props.folder);
+const currentSpecial = ref<SpecialFolder>();
+const folderFilter = ref<Filter>();
+
+const userStore = useUserStore();
+
+watch(
+	[currentFolder, currentSpecial],
+	() => {
+		folderFilter.value = getFolderFilter(currentFolder.value, currentSpecial.value, userStore?.currentUser?.id);
+	},
+	{ immediate: true }
+);
+
+function onFolderChange(target: FolderTarget) {
+	currentFolder.value = target.folder;
+	currentSpecial.value = target.special;
+}
+</script>

--- a/app/src/views/private/components/files-navigation-folder.vue
+++ b/app/src/views/private/components/files-navigation-folder.vue
@@ -2,36 +2,34 @@
 	<div>
 		<v-list-item
 			v-if="folder.children === undefined"
-			v-context-menu="'contextMenu'"
-			:to="`/files/folders/${folder.id}`"
+			v-context-menu="!actionsDisabled ? 'contextMenu' : null"
+			clickable
 			:active="currentFolder === folder.id"
+			@click="clickHandler({ folder: folder.id })"
 		>
-			<div class="content-inner" :style="{ paddingLeft: `${depth * 18}px` }">
-				<v-list-item-icon><v-icon small name="folder" /></v-list-item-icon>
-				<v-list-item-content>
-					<v-text-overflow :text="folder.name" />
-				</v-list-item-content>
-			</div>
+			<v-list-item-icon><v-icon small name="folder" /></v-list-item-icon>
+			<v-list-item-content>
+				<v-text-overflow :text="folder.name" />
+			</v-list-item-content>
 		</v-list-item>
 
 		<v-list-group
 			v-else
-			v-context-menu="'contextMenu'"
-			:to="`/files/folders/${folder.id}`"
+			v-context-menu="!actionsDisabled ? 'contextMenu' : null"
+			clickable
 			:active="currentFolder === folder.id"
 			:value="folder.id"
 			scope="files-navigation"
 			disable-groupable-parent
+			@click="clickHandler({ folder: folder.id })"
 		>
 			<template #activator>
-				<div class="content-inner" :style="{ paddingLeft: `${depth * 18}px` }">
-					<v-list-item-icon>
-						<v-icon small name="folder" />
-					</v-list-item-icon>
-					<v-list-item-content>
-						<v-text-overflow :text="folder.name" />
-					</v-list-item-content>
-				</div>
+				<v-list-item-icon>
+					<v-icon small name="folder" />
+				</v-list-item-icon>
+				<v-list-item-content>
+					<v-text-overflow :text="folder.name" />
+				</v-list-item-content>
 			</template>
 
 			<navigation-folder
@@ -40,7 +38,7 @@
 				:folder="childFolder"
 				:current-folder="currentFolder"
 				:click-handler="clickHandler"
-				:depth="depth + 1"
+				:actions-disabled="actionsDisabled"
 			/>
 		</v-list-group>
 
@@ -56,7 +54,7 @@
 				</v-list-item>
 				<v-list-item clickable @click="moveActive = true">
 					<v-list-item-icon>
-						<v-icon name="drive_file_move" />
+						<v-icon name="folder_move" />
 					</v-list-item-icon>
 					<v-list-item-content>
 						<v-text-overflow :text="t('move_to_folder')" />
@@ -124,19 +122,20 @@ import { ref } from 'vue';
 import { useFolders, Folder } from '@/composables/use-folders';
 import api from '@/api';
 import FolderPicker from '@/views/private/components/folder-picker.vue';
+import NavigationFolder from '@/views/private/components/files-navigation-folder.vue';
 import { useRouter } from 'vue-router';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { FolderTarget } from '@/types/folders';
 
 const props = withDefaults(
 	defineProps<{
 		folder: Folder;
 		currentFolder?: string;
-		clickHandler?: () => void;
-		depth?: number;
+		actionsDisabled?: boolean;
+		clickHandler: (target: FolderTarget) => void;
 	}>(),
 	{
 		clickHandler: () => undefined,
-		depth: 0,
 	}
 );
 
@@ -277,11 +276,5 @@ function useDeleteFolder() {
 	--v-list-item-color: var(--danger);
 	--v-list-item-color-hover: var(--danger);
 	--v-list-item-icon-color: var(--danger);
-}
-
-.content-inner {
-	display: flex;
-	align-items: center;
-	width: 100%;
 }
 </style>

--- a/app/src/views/private/components/files-navigation.vue
+++ b/app/src/views/private/components/files-navigation.vue
@@ -9,13 +9,14 @@
 		<div class="folders">
 			<v-item-group v-model="openFolders" scope="files-navigation" multiple>
 				<v-list-group
-					to="/files"
-					:active="currentFolder === null"
+					clickable
+					:active="!currentFolder && !currentSpecial"
 					value="root"
 					scope="files-navigation"
 					exact
 					disable-groupable-parent
 					:arrow-placement="nestedFolders && nestedFolders.length > 0 ? 'after' : false"
+					@click="onClick({})"
 				>
 					<template #activator>
 						<v-list-item-icon>
@@ -29,9 +30,10 @@
 					<navigation-folder
 						v-for="folder in nestedFolders"
 						:key="folder.id"
+						:click-handler="onClick"
 						:folder="folder"
 						:current-folder="currentFolder"
-						:depth="1"
+						:actions-disabled="actionsDisabled"
 					/>
 				</v-list-group>
 			</v-item-group>
@@ -39,21 +41,21 @@
 
 		<v-divider />
 
-		<v-list-item to="/files/all">
+		<v-list-item clickable :active="currentSpecial === 'all'" @click="onClick({ special: 'all' })">
 			<v-list-item-icon><v-icon small name="file_copy" outline /></v-list-item-icon>
 			<v-list-item-content>
 				<v-text-overflow :text="t('all_files')" />
 			</v-list-item-content>
 		</v-list-item>
 
-		<v-list-item to="/files/mine">
+		<v-list-item clickable :active="currentSpecial === 'mine'" @click="onClick({ special: 'mine' })">
 			<v-list-item-icon><v-icon small name="folder_shared" /></v-list-item-icon>
 			<v-list-item-content>
 				<v-text-overflow :text="t('my_files')" />
 			</v-list-item-content>
 		</v-list-item>
 
-		<v-list-item to="/files/recent">
+		<v-list-item clickable :active="currentSpecial === 'recent'" @click="onClick({ special: 'recent' })">
 			<v-list-item-icon><v-icon small name="history" /></v-list-item-icon>
 			<v-list-item-content>
 				<v-text-overflow :text="t('recent_files')" />
@@ -63,32 +65,54 @@
 </template>
 
 <script setup lang="ts">
-import { Folder, useFolders } from '@/composables/use-folders';
-import { isEqual } from 'lodash';
-import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import NavigationFolder from './navigation-folder.vue';
+import { ref, watch } from 'vue';
+import { Folder, useFolders, openFoldersInitial } from '@/composables/use-folders';
+import NavigationFolder from './files-navigation-folder.vue';
+import { isEqual } from 'lodash';
+import { useRouter } from 'vue-router';
+import { SpecialFolder, FolderTarget } from '@/types/folders';
+
+const router = useRouter();
 
 const props = defineProps<{
 	currentFolder?: string;
+	currentSpecial?: SpecialFolder;
+	customTargetHandler?: (target: FolderTarget) => void;
+	localOpenFolders?: boolean;
+	actionsDisabled?: boolean;
 }>();
 
 const { t } = useI18n();
 
-const { nestedFolders, folders, loading, openFolders } = useFolders();
+const { nestedFolders, folders, loading, openFolders: sharedOpenFolders } = useFolders();
+const openFolders = props.localOpenFolders ? ref(openFoldersInitial) : sharedOpenFolders;
 
-setOpenFolders();
+watch([() => props.currentFolder, loading], setOpenFolders, { immediate: true });
 
-watch(() => props.currentFolder, setOpenFolders);
+function onClick(target: FolderTarget) {
+	if (props.customTargetHandler) {
+		props.customTargetHandler(target);
+	} else {
+		const path = ['files'];
+		if (target.folder) path.push('folders', target.folder);
+
+		if (target.special) {
+			path.push(target.special);
+		}
+
+		router.push(`/${path.join('/')}`);
+	}
+}
 
 function setOpenFolders() {
-	if (!folders.value) return [];
-	if (!openFolders?.value) return [];
+	if (!folders.value) return;
+	if (!openFolders?.value) return;
 
 	const shouldBeOpen: string[] = [];
 	const folder = folders.value.find((folder: Folder) => folder.id === props.currentFolder);
 
-	if (folder && folder.parent) parseFolder(folder.parent);
+	if (folder?.parent) parseFolder(folder.parent);
 
 	const newOpenFolders = [...openFolders.value];
 

--- a/app/src/views/private/components/header-bar-actions.vue
+++ b/app/src/views/private/components/header-bar-actions.vue
@@ -80,7 +80,7 @@ const active = ref(false);
 
 @media (min-width: 960px) {
 	.actions .action-buttons .sidebar-toggle {
-		display: none;
+		display: none !important;
 	}
 }
 

--- a/app/src/views/private/components/header-bar.vue
+++ b/app/src/views/private/components/header-bar.vue
@@ -16,7 +16,9 @@
 			<div class="title">
 				<slot name="title">
 					<slot name="title:prepend" />
-					<h1 class="type-title">{{ title }}</h1>
+					<h1 class="type-title">
+						<v-text-overflow :text="title" placement="bottom">{{ title }}</v-text-overflow>
+					</h1>
 					<slot name="title:append" />
 				</slot>
 			</div>
@@ -127,7 +129,6 @@ onUnmounted(() => {
 		&.full {
 			margin-right: 12px;
 			padding-right: 0;
-
 			@media (min-width: 600px) {
 				margin-right: 20px;
 				padding-right: 20px;

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -10,22 +10,20 @@
 	<div v-else class="private-view" :class="{ theme, 'full-screen': fullScreen }">
 		<aside id="navigation" role="navigation" aria-label="Module Navigation" :class="{ 'is-open': navOpen }">
 			<module-bar />
-			<div ref="moduleNavEl" class="module-nav alt-colors">
+			<v-nav
+				class="module-nav alt-colors"
+				resizeable
+				:min-width="moduleNavMinWidth"
+				:max-width="moduleNavMaxWidth"
+				:width="moduleNavWidth"
+				@update:width="updateModuleNavWidth"
+			>
 				<project-info />
 
 				<div class="module-nav-content">
 					<slot name="navigation" />
 				</div>
-
-				<div
-					class="module-nav-resize-handle"
-					:class="{ active: handleHover }"
-					@pointerenter="handleHover = true"
-					@pointerleave="handleHover = false"
-					@pointerdown.self="onResizeHandlePointerDown"
-					@dblclick="resetModuleNavWidth"
-				/>
-			</div>
+			</v-nav>
 		</aside>
 		<div id="main-content" ref="contentEl" class="content">
 			<header-bar
@@ -76,15 +74,13 @@
 
 <script lang="ts" setup>
 import { useElementSize } from '@cairncms/composables';
-import { useEventListener } from '@/composables/use-event-listener';
 import { useLocalStorage } from '@/composables/use-local-storage';
 import { useTitle } from '@/composables/use-title';
 import { useWindowSize } from '@/composables/use-window-size';
 import { useAppStore } from '@/stores/app';
 import { useUserStore } from '@/stores/user';
-import { debounce } from 'lodash';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, provide, ref, toRefs, watch } from 'vue';
+import { computed, provide, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import HeaderBar from './components/header-bar.vue';
@@ -114,21 +110,11 @@ const { width: windowWidth } = useWindowSize();
 const { width: contentWidth } = useElementSize(contentEl);
 const { width: sidebarWidth } = useElementSize(sidebarEl);
 
-const moduleNavEl = ref<HTMLElement>();
-
-const { handleHover, onResizeHandlePointerDown, resetModuleNavWidth, onPointerMove, onPointerUp } =
-	useModuleNavResize();
-
-useEventListener(window, 'pointermove', onPointerMove);
-useEventListener(window, 'pointerup', onPointerUp);
-
-const { data } = useLocalStorage('module-nav-width');
-
-onMounted(() => {
-	if (!data.value) return;
-	if (Number.isNaN(data.value)) return;
-	moduleNavEl.value!.style.width = `${data.value}px`;
-});
+const { data: localStorageModuleNavWidth } = useLocalStorage('module-nav-width');
+const moduleNavMinWidth = 220;
+const moduleNavMaxWidth = ref();
+const moduleNavWidth = ref(localStorageModuleNavWidth.value);
+const moduleNavCurrentWidth = ref();
 
 const { title } = toRefs(props);
 const navOpen = ref(false);
@@ -157,82 +143,36 @@ router.afterEach(() => {
 
 useTitle(title);
 
-function useModuleNavResize() {
-	const handleHover = ref<boolean>(false);
-	const dragging = ref<boolean>(false);
-	const dragStartX = ref<number>(0);
-	const dragStartWidth = ref<number>(0);
-	const currentWidth = ref<number | null>(null);
-	const currentWidthLimit = ref<number>(0);
-	const rafId = ref<number | null>(null);
+function updateModuleNavWidth(width: number) {
+	moduleNavCurrentWidth.value = width;
 
-	watch(
-		currentWidth,
-		debounce((newVal) => {
-			if (newVal === 220) {
-				data.value = null;
-			} else {
-				data.value = newVal;
-			}
-		}, 300)
-	);
-
-	watch(
-		[windowWidth, contentWidth, sidebarWidth],
-		() => {
-			if (windowWidth.value > 1260) {
-				// 590 = minimum content width, 60 = module bar width, and dynamic side bar width
-				currentWidthLimit.value = windowWidth.value - (590 + 60 + sidebarWidth.value);
-			} else if (windowWidth.value > 960) {
-				// 590 = minimum content width, 60 = module bar width, 60 = side bar width
-				currentWidthLimit.value = windowWidth.value - (590 + 60 + 60);
-			} else {
-				// first 60 = module bar width, second 60 = room for overlay
-				currentWidthLimit.value = windowWidth.value - (60 + 60);
-			}
-
-			if (currentWidth.value && currentWidth.value > currentWidthLimit.value) {
-				currentWidth.value = Math.max(220, currentWidthLimit.value);
-				moduleNavEl.value!.style.width = `${currentWidth.value}px`;
-			}
-		},
-		{ immediate: true }
-	);
-
-	return { handleHover, onResizeHandlePointerDown, resetModuleNavWidth, onPointerMove, onPointerUp };
-
-	function onResizeHandlePointerDown(event: PointerEvent) {
-		dragging.value = true;
-		dragStartX.value = event.pageX;
-		dragStartWidth.value = moduleNavEl.value!.offsetWidth;
-	}
-
-	function resetModuleNavWidth() {
-		currentWidth.value = 220;
-		moduleNavEl.value!.style.width = `220px`;
-	}
-
-	function onPointerMove(event: PointerEvent) {
-		if (!dragging.value) return;
-
-		rafId.value = window.requestAnimationFrame(() => {
-			currentWidth.value = Math.max(220, dragStartWidth.value + (event.pageX - dragStartX.value));
-			if (currentWidth.value >= currentWidthLimit.value) currentWidth.value = currentWidthLimit.value;
-			if (currentWidth.value > 220 && currentWidth.value <= 230) currentWidth.value = 220; // snap when nearing min width
-			moduleNavEl.value!.style.width = `${currentWidth.value}px`;
-		});
-	}
-
-	function onPointerUp() {
-		if (dragging.value === true) {
-			dragging.value = false;
-
-			if (rafId.value) {
-				window.cancelAnimationFrame(rafId.value);
-			}
-		}
+	if (width === moduleNavMinWidth) {
+		localStorageModuleNavWidth.value = null;
+	} else {
+		localStorageModuleNavWidth.value = width;
 	}
 }
+
+watch(
+	[windowWidth, contentWidth, sidebarWidth],
+	() => {
+		if (windowWidth.value > 1260) {
+			// 590 = minimum content width, 60 = module bar width, and dynamic side bar width
+			moduleNavMaxWidth.value = windowWidth.value - (590 + 60 + sidebarWidth.value);
+		} else if (windowWidth.value > 960) {
+			// 590 = minimum content width, 60 = module bar width, 60 = side bar width
+			moduleNavMaxWidth.value = windowWidth.value - (590 + 60 + 60);
+		} else {
+			// first 60 = module bar width, second 60 = room for overlay
+			moduleNavMaxWidth.value = windowWidth.value - (60 + 60);
+		}
+
+		if (moduleNavCurrentWidth.value && moduleNavCurrentWidth.value > moduleNavMaxWidth.value) {
+			moduleNavWidth.value = Math.max(220, moduleNavMaxWidth.value);
+		}
+	},
+	{ immediate: true }
+);
 
 function openSidebar(event: PointerEvent) {
 	if (event.target && (event.target as HTMLElement).classList.contains('close') === false) {
@@ -306,31 +246,6 @@ function openSidebar(event: PointerEvent) {
 				height: calc(100% - 64px);
 				overflow-x: hidden;
 				overflow-y: auto;
-			}
-		}
-
-		.module-nav-resize-handle {
-			position: absolute;
-			top: 0;
-			right: -2px;
-			bottom: 0;
-			width: 4px;
-			z-index: 3;
-			background-color: var(--primary);
-			cursor: ew-resize;
-			opacity: 0;
-			transition: opacity var(--fast) var(--transition);
-			transition-delay: 0;
-			user-select: none;
-			touch-action: none;
-
-			&:hover,
-			&:active {
-				opacity: 1;
-			}
-
-			&.active {
-				transition-delay: var(--slow);
 			}
 		}
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds folder navigation to file and image selector drawers, so operators can browse large file libraries by folder instead of relying on a flat selector list.

This also routes the Files module and selector drawers through the same folder-filter helper, correcting root and folder route scoping, and moves sidebar resizing onto the shared `v-nav` primitive used by both drawers and the main module navigation.

### Testing / verification

Added test coverage for:
- root-file filtering when no folder or special view is selected
- specific-folder filtering
- `All Files`, `My Files`, and `Recent` special views
- `My Files` without a current user
- recent-file date filtering with restored fake timers

Manual verification before merge:
- selector drawers show folder navigation and filter by selected folder
- fixed-folder selectors hide the sidebar and stay scoped to the configured folder
- `/files`, `/files/folders/:folder`, `/files/all`, `/files/mine`, and `/files/recent` each show the expected file set
- root drag-and-drop upload omits a folder preset, while folder drag-and-drop upload sets the folder preset
- module navigation still resizes and persists width after refresh
- long header titles truncate with the overflow tooltip
- desktop sidebar toggle remains hidden where expected

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
