### PR TITLE
Clean up package build outputs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -41,15 +41,13 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.js",
-		"!**/__*__/"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
-		"build": "tsc --build && copyfiles \"src/**/*.{yaml,liquid,md,txt}\" -u 1 dist",
+		"build": "tsc --project tsconfig.prod.json && copyfiles \"src/**/*.{yaml,liquid,md,txt}\" -u 1 dist",
 		"cli": "NODE_ENV=development SERVE_APP=false NODE_OPTIONS=--no-node-snapshot tsx src/cli/run.ts",
 		"dev": "NODE_ENV=development SERVE_APP=false NODE_OPTIONS=--no-node-snapshot tsx watch --clear-screen=false src/start.ts",
 		"test": "vitest --watch=false"

--- a/api/tsconfig.prod.json
+++ b/api/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts", "**/__*__/**"]
+}

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -22,8 +22,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/composables/tsconfig.prod.json
+++ b/packages/composables/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch"
 	},
 	"description": "Shared constants for CairnCMS",

--- a/packages/constants/tsconfig.prod.json
+++ b/packages/constants/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -22,8 +22,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/exceptions/tsconfig.prod.json
+++ b/packages/exceptions/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -24,11 +24,10 @@
 	},
 	"files": [
 		"dist",
-		"templates",
-		"!**/*.test.{js,d.ts}"
+		"templates"
 	],
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},

--- a/packages/extensions-sdk/tsconfig.prod.json
+++ b/packages/extensions-sdk/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/format-title/package.json
+++ b/packages/format-title/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/format-title/tsconfig.prod.json
+++ b/packages/format-title/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -22,8 +22,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -37,7 +37,7 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch"
 	},
 	"dependencies": {

--- a/packages/schema/tsconfig.prod.json
+++ b/packages/schema/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage-driver-azure/tsconfig.prod.json
+++ b/packages/storage-driver-azure/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage-driver-cloudinary/tsconfig.prod.json
+++ b/packages/storage-driver-cloudinary/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage-driver-gcs/tsconfig.prod.json
+++ b/packages/storage-driver-gcs/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage-driver-local/tsconfig.prod.json
+++ b/packages/storage-driver-local/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/storage-driver-s3/tsconfig.prod.json
+++ b/packages/storage-driver-s3/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,13 +21,13 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"
 	},
 	"devDependencies": {
+		"@types/node": "22.19.17",
 		"@vitest/coverage-v8": "1.6.1",
 		"typescript": "5.0.4",
 		"vitest": "1.6.1"

--- a/packages/storage/tsconfig.prod.json
+++ b/packages/storage/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch"
 	},
 	"description": "Shared types for CairnCMS",

--- a/packages/types/tsconfig.prod.json
+++ b/packages/types/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "tsc --build",
+		"build": "tsc --project tsconfig.prod.json",
 		"dev": "tsc --watch",
 		"test": "vitest --watch=false"
 	},
@@ -21,8 +21,7 @@
 	},
 	"main": "dist/index.js",
 	"files": [
-		"dist",
-		"!**/*.d.ts?(.map)"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/update-check/tsconfig.prod.json
+++ b/packages/update-check/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/utils/browser/tsconfig.prod.json
+++ b/packages/utils/browser/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/utils/node/tsconfig.prod.json
+++ b/packages/utils/node/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {
-		"build": "tsc --project browser/tsconfig.json && tsc --project node/tsconfig.json && tsc --project shared/tsconfig.json",
+		"build": "tsc --project browser/tsconfig.prod.json && tsc --project node/tsconfig.prod.json && tsc --project shared/tsconfig.prod.json",
 		"dev": "concurrently \"tsc --watch --project browser/tsconfig.json\" \"tsc --watch --project node/tsconfig.json\" \"tsc --watch --project shared/tsconfig.json\"",
 		"test": "vitest --watch=false"
 	},
@@ -33,8 +33,7 @@
 	},
 	"main": "dist/shared/index.js",
 	"files": [
-		"dist",
-		"!**/*.test.{js,d.ts}"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,6 @@
 	},
 	"dependencies": {
 		"@cairncms/constants": "workspace:*",
-		"@cairncms/storage": "workspace:*",
 		"date-fns": "2.29.3",
 		"fs-extra": "11.1.1",
 		"joi": "17.9.1",
@@ -52,7 +51,6 @@
 	},
 	"devDependencies": {
 		"@cairncms/types": "workspace:*",
-		"@ngneat/falso": "6.4.0",
 		"@types/fs-extra": "11.0.1",
 		"@types/lodash-es": "4.17.7",
 		"@types/node": "22.19.17",

--- a/packages/utils/shared/tsconfig.prod.json
+++ b/packages/utils/shared/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
 
   packages/storage:
     devDependencies:
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
       '@vitest/coverage-v8':
         specifier: 1.6.1
         version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1224,9 +1224,6 @@ importers:
       '@cairncms/constants':
         specifier: workspace:*
         version: link:../constants
-      '@cairncms/storage':
-        specifier: workspace:*
-        version: link:../storage
       date-fns:
         specifier: 2.29.3
         version: 2.29.3
@@ -1252,9 +1249,6 @@ importers:
       '@cairncms/types':
         specifier: workspace:*
         version: link:../types
-      '@ngneat/falso':
-        specifier: 6.4.0
-        version: 6.4.0
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents package builds from shipping test artifacts in `dist/` and removes unused dependencies from the shared utils package.

Also adds production TypeScript configs for the API and workspace packages so build output excludes test files and API test fixtures before packaging, rather than relying on `files` exclusions to hide them. It also collapses redundant package `files` patterns now that the build output is clean, makes the storage package's Node types dependency explicit, and removes unused utils-package dependencies from the install graph.

### Testing / verification

Verified the package and API build outputs no longer contain compiled test files or API fixture directories, and that package manifests still publish only the intended build artifacts. Also verified the lockfile round-trips after the dependency removals and the explicit storage type dependency addition.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
