### PR TITLE
Feat/extensions sdk esm

### DIFF
--- a/docs/develop/extensions/creating-extensions.md
+++ b/docs/develop/extensions/creating-extensions.md
@@ -97,6 +97,16 @@ The build command supports several flags:
 
 Most projects only ever need the bare `build` command and `--watch`.
 
+### Output format
+
+The build CLI emits ESM by default for newly scaffolded extensions. The scaffolder writes `"type": "module"` into the generated `package.json`, and the build reads that field to choose the output format.
+
+Existing extensions without a `"type"` field continue to emit CommonJS, so a rebuild does not change their loader behavior. To migrate an existing extension to ESM, add `"type": "module"` to its `package.json` and rebuild.
+
+The output file extension overrides the manifest. A path ending in `.mjs` always emits ESM. A path ending in `.cjs` always emits CommonJS. App-side bundles always emit ESM regardless of `type`.
+
+The same rules apply when building with explicit `-t -i -o` flags. The CLI consults the current directory's `package.json` to determine the `type`, with the same file-extension override.
+
 ### Custom Rollup configuration
 
 To extend the Rollup config — for example, to add a plugin — create one of these files at the root of the extension package:

--- a/packages/constants/src/extensions.ts
+++ b/packages/constants/src/extensions.ts
@@ -80,6 +80,7 @@ export const ExtensionOptions = ExtensionOptionsBase.and(
 export const ExtensionManifest = z.object({
 	name: z.string(),
 	version: z.string(),
+	type: z.union([z.literal('module'), z.literal('commonjs')]).optional(),
 	dependencies: z.record(z.string()).optional(),
 	[EXTENSION_PKG_KEY]: ExtensionOptions,
 });

--- a/packages/extensions-sdk/create-build.test.ts
+++ b/packages/extensions-sdk/create-build.test.ts
@@ -1,4 +1,4 @@
-import { EXTENSION_LANGUAGES, JAVASCRIPT_FILE_EXTS } from '@cairncms/constants';
+import { EXTENSION_LANGUAGES, EXTENSION_PKG_KEY, JAVASCRIPT_FILE_EXTS } from '@cairncms/constants';
 import { execa } from 'execa';
 import fse from 'fs-extra';
 import { resolve } from 'node:path';
@@ -19,10 +19,10 @@ afterAll(async () => {
 
 function getConfigFileContent(configFileName: string) {
 	switch (configFileName) {
+		case 'extension.config.js':
 		case 'extension.config.mjs':
 			return `export default { plugins: [] };`;
 		case 'extension.config.cjs':
-		case 'extension.config.js':
 			return `module.exports = { plugins: [] };`;
 		default:
 			return '';
@@ -68,5 +68,107 @@ test.each(
 		}
 	},
 	// Bump up timeout duration as the build process can take slightly longer to complete
+	30_000
+);
+
+type Format = 'esm' | 'cjs';
+
+type ContentCase = {
+	label: string;
+	setupManifest?: (manifest: Record<string, any>) => void;
+	buildArgs: string[];
+	builtFile: string;
+	expectFormat: Format;
+};
+
+function assertFormat(content: string, format: Format) {
+	// `\bexport\b` matches the ESM keyword but rejects the CJS identifier `exports`.
+	const esmExport = /\bexport\b/;
+	const cjsExports = /\bmodule\.exports\b/;
+
+	if (format === 'esm') {
+		expect(content).toMatch(esmExport);
+		expect(content).not.toMatch(cjsExports);
+	} else {
+		expect(content).toMatch(cjsExports);
+		expect(content).not.toMatch(esmExport);
+	}
+}
+
+test.each<ContentCase>([
+	{
+		label: 'scaffolded endpoint emits ESM via the default "type": "module"',
+		buildArgs: ['build'],
+		builtFile: 'dist/index.js',
+		expectFormat: 'esm',
+	},
+	{
+		label: 'endpoint without "type" emits CJS',
+		setupManifest: (manifest) => {
+			delete manifest['type'];
+		},
+		buildArgs: ['build'],
+		builtFile: 'dist/index.js',
+		expectFormat: 'cjs',
+	},
+	{
+		label: '.mjs output extension forces ESM even when manifest has no "type"',
+		setupManifest: (manifest) => {
+			delete manifest['type'];
+			manifest[EXTENSION_PKG_KEY].path = 'dist/index.mjs';
+		},
+		buildArgs: ['build'],
+		builtFile: 'dist/index.mjs',
+		expectFormat: 'esm',
+	},
+	{
+		label: '.cjs output extension forces CJS even when manifest has "type": "module"',
+		setupManifest: (manifest) => {
+			manifest[EXTENSION_PKG_KEY].path = 'dist/index.cjs';
+		},
+		buildArgs: ['build'],
+		builtFile: 'dist/index.cjs',
+		expectFormat: 'cjs',
+	},
+	{
+		label: 'explicit-CLI without manifest "type" emits CJS',
+		setupManifest: (manifest) => {
+			delete manifest['type'];
+		},
+		buildArgs: ['build', '-t', 'endpoint', '-i', 'src/index.js', '-o', 'dist/explicit.js'],
+		builtFile: 'dist/explicit.js',
+		expectFormat: 'cjs',
+	},
+	{
+		label: 'explicit-CLI with manifest "type": "module" emits ESM',
+		buildArgs: ['build', '-t', 'endpoint', '-i', 'src/index.js', '-o', 'dist/explicit.js'],
+		builtFile: 'dist/explicit.js',
+		expectFormat: 'esm',
+	},
+])(
+	'$label',
+	async ({ setupManifest, buildArgs, builtFile, expectFormat }) => {
+		const currentTime = Date.now();
+
+		const testExtensionPath = `${testPrefix}-content-${expectFormat}-${currentTime}-${Math.random()
+			.toString(36)
+			.slice(2, 8)}`;
+
+		await create('endpoint', testExtensionPath, { language: 'javascript' });
+
+		if (setupManifest) {
+			const manifestPath = resolve(testExtensionPath, 'package.json');
+			const manifest = await fse.readJson(manifestPath);
+			setupManifest(manifest);
+			await fse.writeJson(manifestPath, manifest, { spaces: '\t' });
+		}
+
+		await execa('node', ['../cli.js', ...buildArgs], { cwd: testExtensionPath });
+
+		const builtFileParts = builtFile.split('/');
+		const content = await fse.readFile(resolve(testExtensionPath, ...builtFileParts), 'utf-8');
+
+		assertFormat(content, expectFormat);
+	},
 	30_000
 );

--- a/packages/extensions-sdk/src/cli/commands/build.ts
+++ b/packages/extensions-sdk/src/cli/commands/build.ts
@@ -30,8 +30,8 @@ import { rollup, watch as rollupWatch } from 'rollup';
 import esbuildDefault from 'rollup-plugin-esbuild';
 import stylesDefault from 'rollup-plugin-styles';
 import vueDefault from 'rollup-plugin-vue';
-import type { Language, RollupConfig, RollupMode } from '../types.js';
-import { getLanguageFromPath, isLanguage } from '../utils/languages.js';
+import type { Format, RollupConfig, RollupMode } from '../types.js';
+import { getFileExt } from '../utils/file.js';
 import { clear, log } from '../utils/logger.js';
 import tryParseJson from '../utils/try-parse-json.js';
 import generateBundleEntrypoint from './helpers/generate-bundle-entrypoint.js';
@@ -82,11 +82,14 @@ export default async function build(options: BuildOptions): Promise<void> {
 
 		const extensionOptions = extensionManifest[EXTENSION_PKG_KEY];
 
+		const format: Format = extensionManifest.type === 'module' ? 'esm' : 'cjs';
+
 		if (extensionOptions.type === 'bundle') {
 			await buildBundleExtension({
 				entries: extensionOptions.entries,
 				outputApp: extensionOptions.path.app,
 				outputApi: extensionOptions.path.api,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -97,6 +100,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				inputApi: extensionOptions.source.api,
 				outputApp: extensionOptions.path.app,
 				outputApi: extensionOptions.path.api,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -106,6 +110,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				type: extensionOptions.type,
 				input: extensionOptions.source,
 				output: extensionOptions.path,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -146,6 +151,14 @@ export default async function build(options: BuildOptions): Promise<void> {
 			process.exit(1);
 		}
 
+		let format: Format = 'cjs';
+		const manifestPath = path.resolve('package.json');
+
+		if (await fse.pathExists(manifestPath)) {
+			const manifest = await fse.readJSON(manifestPath).catch(() => null);
+			if (manifest?.type === 'module') format = 'esm';
+		}
+
 		if (type === 'bundle') {
 			const entries = ExtensionOptionsBundleEntries.safeParse(tryParseJson(input));
 			const splitOutput = tryParseJson(output);
@@ -176,6 +189,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				entries: entries.data,
 				outputApp: splitOutput.app,
 				outputApi: splitOutput.api,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -211,6 +225,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				inputApi: splitInput.api,
 				outputApp: splitOutput.app,
 				outputApi: splitOutput.api,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -220,6 +235,7 @@ export default async function build(options: BuildOptions): Promise<void> {
 				type,
 				input,
 				output,
+				format,
 				watch,
 				sourcemap,
 				minify,
@@ -232,6 +248,7 @@ async function buildAppOrApiExtension({
 	type,
 	input,
 	output,
+	format,
 	watch,
 	sourcemap,
 	minify,
@@ -239,6 +256,7 @@ async function buildAppOrApiExtension({
 	type: AppExtensionType | ApiExtensionType;
 	input: string;
 	output: string;
+	format: Format;
 	watch: boolean;
 	sourcemap: boolean;
 	minify: boolean;
@@ -253,20 +271,13 @@ async function buildAppOrApiExtension({
 		process.exit(1);
 	}
 
-	const language = getLanguageFromPath(input);
-
-	if (!isLanguage(language)) {
-		log(`Language ${chalk.bold(language)} is not supported.`, 'error');
-		process.exit(1);
-	}
-
 	const config = await loadConfig();
 	const plugins = config.plugins ?? [];
 
 	const mode = isIn(type, APP_EXTENSION_TYPES) ? 'browser' : 'node';
 
-	const rollupOptions = getRollupOptions({ mode, input, language, sourcemap, minify, plugins });
-	const rollupOutputOptions = getRollupOutputOptions({ mode, output, sourcemap });
+	const rollupOptions = getRollupOptions({ mode, input, sourcemap, minify, plugins });
+	const rollupOutputOptions = getRollupOutputOptions({ mode, output, format, sourcemap });
 
 	if (watch) {
 		await watchExtension({ rollupOptions, rollupOutputOptions });
@@ -280,6 +291,7 @@ async function buildHybridExtension({
 	inputApi,
 	outputApp,
 	outputApi,
+	format,
 	watch,
 	sourcemap,
 	minify,
@@ -288,6 +300,7 @@ async function buildHybridExtension({
 	inputApi: string;
 	outputApp: string;
 	outputApi: string;
+	format: Format;
 	watch: boolean;
 	sourcemap: boolean;
 	minify: boolean;
@@ -312,26 +325,12 @@ async function buildHybridExtension({
 		process.exit(1);
 	}
 
-	const languageApp = getLanguageFromPath(inputApp);
-	const languageApi = getLanguageFromPath(inputApi);
-
-	if (!isLanguage(languageApp)) {
-		log(`App language ${chalk.bold(languageApp)} is not supported.`, 'error');
-		process.exit(1);
-	}
-
-	if (!isLanguage(languageApi)) {
-		log(`API language ${chalk.bold(languageApi)} is not supported.`, 'error');
-		process.exit(1);
-	}
-
 	const config = await loadConfig();
 	const plugins = config.plugins ?? [];
 
 	const rollupOptionsApp = getRollupOptions({
 		mode: 'browser',
 		input: inputApp,
-		language: languageApp,
 		sourcemap,
 		minify,
 		plugins,
@@ -340,14 +339,13 @@ async function buildHybridExtension({
 	const rollupOptionsApi = getRollupOptions({
 		mode: 'node',
 		input: inputApi,
-		language: languageApi,
 		sourcemap,
 		minify,
 		plugins,
 	});
 
-	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, sourcemap });
-	const rollupOutputOptionsApi = getRollupOutputOptions({ mode: 'node', output: outputApi, sourcemap });
+	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, format, sourcemap });
+	const rollupOutputOptionsApi = getRollupOutputOptions({ mode: 'node', output: outputApi, format, sourcemap });
 
 	const rollupOptionsAll = [
 		{ rollupOptions: rollupOptionsApp, rollupOutputOptions: rollupOutputOptionsApp },
@@ -365,6 +363,7 @@ async function buildBundleExtension({
 	entries,
 	outputApp,
 	outputApi,
+	format,
 	watch,
 	sourcemap,
 	minify,
@@ -372,6 +371,7 @@ async function buildBundleExtension({
 	entries: ExtensionOptionsBundleEntry[];
 	outputApp: string;
 	outputApi: string;
+	format: Format;
 	watch: boolean;
 	sourcemap: boolean;
 	minify: boolean;
@@ -386,62 +386,6 @@ async function buildBundleExtension({
 		process.exit(1);
 	}
 
-	const languagesApp = new Set<Language>();
-	const languagesApi = new Set<Language>();
-
-	for (const entry of entries) {
-		if (isTypeIn(entry, HYBRID_EXTENSION_TYPES)) {
-			const inputApp = entry.source.app;
-			const inputApi = entry.source.api;
-
-			if (!(await fse.pathExists(inputApp)) || !(await fse.stat(inputApp)).isFile()) {
-				log(`App entrypoint ${chalk.bold(inputApp)} does not exist.`, 'error');
-				process.exit(1);
-			}
-
-			if (!(await fse.pathExists(inputApi)) || !(await fse.stat(inputApi)).isFile()) {
-				log(`API entrypoint ${chalk.bold(inputApi)} does not exist.`, 'error');
-				process.exit(1);
-			}
-
-			const languageApp = getLanguageFromPath(inputApp);
-			const languageApi = getLanguageFromPath(inputApi);
-
-			if (!isLanguage(languageApp)) {
-				log(`App language ${chalk.bold(languageApp)} is not supported.`, 'error');
-				process.exit(1);
-			}
-
-			if (!isLanguage(languageApi)) {
-				log(`API language ${chalk.bold(languageApi)} is not supported.`, 'error');
-				process.exit(1);
-			}
-
-			languagesApp.add(languageApp);
-			languagesApi.add(languageApi);
-		} else {
-			const input = entry.source;
-
-			if (!(await fse.pathExists(input)) || !(await fse.stat(input)).isFile()) {
-				log(`Entrypoint ${chalk.bold(input)} does not exist.`, 'error');
-				process.exit(1);
-			}
-
-			const language = getLanguageFromPath(input);
-
-			if (!isLanguage(language)) {
-				log(`Language ${chalk.bold(language)} is not supported.`, 'error');
-				process.exit(1);
-			}
-
-			if (isIn(entry.type, APP_EXTENSION_TYPES)) {
-				languagesApp.add(language);
-			} else {
-				languagesApi.add(language);
-			}
-		}
-	}
-
 	const config = await loadConfig();
 	const plugins = config.plugins ?? [];
 
@@ -451,7 +395,6 @@ async function buildBundleExtension({
 	const rollupOptionsApp = getRollupOptions({
 		mode: 'browser',
 		input: { entry: entrypointApp },
-		language: Array.from(languagesApp),
 		sourcemap,
 		minify,
 		plugins,
@@ -460,14 +403,13 @@ async function buildBundleExtension({
 	const rollupOptionsApi = getRollupOptions({
 		mode: 'node',
 		input: { entry: entrypointApi },
-		language: Array.from(languagesApi),
 		sourcemap,
 		minify,
 		plugins,
 	});
 
-	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, sourcemap });
-	const rollupOutputOptionsApi = getRollupOutputOptions({ mode: 'node', output: outputApi, sourcemap });
+	const rollupOutputOptionsApp = getRollupOutputOptions({ mode: 'browser', output: outputApp, format, sourcemap });
+	const rollupOutputOptionsApi = getRollupOutputOptions({ mode: 'node', output: outputApi, format, sourcemap });
 
 	const rollupOptionsAll = [
 		{ rollupOptions: rollupOptionsApp, rollupOutputOptions: rollupOutputOptionsApp },
@@ -569,27 +511,23 @@ async function watchExtension(config: RollupConfig | RollupConfig[]) {
 function getRollupOptions({
 	mode,
 	input,
-	language,
 	sourcemap,
 	minify,
 	plugins,
 }: {
 	mode: RollupMode;
 	input: string | Record<string, string>;
-	language: Language | Language[];
 	sourcemap: boolean;
 	minify: boolean;
 	plugins: Plugin[];
 }): RollupOptions {
-	const languages = Array.isArray(language) ? language : [language];
-
 	return {
 		input: typeof input !== 'string' ? 'entry' : input,
 		external: mode === 'browser' ? APP_SHARED_DEPS : API_SHARED_DEPS,
 		plugins: [
 			typeof input !== 'string' ? virtual(input) : null,
 			mode === 'browser' ? (vue({ preprocessStyles: true }) as Plugin) : null,
-			languages.includes('typescript') ? esbuild({ include: /\.tsx?$/, sourceMap: sourcemap }) : null,
+			esbuild({ include: /\.tsx?$/, sourceMap: sourcemap }),
 			mode === 'browser' ? styles() : null,
 			...plugins,
 			nodeResolve({ browser: mode === 'browser', preferBuiltins: mode === 'node' }),
@@ -614,15 +552,26 @@ function getRollupOptions({
 function getRollupOutputOptions({
 	mode,
 	output,
+	format,
 	sourcemap,
 }: {
 	mode: RollupMode;
 	output: string;
+	format: Format;
 	sourcemap: boolean;
 }): RollupOutputOptions {
+	const fileExtension = getFileExt(output);
+	let outputFormat = format;
+
+	if (mode === 'browser' || fileExtension === 'mjs') {
+		outputFormat = 'esm';
+	} else if (fileExtension === 'cjs') {
+		outputFormat = 'cjs';
+	}
+
 	return {
 		file: output,
-		format: mode === 'browser' ? 'es' : 'cjs',
+		format: outputFormat,
 		exports: 'auto',
 		inlineDynamicImports: true,
 		sourcemap,

--- a/packages/extensions-sdk/src/cli/commands/create.ts
+++ b/packages/extensions-sdk/src/cli/commands/create.ts
@@ -170,6 +170,7 @@ function getPackageManifest(name: string, options: ExtensionOptions, deps: Recor
 		icon: 'extension',
 		version: '1.0.0',
 		keywords: ['cairncms', 'cairncms-extension', `cairncms-custom-${options.type}`],
+		type: 'module',
 		[EXTENSION_PKG_KEY]: options,
 		scripts: {
 			build: 'cairncms-extension build',

--- a/packages/extensions-sdk/src/cli/types.ts
+++ b/packages/extensions-sdk/src/cli/types.ts
@@ -10,3 +10,5 @@ export type Config = {
 
 export type RollupConfig = { rollupOptions: RollupOptions; rollupOutputOptions: RollupOutputOptions };
 export type RollupMode = 'browser' | 'node';
+
+export type Format = 'esm' | 'cjs';

--- a/packages/extensions-sdk/src/cli/utils/file.ts
+++ b/packages/extensions-sdk/src/cli/utils/file.ts
@@ -1,0 +1,3 @@
+export function getFileExt(path: string): string {
+	return path.substring(path.lastIndexOf('.') + 1);
+}

--- a/packages/extensions-sdk/src/cli/utils/languages.ts
+++ b/packages/extensions-sdk/src/cli/utils/languages.ts
@@ -1,5 +1,6 @@
 import { EXTENSION_LANGUAGES } from '@cairncms/constants';
 import type { Language, LanguageShort } from '../types.js';
+import { getFileExt } from './file.js';
 
 export function isLanguage(language: string): language is Language {
 	return (EXTENSION_LANGUAGES as readonly string[]).includes(language);
@@ -14,7 +15,7 @@ export function languageToShort(language: Language): LanguageShort {
 }
 
 export function getLanguageFromPath(path: string): string {
-	const fileExtension = path.substring(path.lastIndexOf('.') + 1);
+	const fileExtension = getFileExt(path);
 
 	if (fileExtension === 'js') {
 		return 'javascript';


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds ESM output support to the extensions SDK while preserving CommonJS output for existing extensions that have not opted into ESM.

Newly scaffolded extensions now include `"type": "module"` and build to ESM by default. Existing extensions without a `type` field continue to build as CommonJS, `.mjs` and `.cjs` output paths explicitly force the matching format, and explicit `-t -i -o` builds follow the same rules instead of changing legacy build scripts to ESM.

### Testing / verification

Added test coverage for:
- newly scaffolded API extensions emitting ESM by default
- existing no-`type` extension manifests continuing to emit CommonJS
- `.mjs` and `.cjs` output paths overriding the manifest format
- explicit `-t -i -o` builds honoring the same manifest and file-extension rules
- the existing create/build matrix across app, api, and hybrid extensions with `.js`, `.mjs`, and `.cjs` config files

Verified against generated extensions:
- new scaffolded extensions include `"type": "module"` and build ESM output
- existing extensions without `type` build CommonJS output
- `.mjs` and `.cjs` output paths force ESM and CommonJS respectively
- explicit `-t -i -o` builds follow the same format rules
- rebuilt ESM and CommonJS API extensions load successfully in CairnCMS

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
