### PR TITLE
Add kanban layout

### DIFF
--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -141,7 +141,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value?.[key] : defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue;
 					},
 					set(newValue: T) {
 						layoutOptions.value = {

--- a/app/src/layouts/kanban/actions.vue
+++ b/app/src/layouts/kanban/actions.vue
@@ -1,0 +1,34 @@
+<template>
+	<v-button v-if="limitWarning" rounded icon>
+		<v-icon v-tooltip.bottom.start="t('layouts.kanban.not_all_loaded')" name="warning" />
+	</v-button>
+</template>
+
+<script lang="ts">
+export default {
+	inheritAttrs: false,
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n';
+
+interface Props {
+	limitWarning?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+	limitWarning: false,
+});
+
+const { t } = useI18n();
+</script>
+
+<style lang="scss" scoped>
+.v-button :deep(.button) {
+	background-color: var(--warning-10);
+	border: none;
+	color: var(--warning);
+	margin-right: 8px;
+}
+</style>

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -18,6 +18,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	icon: 'view_week',
 	component: KanbanLayout,
 	headerShadow: false,
+	sidebarShadow: true,
 	slots: {
 		options: KanbanOptions,
 		sidebar: () => undefined,

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -354,7 +354,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
 				return computed<T>({
 					get() {
-						return layoutOptions.value?.[key] ?? defaultValue;
+						return layoutOptions.value?.[key] !== undefined ? layoutOptions.value[key] : defaultValue;
 					},
 					set(newValue: T) {
 						layoutOptions.value = {

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -70,8 +70,12 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 				}
 			},
 			group: (field) => {
-				if (field.meta?.options && Object.keys(field.meta?.options).includes('choices')) {
-					return Object.keys(field.meta?.options).includes('choices');
+				if (
+					field.meta?.options &&
+					Object.keys(field.meta.options).includes('choices') &&
+					['string', 'integer', 'float', 'bigInteger'].includes(field.type)
+				) {
+					return Object.keys(field.meta.options).includes('choices');
 				}
 
 				const relation = relationsStore.relations.find(

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -1,0 +1,618 @@
+import api from '@/api';
+import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
+import { getRootPath } from '@/utils/get-root-path';
+import { translate } from '@/utils/translate-literal';
+import { useCollection, useFilterFields, useItems, useSync } from '@cairncms/composables';
+import { User } from '@cairncms/types';
+import { defineLayout, getRelationType, moveInArray } from '@cairncms/utils';
+import { computed, ref, toRefs, watch } from 'vue';
+import KanbanActions from './actions.vue';
+import KanbanLayout from './kanban.vue';
+import KanbanOptions from './options.vue';
+import type { ChangeEvent, Group, Item, LayoutOptions, LayoutQuery } from './types';
+
+export default defineLayout<LayoutOptions, LayoutQuery>({
+	id: 'kanban',
+	name: '$t:layouts.kanban.name',
+	icon: 'view_week',
+	component: KanbanLayout,
+	headerShadow: false,
+	slots: {
+		options: KanbanOptions,
+		sidebar: () => undefined,
+		actions: KanbanActions,
+	},
+	setup(props, { emit }) {
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		const layoutOptions = useSync(props, 'layoutOptions', emit);
+		const layoutQuery = useSync(props, 'layoutQuery', emit);
+
+		const { collection, filter, search } = toRefs(props);
+
+		const { info, primaryKeyField, fields: fieldsInCollection, sortField } = useCollection(collection);
+
+		const { sort, limit, page, fields } = useLayoutQuery();
+
+		const { fieldGroups } = useFilterFields(fieldsInCollection, {
+			title: (field) => field.type === 'string',
+			text: (field) => field.type === 'string' || field.type === 'text',
+			tags: (field) => field.type === 'json' || field.type === 'csv',
+			date: (field) => ['date', 'time', 'dateTime', 'timestamp'].includes(field.type),
+			user: (field) => {
+				const junction = relationsStore.relations.find(
+					(relation) =>
+						relation.meta?.one_collection === props.collection &&
+						relation.meta.one_field === field.field &&
+						relation.meta.junction_field !== null
+				);
+
+				if (junction !== undefined) {
+					const related = relationsStore.relations.find(
+						(relation) =>
+							relation.collection === junction.collection &&
+							relation.field === junction.meta?.junction_field &&
+							relation.related_collection === 'directus_users'
+					);
+
+					return related !== undefined;
+				} else {
+					const related = relationsStore.relations.find(
+						(relation) =>
+							relation.collection === props.collection &&
+							relation.field === field.field &&
+							relation.related_collection === 'directus_users'
+					);
+
+					return related !== undefined;
+				}
+			},
+			group: (field) => {
+				if (field.meta?.options && Object.keys(field.meta?.options).includes('choices')) {
+					return Object.keys(field.meta?.options).includes('choices');
+				}
+
+				const relation = relationsStore.relations.find(
+					(relation) => getRelationType({ relation, collection: collection.value, field: field.field }) === 'm2o'
+				);
+
+				return !!relation;
+			},
+
+			file: (field) => {
+				if (field.field === '$thumbnail') return true;
+
+				const relation = relationsStore.relations.find((relation) => {
+					return (
+						relation.collection === props.collection &&
+						relation.field === field.field &&
+						relation.related_collection === 'directus_files'
+					);
+				});
+
+				return !!relation;
+			},
+		});
+
+		const {
+			groupField,
+			groupTitle,
+			imageSource,
+			titleField,
+			textField,
+			crop,
+			selectedGroup,
+			dateField,
+			tagsField,
+			userField,
+			showUngrouped,
+			userFieldJunction,
+			userFieldType,
+		} = useLayoutOptions();
+
+		const {
+			groups,
+			groupsSortField,
+			groupsPrimaryKeyField,
+			groupTitleFields,
+			groupsCollection,
+			changeGroupSort,
+			addGroup,
+			editGroup,
+			deleteGroup,
+			isRelational,
+		} = useGrouping();
+
+		const { items, loading, error, totalPages, itemCount, totalCount, changeManualSort } = useItems(collection, {
+			sort,
+			limit,
+			page,
+			fields,
+			filter,
+			search,
+		});
+
+		const limitWarning = computed(() => items.value.length >= limit.value);
+
+		const groupedItems = computed<Group[]>(() => {
+			const groupsCollectionPrimaryKeyField = groupsPrimaryKeyField.value?.field;
+			const groupTitleField = groupTitle?.value || groupsCollectionPrimaryKeyField;
+			const group = groupField.value;
+			const pkField = primaryKeyField.value?.field;
+			const itemGroups: Record<string | number, Group> = {};
+
+			if (!pkField || !group) return [];
+
+			if (isRelational.value && !groupTitleField) return [];
+
+			groups.value.forEach((group, index) => {
+				const id =
+					isRelational.value && groupsCollectionPrimaryKeyField ? group[groupsCollectionPrimaryKeyField] : group.value;
+
+				const title = String(isRelational.value && groupTitleField ? group[groupTitleField] : group.text);
+
+				itemGroups[id] = {
+					id,
+					title: translate(title),
+					items: [],
+					sort: index,
+				};
+			});
+
+			if (showUngrouped.value) {
+				itemGroups['_ungrouped'] = {
+					id: null,
+					items: [],
+					title: '_ungrouped',
+					sort: -1,
+				};
+			}
+
+			items.value.forEach((item, index) => {
+				if (!group || !pkField) return;
+
+				const junctionField = userFieldJunction.value?.meta?.junction_field;
+
+				let users: User[];
+
+				if (userField.value && item[userField.value]) {
+					users = junctionField
+						? (item[userField.value] as Record<string, any>[]).map((val) => val[junctionField] as User)
+						: [item[userField.value] as User];
+				} else {
+					users = [];
+				}
+
+				itemGroups[item[group] ?? '_ungrouped']?.items.push({
+					id: item[pkField],
+					title: titleField.value ? item[titleField.value] : undefined,
+					text: textField.value ? item[textField.value] : undefined,
+					image: imageSource.value ? parseUrl(item[imageSource.value]) : undefined,
+					date: dateField.value ? item[dateField.value] : undefined,
+					dateType: fieldGroups.value.date.find((field) => field.field === dateField.value)?.type,
+					tags: tagsField.value ? item[tagsField.value] : undefined,
+					sort: index,
+					users,
+					item,
+				});
+			});
+
+			return Object.values(itemGroups).sort((a, b) => a.sort - b.sort);
+		});
+
+		return {
+			isRelational,
+			groupedItems,
+			groupsPrimaryKeyField,
+			groups,
+			groupTitle,
+			groupTitleFields,
+			groupField,
+			imageSource,
+			titleField,
+			textField,
+			crop,
+			items,
+			loading,
+			error,
+			totalPages,
+			page,
+			itemCount,
+			totalCount,
+			fieldsInCollection,
+			fields,
+			limit,
+			primaryKeyField,
+			info,
+			sortField,
+			changeManualSort,
+			dateField,
+			tagsField,
+			change,
+			changeGroupSort,
+			groupsSortField,
+			fieldGroups,
+			userField,
+			groupsCollection,
+			addGroup,
+			editGroup,
+			deleteGroup,
+			showUngrouped,
+			limitWarning,
+			userFieldType,
+		};
+
+		async function change(group: Group, event: ChangeEvent<Item>) {
+			const gField = groupField.value;
+			const pkField = primaryKeyField.value?.field;
+
+			if (gField === null || pkField === undefined || event.removed) return;
+
+			if (event.moved) {
+				const item = group.items[event.moved.oldIndex]?.id;
+				const to = group.items[event.moved.newIndex]?.id;
+
+				if (item !== undefined && to !== undefined) await changeManualSort({ item, to });
+			} else if (event.added) {
+				items.value = items.value.map((item) => {
+					if (item[pkField] === event.added?.element.id) {
+						return {
+							...item,
+							[gField]: group.id,
+						};
+					}
+
+					return item;
+				});
+
+				if (group.items.length > 0) {
+					const item = event.added.element;
+					const before = group.items[event.added.newIndex - 1] as Item | undefined;
+					const after = group.items[event.added.newIndex] as Item | undefined;
+
+					if (item.sort !== undefined) {
+						if (after?.sort !== undefined && after.sort < item.sort) {
+							await changeManualSort({ item: item.id, to: after.id });
+						} else if (before?.sort !== undefined && before.sort > item.sort) {
+							await changeManualSort({ item: item.id, to: before.id });
+						}
+					}
+				}
+
+				await api.patch(`/items/${collection.value}/${event.added.element.id}`, {
+					[gField]: group.id,
+				});
+			}
+		}
+
+		function parseUrl(file: Record<string, any>) {
+			if (!file || !file.type) return;
+			if (file.type.startsWith('image') === false) return;
+			if (file.type.includes('svg')) return;
+
+			const fit = crop.value ? '&width=250&height=150' : `&key=system-medium-contain`;
+
+			return getRootPath() + `assets/${file.id}?modified=${file.modified_on}` + fit;
+		}
+
+		function useLayoutOptions() {
+			const groupField = createViewOption<string | null>('groupField', fieldGroups.value.group[0]?.field ?? null);
+			const groupTitle = createViewOption<string | null>('groupTitle', null);
+			const dateField = createViewOption<string | null>('dateField', fieldGroups.value.date[0]?.field ?? null);
+			const tagsField = createViewOption<string | null>('tagsField', fieldGroups.value.tags[0]?.field ?? null);
+			const userField = createViewOption<string | null>('userField', fieldGroups.value.user[0]?.field ?? null);
+			const titleField = createViewOption<string | null>('titleField', fieldGroups.value.title[0]?.field ?? null);
+			const textField = createViewOption<string | null>('textField', fieldGroups.value.text[0]?.field ?? null);
+			const showUngrouped = createViewOption<boolean>('showUngrouped', false);
+			const imageSource = createViewOption<string | null>('imageSource', fieldGroups.value.file[0]?.field ?? null);
+			const crop = createViewOption<boolean>('crop', true);
+
+			const selectedGroup = computed(() => fieldGroups.value.group.find((group) => group.field === groupField.value));
+
+			watch(groupField, () => {
+				groupTitle.value = null;
+			});
+
+			const userFieldJunction = computed(() => {
+				if (userField.value === null) return;
+
+				return relationsStore.relations.find(
+					(relation) =>
+						relation.meta?.one_collection === props.collection &&
+						relation.meta.one_field === userField.value &&
+						relation.meta.junction_field !== null
+				);
+			});
+
+			const userFieldType = computed(() => {
+				if (userField.value === null) return;
+				return userFieldJunction.value !== undefined ? 'm2m' : 'm2o';
+			});
+
+			return {
+				groupField,
+				groupTitle,
+				imageSource,
+				selectedGroup,
+				titleField,
+				textField,
+				crop,
+				dateField,
+				tagsField,
+				userField,
+				showUngrouped,
+				userFieldJunction,
+				userFieldType,
+			};
+
+			function createViewOption<T>(key: keyof LayoutOptions, defaultValue: any) {
+				return computed<T>({
+					get() {
+						return layoutOptions.value?.[key] ?? defaultValue;
+					},
+					set(newValue: T) {
+						layoutOptions.value = {
+							...layoutOptions.value,
+							[key]: newValue,
+						};
+					},
+				});
+			}
+		}
+
+		function useGrouping() {
+			const isRelational = computed(() => !selectedGroup.value?.meta?.options?.choices);
+
+			const groupsCollection = computed(() => {
+				if (isRelational.value) {
+					const field = groupField.value;
+
+					if (field === null) return null;
+
+					const relation = (relationsStore.relations as any[]).find(
+						(relation) => getRelationType({ relation, collection: collection.value, field }) === 'm2o'
+					);
+
+					if (relation === undefined || relation.related_collection === null) return null;
+
+					return relation.related_collection as string;
+				}
+
+				return null;
+			});
+
+			const {
+				fields: groupsCollectionFields,
+				sortField: groupsSortField,
+				primaryKeyField: groupsPrimaryKeyField,
+			} = useCollection(groupsCollection);
+
+			const sort = computed(() => {
+				if (groupsSortField.value) return [groupsSortField.value];
+				if (groupsPrimaryKeyField.value?.field) return [groupsPrimaryKeyField.value.field];
+				return [];
+			});
+
+			const groupFieldsToLoad = computed(() => {
+				if (primaryKeyField.value === null || groupTitle.value === null) return [];
+				return [primaryKeyField.value?.field, groupTitle.value];
+			});
+
+			const groupTitleFields = computed(() => {
+				if (isRelational.value) {
+					return groupsCollectionFields.value.filter((field) => field.type === 'string' || field.type === 'text');
+				}
+
+				return null;
+			});
+
+			const {
+				items: relationalGroupsItems,
+				loading: groupsLoading,
+				error: groupsError,
+				changeManualSort: groupsChangeManualSort,
+				getItems: getGroups,
+			} = useItems(groupsCollection, {
+				sort,
+				limit: ref(100),
+				page: ref(1),
+				fields: groupFieldsToLoad,
+				filter: ref({}),
+				search: ref(null),
+			});
+
+			const groups = computed(() => {
+				if (isRelational.value) return relationalGroupsItems.value;
+				return (selectedGroup.value?.meta?.options?.choices ?? []) as Record<string, any>[];
+			});
+
+			return {
+				groups,
+				groupsLoading,
+				groupsError,
+				groupsChangeManualSort,
+				info,
+				fields,
+				groupTitleFields,
+				groupsPrimaryKeyField,
+				groupsSortField,
+				groupsCollection,
+				addGroup,
+				editGroup,
+				deleteGroup,
+				changeGroupSort,
+				isRelational,
+			};
+
+			async function deleteGroup(id: string | number) {
+				const pkField = primaryKeyField.value?.field;
+
+				if (pkField === undefined) return;
+
+				items.value = items.value.filter((item) => item[pkField] !== id);
+
+				await api.delete(`/items/${groupsCollection.value}/${id}`);
+
+				await getGroups();
+			}
+
+			async function addGroup(title: string) {
+				if (groupTitle.value === null) return;
+
+				await api.post(`/items/${groupsCollection.value}`, {
+					[groupTitle.value]: title,
+				});
+
+				await getGroups();
+			}
+
+			async function editGroup(id: string | number, title: string) {
+				if (isRelational.value) {
+					if (groupTitle.value === null) return;
+
+					await api.patch(`/items/${groupsCollection.value}/${id}`, {
+						[groupTitle.value]: title,
+					});
+				} else {
+					if (!selectedGroup.value) return;
+
+					const updatedChoices = ((selectedGroup.value?.meta?.options?.choices as Record<string, any>[]) ?? []).map(
+						(choice) => {
+							if (choice.value === id) {
+								return {
+									...choice,
+									text: title,
+								};
+							}
+
+							return choice;
+						}
+					);
+
+					await fieldsStore.updateField(selectedGroup.value.collection, selectedGroup.value.field, {
+						meta: { options: { choices: updatedChoices } },
+					});
+				}
+
+				await getGroups();
+			}
+
+			async function changeGroupSort(event: ChangeEvent<Group>) {
+				if (!event.moved) return;
+
+				const offset = showUngrouped.value ? 1 : 0;
+				const item = groupedItems.value[event.moved.oldIndex - offset]?.id;
+				const to = groupedItems.value[event.moved.newIndex - offset]?.id;
+				// the special "ungrouped" group has null id
+				if (!item || !to) return;
+
+				if (isRelational.value) {
+					if (groupsSortField.value == null) return;
+					await groupsChangeManualSort({ item, to });
+				} else {
+					if (!selectedGroup.value) return;
+					const groupedIds = groupedItems.value.map((item) => item.id);
+					const currentIndex = groupedIds.indexOf(item);
+					const targetIndex = groupedIds.indexOf(to);
+
+					const newSortedChoices = moveInArray(
+						groupedItems.value.map((item) => {
+							return { text: item.title, value: item.id };
+						}),
+						currentIndex,
+						targetIndex
+					);
+
+					await fieldsStore.updateField(selectedGroup.value.collection, selectedGroup.value.field, {
+						meta: { options: { choices: newSortedChoices } },
+					});
+				}
+			}
+		}
+
+		function useLayoutQuery() {
+			const page = computed({
+				get() {
+					return layoutQuery.value?.page || 1;
+				},
+				set(newPage: number) {
+					layoutQuery.value = {
+						...(layoutQuery.value || {}),
+						page: newPage,
+					};
+				},
+			});
+
+			const sort = computed(() => {
+				if (sortField.value) return [sortField.value];
+				if (primaryKeyField.value?.field) return [primaryKeyField.value.field];
+				return [];
+			});
+
+			const limit = computed({
+				get() {
+					return layoutQuery.value?.limit || 1000;
+				},
+				set(newLimit: number) {
+					layoutQuery.value = {
+						...(layoutQuery.value || {}),
+						page: 1,
+						limit: newLimit,
+					};
+				},
+			});
+
+			const fields = computed<string[]>(() => {
+				if (!primaryKeyField.value || !props.collection) return [];
+				const fields = [primaryKeyField.value.field];
+
+				if (imageSource.value) {
+					fields.push(`${imageSource.value}.modified_on`);
+					fields.push(`${imageSource.value}.type`);
+					fields.push(`${imageSource.value}.filename_disk`);
+					fields.push(`${imageSource.value}.storage`);
+					fields.push(`${imageSource.value}.id`);
+				}
+
+				if (props.collection === 'directus_files' && imageSource.value === '$thumbnail') {
+					fields.push('modified_on');
+					fields.push('type');
+				}
+
+				if (userFieldType.value !== undefined) {
+					const relatedUser =
+						userFieldType.value === 'm2m'
+							? `${userField.value}.${userFieldJunction.value?.meta?.junction_field}`
+							: `${userField.value}`;
+
+					fields.push(`${relatedUser}.id`);
+					fields.push(`${relatedUser}.first_name`);
+					fields.push(`${relatedUser}.last_name`);
+					fields.push(`${relatedUser}.avatar.id`);
+					fields.push(`${relatedUser}.avatar.storage`);
+					fields.push(`${relatedUser}.avatar.filename_disk`);
+					fields.push(`${relatedUser}.avatar.type`);
+					fields.push(`${relatedUser}.avatar.modified_on`);
+				}
+
+				if (sort.value.length > 0) {
+					const sortField = sort.value[0].startsWith('-') ? sort.value[0].substring(1) : sort.value[0];
+
+					if (fields.includes(sortField) === false) {
+						fields.push(sortField);
+					}
+				}
+
+				[groupField.value, titleField.value, textField.value, tagsField.value, dateField.value].forEach((val) => {
+					if (val !== null) fields.push(val);
+				});
+
+				return fields;
+			});
+
+			return { sort, limit, page, fields };
+		}
+	},
+});

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -202,7 +202,7 @@ function saveChanges() {
 			flex-direction: column;
 			width: 320px;
 			padding: 8px 0;
-			background-color: var(--background-subdued);
+			background-color: var(--background-normal);
 			border: var(--border-width) solid var(--border-normal);
 			border-radius: var(--border-radius);
 			margin-right: 20px;

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -1,0 +1,395 @@
+<template>
+	<div class="kanban">
+		<draggable
+			:model-value="groupedItems"
+			group="groups"
+			item-key="id"
+			draggable=".draggable"
+			:animation="150"
+			class="draggable"
+			:class="{ sortable: groupsSortField !== null }"
+			@change="changeGroupSort"
+		>
+			<template #item="{ element: group }">
+				<div class="group" :class="{ draggable: group.id !== null }">
+					<div class="header">
+						<div class="title">
+							<div class="title-content">
+								{{ group.id === null ? t('layouts.kanban.no_group') : group.title }}
+							</div>
+							<span class="badge">{{ group.items.length }}</span>
+						</div>
+						<div v-if="group.id !== null" class="actions">
+							<!-- <router-link :to="`${collection}/+`"><v-icon name="add" /></router-link> -->
+							<v-menu show-arrow placement="bottom-end">
+								<template #activator="{ toggle }">
+									<v-icon name="more_horiz" clickable @click="toggle" />
+								</template>
+
+								<v-list>
+									<v-list-item clickable @click="openEditGroup(group)">
+										<v-list-item-icon><v-icon name="edit" /></v-list-item-icon>
+										<v-list-item-content>{{ t('layouts.kanban.edit_group') }}</v-list-item-content>
+									</v-list-item>
+									<v-list-item v-if="isRelational" class="danger" clickable @click="deleteGroup(group.id)">
+										<v-list-item-icon><v-icon name="delete" /></v-list-item-icon>
+										<v-list-item-content>{{ t('layouts.kanban.delete_group') }}</v-list-item-content>
+									</v-list-item>
+								</v-list>
+							</v-menu>
+						</div>
+					</div>
+					<draggable
+						:model-value="group.items"
+						group="items"
+						draggable=".item"
+						:animation="150"
+						:sort="sortField !== null"
+						class="items"
+						item-key="id"
+						@change="change(group, $event)"
+					>
+						<template #item="{ element }">
+							<router-link :to="`${collection}/${element.id}`" class="item">
+								<div v-if="element.title" class="title">{{ element.title }}</div>
+								<img v-if="element.image" class="image" :src="element.image" />
+								<div v-if="element.text" class="text">{{ element.text }}</div>
+								<display-labels
+									v-if="element.tags"
+									:value="element.tags"
+									:type="Array.isArray(element.tags) ? 'csv' : 'json'"
+								/>
+								<div class="bottom">
+									<display-datetime v-if="element.date" format="short" :value="element.date" :type="element.dateType" />
+									<div class="avatars">
+										<span v-if="element.users.length > 3" class="avatar-overflow">+{{ element.users.length - 3 }}</span>
+										<v-avatar
+											v-for="user in element.users.slice(0, 3)"
+											:key="user.id"
+											v-tooltip.bottom="`${user.first_name} ${user.last_name}`"
+											class="avatar"
+										>
+											<img v-if="user.avatar" :src="parseAvatar(user.avatar)" />
+											<v-icon v-else name="person" />
+										</v-avatar>
+									</div>
+								</div>
+							</router-link>
+						</template>
+					</draggable>
+				</div>
+			</template>
+		</draggable>
+		<!-- <div v-if="isRelational" class="add-group" @click="editDialogOpen = '+'">
+			<v-icon name="add_box" />
+		</div> -->
+
+		<v-dialog :model-value="editDialogOpen !== null" @esc="cancelChanges()">
+			<v-card>
+				<v-card-title>
+					{{ editDialogOpen === '+' ? t('layouts.kanban.add_group') : t('layouts.kanban.edit_group') }}
+				</v-card-title>
+				<v-card-text>
+					<v-input v-model="editTitle" :placeholder="t('layouts.kanban.add_group_placeholder')" />
+				</v-card-text>
+				<v-card-actions>
+					<v-button secondary @click="cancelChanges()">{{ t('cancel') }}</v-button>
+					<v-button @click="saveChanges">{{ editDialogOpen === '+' ? t('create') : t('save') }}</v-button>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
+	</div>
+</template>
+
+<script lang="ts">
+export default {
+	inheritAttrs: false,
+};
+</script>
+
+<script lang="ts" setup>
+import { getRootPath } from '@/utils/get-root-path';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Draggable from 'vuedraggable';
+import type { ChangeEvent, Group, Item } from './types';
+
+const props = withDefaults(
+	defineProps<{
+		collection?: string | null;
+		groupCollection?: string | null;
+		fieldsInCollection?: Record<string, any>[];
+		primaryKeyField?: Record<string, any> | null;
+		groupedItems?: Group[];
+		groupTitle?: string | null;
+		groupPrimaryKeyField?: Record<string, any> | null;
+		change: (group: Group, event: ChangeEvent<Item>) => void;
+		changeGroupSort: (event: ChangeEvent<Group>) => void;
+		addGroup: (title: string) => Promise<void>;
+		editGroup: (id: string | number, title: string) => Promise<void>;
+		deleteGroup: (id: string | number) => Promise<void>;
+		isRelational?: boolean;
+		sortField?: string | null;
+		userField?: string | null;
+		groupsSortField?: string | null;
+	}>(),
+	{
+		collection: null,
+		groupCollection: null,
+		fieldsInCollection: () => [],
+		primaryKeyField: null,
+		groupedItems: () => [],
+		groupTitle: null,
+		groupPrimaryKeyField: null,
+		isRelational: true,
+		sortField: null,
+		userField: null,
+		groupsSortField: null,
+	}
+);
+
+defineEmits(['update:selection', 'update:limit', 'update:size', 'update:sort', 'update:width']);
+
+const { t } = useI18n();
+
+const editDialogOpen = ref<string | number | null>(null);
+const editTitle = ref('');
+
+function openEditGroup(group: Group) {
+	editDialogOpen.value = group.id;
+	editTitle.value = group.title;
+}
+
+function parseAvatar(file: Record<string, any>) {
+	if (!file || !file.type) return;
+	if (file.type.startsWith('image') === false) return;
+	if (file.type.includes('svg')) return;
+
+	return getRootPath() + `assets/${file.id}?modified=${file.modified_on}&width=48&height=48`;
+}
+
+function cancelChanges() {
+	editDialogOpen.value = null;
+	editTitle.value = '';
+}
+
+function saveChanges() {
+	if (editDialogOpen.value === '+') {
+		props.addGroup(editTitle.value);
+	} else if (editDialogOpen.value) {
+		props.editGroup(editDialogOpen.value, editTitle.value);
+	}
+
+	editDialogOpen.value = null;
+	editTitle.value = '';
+}
+</script>
+
+<style lang="scss" scoped>
+.kanban {
+	display: flex;
+	height: calc(100% - 65px - 2 * 24px);
+	padding: 0px 32px 24px 32px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	--user-spacing: 16px;
+
+	.draggable {
+		display: flex;
+
+		.group {
+			display: flex;
+			flex-direction: column;
+			width: 320px;
+			padding: 8px 0;
+			background-color: var(--background-subdued);
+			border: var(--border-width) solid var(--border-normal);
+			border-radius: var(--border-radius);
+			margin-right: 20px;
+			transition: border-color var(--transition) var(--fast);
+
+			&:active {
+				border-color: var(--border-normal-alt);
+				cursor: move;
+			}
+
+			.header {
+				display: flex;
+				justify-content: space-between;
+				margin: 0 16px 8px 16px;
+				font-weight: 700;
+
+				.title {
+					max-width: calc(100% - 60px);
+					display: flex;
+
+					.title-content {
+						width: auto;
+						overflow: hidden;
+						white-space: nowrap;
+						text-overflow: ellipsis;
+						color: var(--foreground-normal-alt);
+						margin-right: 6px;
+					}
+				}
+
+				.badge {
+					display: inline-flex;
+					justify-content: center;
+					padding: 0px 6px;
+					height: 20px;
+					min-width: 20px;
+					margin-top: 2px;
+					text-align: center;
+					font-size: 12px;
+					line-height: 20px;
+					background-color: var(--background-normal-alt);
+					border-radius: 12px; //var(--border-radius);
+				}
+
+				.actions {
+					color: var(--foreground-subdued);
+
+					.v-icon {
+						margin-left: 4px;
+						transition: color var(--transition) var(--fast);
+					}
+
+					.v-icon:hover {
+						color: var(--foreground-normal);
+					}
+				}
+			}
+
+			.items {
+				flex: 1;
+				overflow-x: hidden;
+				overflow-y: auto;
+
+				.item {
+					display: block;
+					margin: 2px 16px 6px 16px;
+					padding: 12px 16px;
+					background-color: var(--background-page);
+					border-radius: var(--border-radius);
+					box-shadow: 0px 2px 4px 0px rgba(var(--card-shadow-color), 0.1);
+
+					&:hover .title {
+						// color: var(--primary);
+						text-decoration: underline;
+					}
+				}
+
+				.title {
+					color: var(--primary);
+					transition: color var(--transition) var(--fast);
+					font-weight: 700;
+					line-height: 1.25;
+					margin-bottom: 4px;
+				}
+
+				.text {
+					font-size: 14px;
+					line-height: 1.4em;
+					-webkit-line-clamp: 4;
+					-webkit-box-orient: vertical;
+					overflow: hidden;
+					display: -webkit-box;
+				}
+
+				.image {
+					width: 100%;
+					margin-top: 10px;
+					border-radius: var(--border-radius);
+					margin-top: 4px;
+					max-height: 300px;
+				}
+
+				.display-labels {
+					display: flex;
+					flex-wrap: wrap;
+					margin-top: 6px;
+
+					:deep(.v-chip) {
+						border: none;
+						background-color: var(--background-normal);
+						font-size: 12px;
+						font-weight: 600;
+						margin-top: 4px;
+						margin-right: 4px;
+						height: 20px;
+						padding: 0 6px;
+					}
+					:deep(.v-chip + .v-chip) {
+						margin-left: 0;
+					}
+				}
+
+				.bottom {
+					width: 100%;
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+					margin-top: 8px;
+					margin-bottom: 2px;
+					.datetime {
+						display: inline-block;
+						color: var(--foreground-subdued);
+						font-size: 13px;
+						font-weight: 600;
+						line-height: 24px;
+					}
+
+					.avatars {
+						padding-left: var(--user-spacing);
+						display: flex;
+						flex-direction: row-reverse;
+						.avatar {
+							margin-left: calc(var(--user-spacing) * -1);
+							border-radius: 24px;
+							border: 4px solid var(--background-page);
+							height: 32px;
+							width: 32px;
+							margin-bottom: -4px;
+							margin-top: -4px;
+						}
+
+						.avatar-overflow {
+							align-self: center;
+							color: var(--foreground-subdued);
+							margin-left: 2px;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	.add-group {
+		cursor: pointer;
+		padding: 8px 8px;
+		border: var(--border-width) dashed var(--border-subdued);
+		border-radius: var(--border-radius);
+		transition: border-color var(--transition) var(--fast);
+
+		.v-icon {
+			color: var(--foreground-subdued);
+			transition: color var(--transition) var(--fast);
+		}
+
+		&:hover {
+			border-color: var(--primary);
+
+			.v-icon {
+				color: var(--primary);
+			}
+		}
+	}
+}
+
+.v-list-item.danger {
+	--v-list-item-color: var(--danger);
+	--v-list-item-color-hover: var(--danger);
+	--v-list-item-icon-color: var(--danger);
+}
+</style>

--- a/app/src/layouts/kanban/options.vue
+++ b/app/src/layouts/kanban/options.vue
@@ -1,0 +1,188 @@
+<template>
+	<div class="field">
+		<div class="type-label">{{ t('layouts.kanban.group_field') }}</div>
+		<v-select
+			v-model="groupFieldSync"
+			item-value="field"
+			item-text="name"
+			:items="fieldGroups.group"
+			:placeholder="t('layouts.kanban.group_field_placeholder')"
+		/>
+	</div>
+
+	<div v-if="groupFieldSync && isRelational" class="field">
+		<div class="type-label">{{ t('layouts.kanban.group_title') }}</div>
+		<v-select
+			v-model="groupTitleSync"
+			item-value="field"
+			item-text="name"
+			:items="groupTitleFields"
+			:placeholder="t('layouts.kanban.group_title_placeholder')"
+		/>
+	</div>
+
+	<div class="field">
+		<div class="type-label">{{ t('layouts.kanban.title') }}</div>
+		<v-select
+			v-model="titleFieldSync"
+			:items="fieldGroups.title"
+			item-value="field"
+			item-text="name"
+			:placeholder="t('layouts.kanban.title_placeholder')"
+			show-deselect
+		/>
+	</div>
+
+	<div class="field">
+		<div class="type-label">{{ t('layouts.kanban.text') }}</div>
+		<v-select
+			v-model="textFieldSync"
+			:items="fieldGroups.text"
+			item-value="field"
+			item-text="name"
+			:placeholder="t('layouts.kanban.text_placeholder')"
+			show-deselect
+		/>
+	</div>
+
+	<v-detail class="field">
+		<template #title>{{ t('layouts.kanban.advanced') }}</template>
+
+		<div class="nested-options">
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.tags') }}</div>
+				<v-select
+					v-model="tagsFieldSync"
+					:items="fieldGroups.tags"
+					item-value="field"
+					item-text="name"
+					:placeholder="t('layouts.kanban.tags_placeholder')"
+					show-deselect
+				/>
+			</div>
+
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.date') }}</div>
+				<v-select
+					v-model="dateFieldSync"
+					:items="fieldGroups.date"
+					item-value="field"
+					item-text="name"
+					:placeholder="t('layouts.kanban.date_placeholder')"
+					show-deselect
+				/>
+			</div>
+
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.image') }}</div>
+				<v-select
+					v-model="imageSourceSync"
+					show-deselect
+					item-value="field"
+					item-text="name"
+					:items="fieldGroups.file"
+					:placeholder="t('layouts.kanban.image_placeholder')"
+				/>
+			</div>
+
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.image_fit') }}</div>
+				<v-checkbox v-model="cropSync" block :label="t('layouts.kanban.crop')" />
+			</div>
+
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.user') }}</div>
+				<v-select
+					v-model="userFieldSync"
+					:items="fieldGroups.user"
+					item-value="field"
+					item-text="name"
+					:placeholder="t('layouts.kanban.user_placeholder')"
+					show-deselect
+				/>
+			</div>
+
+			<div class="field">
+				<div class="type-label">{{ t('layouts.kanban.show_ungrouped') }}</div>
+				<v-checkbox v-model="showUngroupedSync" block :label="t('layouts.kanban.show')" />
+			</div>
+		</div>
+	</v-detail>
+</template>
+
+<script lang="ts">
+export default {
+	inheritAttrs: false,
+};
+</script>
+
+<script lang="ts" setup>
+import { useSync } from '@cairncms/extensions-sdk';
+import { useI18n } from 'vue-i18n';
+
+const props = withDefaults(
+	defineProps<{
+		collection: string;
+		fieldGroups: Record<string, Record<string, any>[]>;
+		groupTitleFields?: Record<string, any>[];
+		groupField?: string | null;
+		groupTitle?: string | null;
+		isRelational?: boolean;
+		imageSource?: string | null;
+		titleField?: string | null;
+		textField?: string | null;
+		crop: boolean;
+		dateField?: string | null;
+		tagsField?: string | null;
+		userField?: string | null;
+		showUngrouped: boolean;
+	}>(),
+	{
+		groupTitleFields: () => [],
+		groupField: null,
+		groupTitle: null,
+		isRelational: true,
+		imageSource: null,
+		titleField: null,
+		textField: null,
+		dateField: null,
+		tagsField: null,
+		userField: null,
+		showUngrouped: true,
+	}
+);
+
+const emit = defineEmits([
+	'update:imageSource',
+	'update:titleField',
+	'update:crop',
+	'update:textField',
+	'update:groupField',
+	'update:groupTitle',
+	'update:dateField',
+	'update:tagsField',
+	'update:userField',
+	'update:showUngrouped',
+]);
+
+const { t } = useI18n();
+
+const imageSourceSync = useSync(props, 'imageSource', emit);
+const titleFieldSync = useSync(props, 'titleField', emit);
+const cropSync = useSync(props, 'crop', emit);
+const textFieldSync = useSync(props, 'textField', emit);
+const showUngroupedSync = useSync(props, 'showUngrouped', emit);
+const groupFieldSync = useSync(props, 'groupField', emit);
+const groupTitleSync = useSync(props, 'groupTitle', emit);
+const dateFieldSync = useSync(props, 'dateField', emit);
+const tagsFieldSync = useSync(props, 'tagsField', emit);
+const userFieldSync = useSync(props, 'userField', emit);
+</script>
+
+<style lang="scss" scoped>
+.nested-options {
+	display: grid;
+	grid-template-columns: [start] minmax(0, 1fr) [half] minmax(0, 1fr) [full];
+	gap: var(--form-vertical-gap) var(--form-horizontal-gap);
+}
+</style>

--- a/app/src/layouts/kanban/types.ts
+++ b/app/src/layouts/kanban/types.ts
@@ -1,0 +1,57 @@
+import { User } from '@cairncms/types';
+
+export type LayoutOptions = {
+	groupField: string;
+	groupTitle: string;
+	dateField: string;
+	tagsField?: string;
+	userField?: string;
+	titleField?: string;
+	textField?: string;
+	imageSource?: string;
+	crop: boolean;
+	showUngrouped: boolean;
+};
+
+export type LayoutQuery = {
+	fields?: string[];
+	sort?: string;
+	limit?: number;
+	page?: number;
+};
+
+export type Group = {
+	id: string | number | null;
+	title: string;
+	items: Item[];
+	sort: number;
+};
+
+export type Item = {
+	id: string | number;
+	sort: number;
+	title?: string;
+	text?: string;
+	image?: string;
+	date?: string;
+	dateType?: string;
+	tags?: string;
+	item: Record<string, any>;
+	users: User[];
+};
+
+export type ChangeEvent<T> = {
+	added?: {
+		element: T;
+		newIndex: number;
+	};
+	removed?: {
+		element: T;
+		oldIndex: number;
+	};
+	moved?: {
+		element: T;
+		newIndex: number;
+		oldIndex: number;
+	};
+};

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -19,6 +19,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	name: '$t:layouts.map.map',
 	icon: 'map',
 	smallHeader: true,
+	sidebarShadow: true,
 	component: MapLayout,
 	slots: {
 		options: MapOptions,

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -20,6 +20,7 @@
 			:title="bookmark ? bookmarkTitle : currentCollection.name"
 			:small-header="currentLayout?.smallHeader"
 			:header-shadow="currentLayout?.headerShadow"
+			:sidebar-shadow="currentLayout?.sidebarShadow"
 		>
 			<template #title-outer:prepend>
 				<v-button class="header-icon" :class="{ archive }" rounded icon secondary disabled>

--- a/app/src/styles/themes/_dark.scss
+++ b/app/src/styles/themes/_dark.scss
@@ -34,6 +34,10 @@
 	--card-shadow: 0px 0px 6px 0px rgba(var(--card-shadow-color), 0.08);
 	--overlay-color: rgba(0, 0, 0, 0.9);
 
+	--header-shadow: 0 4px 7px -4px rgb(0 0 0 / 0.2);
+	--navigation-shadow: 0px 0px 12px var(--black);
+	--sidebar-shadow: var(--navigation-shadow);
+
 	--module-background: #14171b;
 	--module-background-alt: #0e1014;
 	--module-icon: var(--foreground-subdued);

--- a/app/src/styles/themes/_light.scss
+++ b/app/src/styles/themes/_light.scss
@@ -25,6 +25,10 @@
 	--card-shadow: 0px 0px 6px 0px rgba(var(--card-shadow-color), 0.08);
 	--overlay-color: rgba(56, 62, 71, 0.8);
 
+	--header-shadow: 0 4px 7px -4px rgb(0 0 0 / 0.2);
+	--navigation-shadow: 4px 0 7px -4px rgb(0 0 0 / 0.2);
+	--sidebar-shadow: -4px 0 7px -4px rgb(0 0 0 / 0.2);
+
 	--module-background: #383e47;
 	--module-background-alt: #2d323a;
 	--module-icon: rgba(250, 248, 243, 0.5);

--- a/app/src/views/private/components/header-bar.vue
+++ b/app/src/views/private/components/header-bar.vue
@@ -186,7 +186,7 @@ onUnmounted(() => {
 	}
 
 	&.collapsed.shadow {
-		box-shadow: 0 4px 7px -4px rgb(0 0 0 / 0.2);
+		box-shadow: var(--header-shadow);
 
 		.title-container {
 			.headline {

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -8,7 +8,12 @@
 	</v-info>
 
 	<div v-else class="private-view" :class="{ theme, 'full-screen': fullScreen }">
-		<aside id="navigation" role="navigation" aria-label="Module Navigation" :class="{ 'is-open': navOpen }">
+		<aside
+			id="navigation"
+			role="navigation"
+			aria-label="Module Navigation"
+			:class="{ 'is-open': navOpen, 'has-shadow': sidebarShadow }"
+		>
 			<module-bar />
 			<v-nav
 				class="module-nav alt-colors"
@@ -49,7 +54,7 @@
 			role="contentinfo"
 			class="alt-colors"
 			aria-label="Module Sidebar"
-			:class="{ 'is-open': sidebarOpen }"
+			:class="{ 'is-open': sidebarOpen, 'has-shadow': sidebarShadow }"
 			@click="openSidebar"
 		>
 			<div class="flex-container">
@@ -96,9 +101,15 @@ interface Props {
 	title?: string | null;
 	smallHeader?: boolean;
 	headerShadow?: boolean;
+	sidebarShadow?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), { title: null, smallHeader: false, headerShadow: true });
+const props = withDefaults(defineProps<Props>(), {
+	title: null,
+	smallHeader: false,
+	headerShadow: true,
+	sidebarShadow: false,
+});
 
 const { t } = useI18n();
 
@@ -223,6 +234,9 @@ function openSidebar(event: PointerEvent) {
 		&.is-open {
 			transform: translateX(0);
 		}
+		&.has-shadow {
+			box-shadow: var(--navigation-shadow);
+		}
 
 		&:not(.is-open) {
 			.module-nav-resize-handle {
@@ -309,6 +323,9 @@ function openSidebar(event: PointerEvent) {
 
 		&.is-open {
 			transform: translateX(0);
+		}
+		&.has-shadow {
+			box-shadow: var(--sidebar-shadow);
 		}
 
 		.flex-container {

--- a/docs/guides/content/layouts.md
+++ b/docs/guides/content/layouts.md
@@ -1,6 +1,6 @@
 ---
 title: Layouts
-description: Browse collection items as tables, cards, calendars, or maps.
+description: Browse collection items as tables, cards, calendars, maps, or kanban boards.
 sidebar:
   order: 1
 ---
@@ -11,12 +11,13 @@ Use layouts when the default table view is not the clearest way to work with a c
 
 ## Built-in layouts
 
-CairnCMS currently ships with four built-in collection layouts:
+CairnCMS currently ships with five built-in collection layouts:
 
 - **Table** for general-purpose browsing and bulk work
 - **Cards** for image-first or summary-oriented collections
 - **Calendar** for time-based records
 - **Map** for geospatial records
+- **Kanban** for grouping items into drag-and-drop columns by a status or category field
 
 Each layout has its own controls and its own requirements. Calendar needs date fields. Map needs compatible geometry or location data. Cards are most useful when the collection has an image and short summary fields.
 
@@ -78,6 +79,26 @@ Typical uses include:
 - survey or asset locations
 
 The collection needs a compatible geospatial field before this layout is useful.
+
+### Kanban
+
+Kanban is useful for collections that represent a small set of states, statuses, or categories. Items appear as cards inside columns, one column per group value. Operators drag a card from one column to another to change its group, which updates the underlying grouping field on the item.
+
+To use Kanban, the collection needs one of:
+
+- a single-select choice field on `string`, `integer`, `float`, or `bigInteger`
+- an M2O field to a small lookup collection
+
+Plain string fields with arbitrary values are not eligible. The grouping selector only offers fields that match one of the two shapes above so that drag-to-update produces valid persisted state.
+
+Each card can optionally surface:
+
+- a title field
+- a text field
+- a date field
+- a tags field
+- a related user (with avatar)
+- an image with cover or contain fit
 
 ## Display templates
 

--- a/packages/types/src/layouts.ts
+++ b/packages/types/src/layouts.ts
@@ -14,6 +14,7 @@ export interface LayoutConfig<Options = any, Query = any> {
 	};
 	smallHeader?: boolean;
 	headerShadow?: boolean;
+	sidebarShadow?: boolean;
 	setup: (props: LayoutProps<Options, Query>, ctx: LayoutContext) => Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds a built-in Kanban layout so operators can work with collections as grouped, drag-and-drop boards.

Kanban groups items by single-select scalar choice fields or M2O lookup fields, renders configurable card fields, and updates the underlying grouping field when a card moves between columns. The implementation also keeps first-party asset and avatar URLs token-free, fixes cleared Kanban layout options staying cleared, and adds the sidebar-shadow layout capability used by Kanban and Map.

### Testing / verification

No dedicated automated layout test was added for this UI-only batch.

Manual verification should confirm:
- Kanban appears in the layout switcher and renders grouped columns
- Group By only offers supported single-select scalar choice fields and M2O fields
- dragging a card between columns persists the updated grouping field after refresh
- clearing Kanban layout options keeps them cleared instead of restoring defaults
- image and avatar asset requests do not include `access_token` in the URL
- Add Group is not visible, while Edit Group and Delete Group behave as expected for supported group types
- Kanban and Map show sidebar shadows, while the other layouts remain unchanged
- Table, Cards, Calendar, Map, and file/image selector workflows still work after the new layout is registered

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
