### PR TITLE
Fix last admin role navigation

### DIFF
--- a/app/src/modules/settings/routes/roles/collection.vue
+++ b/app/src/modules/settings/routes/roles/collection.vue
@@ -78,11 +78,6 @@ const router = useRouter();
 const roles = ref<RoleItem[]>([]);
 const loading = ref(false);
 
-const lastAdminRoleId = computed(() => {
-	const adminRoles = roles.value.filter((role) => role.admin_access === true);
-	return adminRoles.length === 1 ? adminRoles[0].id : null;
-});
-
 const tableHeaders = ref<TableHeader[]>([
 	{
 		text: '',
@@ -164,14 +159,7 @@ async function fetchRoles() {
 }
 
 function navigateToRole({ item }: { item: Role }) {
-	if (item.id !== 'public' && lastAdminRoleId.value) {
-		router.push({
-			name: 'settings-roles-item',
-			params: { primaryKey: item.id, lastAdminRoleId: lastAdminRoleId.value },
-		});
-	} else {
-		router.push(`/settings/roles/${item.id}`);
-	}
+	router.push(`/settings/roles/${item.id}`);
 }
 </script>
 

--- a/app/src/modules/settings/routes/roles/item/item.vue
+++ b/app/src/modules/settings/routes/roles/item/item.vue
@@ -12,7 +12,7 @@
 			<v-dialog v-if="[1, 2].includes(+primaryKey) === false" v-model="confirmDelete" @esc="confirmDelete = false">
 				<template #activator="{ on }">
 					<v-button
-						v-if="primaryKey !== lastAdminRoleId"
+						v-if="isLastAdminRole === false"
 						v-tooltip.bottom="t('delete_label')"
 						rounded
 						icon
@@ -106,15 +106,18 @@
 </template>
 
 <script setup lang="ts">
+import api from '@/api';
 import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
 import { useShortcut } from '@/composables/use-shortcut';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
+import { isLastAdminRole as computeLastAdmin } from '@/utils/is-last-admin-role';
+import { unexpectedError } from '@/utils/unexpected-error';
 import RevisionsDrawerDetail from '@/views/private/components/revisions-drawer-detail.vue';
 import UsersInvite from '@/views/private/components/users-invite.vue';
-import { computed, ref, toRefs } from 'vue';
+import { computed, onMounted, ref, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import SettingsNavigation from '../../../components/navigation.vue';
@@ -124,8 +127,25 @@ import RoleInfoSidebarDetail from './components/role-info-sidebar-detail.vue';
 const props = defineProps<{
 	primaryKey: string;
 	permissionKey?: string;
-	lastAdminRoleId?: string;
 }>();
+
+type RoleSummary = { id: string; admin_access: boolean };
+
+const roles = ref<RoleSummary[] | null>(null);
+
+onMounted(async () => {
+	try {
+		const response = await api.get('/roles', {
+			params: { fields: ['id', 'admin_access'], limit: -1 },
+		});
+
+		roles.value = response.data.data;
+	} catch (error: any) {
+		unexpectedError(error);
+	}
+});
+
+const isLastAdminRole = computed(() => computeLastAdmin(roles.value, props.primaryKey));
 
 const { t } = useI18n();
 

--- a/app/src/modules/users/components/navigation-role.vue
+++ b/app/src/modules/users/components/navigation-role.vue
@@ -5,7 +5,7 @@
 
 		<v-menu v-if="isAdmin" ref="contextMenu" show-arrow placement="bottom-start">
 			<v-list>
-				<v-list-item clickable :to="settingLink">
+				<v-list-item clickable :to="`/settings/roles/${role.id}`">
 					<v-list-item-icon>
 						<v-icon name="list_alt" />
 					</v-list-item-icon>
@@ -20,25 +20,14 @@
 
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user';
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { BasicRole } from '../composables/use-navigation';
 
-const props = defineProps<{
+defineProps<{
 	role: BasicRole;
-	lastAdmin: boolean;
 }>();
 
 const { t } = useI18n();
 
 const { isAdmin } = useUserStore();
-
-const settingLink = computed(() => {
-	return props.role.id !== 'public' && props.lastAdmin
-		? {
-				name: 'settings-roles-item',
-				params: { primaryKey: props.role.id, lastAdminRoleId: props.role.id },
-		  }
-		: `/settings/roles/${props.role.id}`;
-});
 </script>

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -13,18 +13,11 @@
 			</v-list-item>
 		</template>
 
-		<navigation-role
-			v-for="role in roles"
-			:key="role.id"
-			:role="role"
-			:last-admin="lastAdminRoleId === role.id"
-			:active="currentRole === role.id"
-		/>
+		<navigation-role v-for="role in roles" :key="role.id" :role="role" :active="currentRole === role.id" />
 	</v-list>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import useNavigation from '../composables/use-navigation';
 import NavigationRole from './navigation-role.vue';
@@ -36,12 +29,6 @@ defineProps<{
 const { t } = useI18n();
 
 const { roles, loading } = useNavigation();
-
-const lastAdminRoleId = computed(() => {
-	if (!roles.value) return null;
-	const adminRoles = roles.value.filter((role) => role.admin_access === true);
-	return adminRoles.length === 1 ? adminRoles[0].id : null;
-});
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/utils/is-last-admin-role.test.ts
+++ b/app/src/utils/is-last-admin-role.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { isLastAdminRole } from './is-last-admin-role';
+
+describe('isLastAdminRole', () => {
+	it('returns null when roles have not loaded yet', () => {
+		expect(isLastAdminRole(null, 'role-1')).toBe(null);
+	});
+
+	it('returns true when the queried role is the only admin role', () => {
+		const roles = [
+			{ id: 'role-1', admin_access: true },
+			{ id: 'role-2', admin_access: false },
+		];
+
+		expect(isLastAdminRole(roles, 'role-1')).toBe(true);
+	});
+
+	it('returns false when the queried role is admin but other admins exist', () => {
+		const roles = [
+			{ id: 'role-1', admin_access: true },
+			{ id: 'role-2', admin_access: true },
+		];
+
+		expect(isLastAdminRole(roles, 'role-1')).toBe(false);
+	});
+
+	it('returns false when the queried role is not admin', () => {
+		const roles = [
+			{ id: 'role-1', admin_access: true },
+			{ id: 'role-2', admin_access: false },
+		];
+
+		expect(isLastAdminRole(roles, 'role-2')).toBe(false);
+	});
+
+	it('returns false when the primaryKey is not in the roles list', () => {
+		const roles = [{ id: 'role-1', admin_access: true }];
+		expect(isLastAdminRole(roles, 'role-missing')).toBe(false);
+	});
+});

--- a/app/src/utils/is-last-admin-role.ts
+++ b/app/src/utils/is-last-admin-role.ts
@@ -1,0 +1,11 @@
+type Role = { id: string; admin_access: boolean };
+
+export function isLastAdminRole(roles: Role[] | null, primaryKey: string): boolean | null {
+	if (roles === null) return null;
+
+	const adminRoles = roles.filter((role) => role.admin_access === true);
+
+	if (adminRoles.length !== 1) return false;
+
+	return adminRoles[0]!.id === primaryKey;
+}


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents the role editor from showing the delete action for the last admin role and removes the related Vue Router discarded-param warning.

The role editor now derives the last-admin state from the roles list instead of relying on navigation state, so the guard also works after direct loads and reloads. API enforcement is unchanged.

### Testing / verification

Added helper coverage for loaded, unloaded, last-admin, non-last-admin, and missing-role cases.

Also verified in the admin app that the warning is gone, the delete action is hidden for the last admin role after navigation and reload, and delete remains available for other roles.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
