### PR TITLE
Clean up Vue warnings

### DIFF
--- a/app/src/components/v-select/v-select.test.ts
+++ b/app/src/components/v-select/v-select.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 import VSelect from './v-select.vue';
@@ -52,4 +52,57 @@ test('Mount component', () => {
 	});
 
 	expect(wrapper.html()).toMatchSnapshot();
+});
+
+test('Resolves a numeric scalar modelValue to the matching item text without a modelValue prop warning', () => {
+	const numericItems = [
+		{ text: 'Thin', value: 8 },
+		{ text: 'Medium', value: 20 },
+		{ text: 'Broad', value: 48 },
+	];
+
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+	const slotAwareGlobal: GlobalMountOptions = {
+		...global,
+		stubs: {
+			'v-list': true,
+			'v-list-item': true,
+			'v-list-item-icon': true,
+			'v-list-item-content': true,
+			'v-divider': true,
+			'v-checkbox': true,
+			'v-icon': true,
+			'v-input': true,
+			'v-menu': {
+				name: 'v-menu',
+				template:
+					'<div><slot name="activator" :toggle="() => {}" :active="false" :deactivate="() => {}" /><slot /></div>',
+			},
+		},
+	};
+
+	try {
+		const wrapper = mount(VSelect, {
+			props: {
+				items: numericItems,
+				modelValue: 20,
+			},
+			global: slotAwareGlobal,
+		});
+
+		expect(wrapper.exists()).toBe(true);
+
+		const modelValueWarnings = warnSpy.mock.calls
+			.flatMap((call) => call.map(String))
+			.filter((message) => message.includes('modelValue'));
+
+		expect(modelValueWarnings).toEqual([]);
+
+		const previewInput = wrapper.find('v-input-stub');
+		expect(previewInput.exists()).toBe(true);
+		expect(previewInput.attributes('model-value')).toBe('Medium');
+	} finally {
+		warnSpy.mockRestore();
+	}
 });

--- a/app/src/components/v-select/v-select.vue
+++ b/app/src/components/v-select/v-select.vue
@@ -139,7 +139,7 @@ import SelectListItem from './select-list-item.vue';
 import { Option } from './types';
 
 type ItemsRaw = (string | any)[];
-type InputValue = string[] | string | null;
+type InputValue = string[] | string | number | null;
 
 interface Props {
 	/** The items that should be selectable */

--- a/app/src/displays/boolean/boolean.vue
+++ b/app/src/displays/boolean/boolean.vue
@@ -14,12 +14,12 @@ import { computed } from 'vue';
 const props = withDefaults(
 	defineProps<{
 		value: boolean;
-		labelOn: string | null;
-		labelOff: string | null;
-		iconOn: string | null;
-		iconOff: string | null;
-		colorOn: string;
-		colorOff: string;
+		labelOn?: string | null;
+		labelOff?: string | null;
+		iconOn?: string | null;
+		iconOff?: string | null;
+		colorOn?: string;
+		colorOff?: string;
 	}>(),
 	{
 		value: false,

--- a/app/src/interfaces/_system/system-display-template/system-display-template.vue
+++ b/app/src/interfaces/_system/system-display-template/system-display-template.vue
@@ -20,7 +20,7 @@ import { computed, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-	value: string | null;
+	value?: string | null;
 	disabled?: boolean;
 	collectionField?: string;
 	collectionName?: string;

--- a/app/src/interfaces/_system/system-field/system-field.vue
+++ b/app/src/interfaces/_system/system-field/system-field.vue
@@ -24,7 +24,7 @@ import { useI18n } from 'vue-i18n';
 
 const props = withDefaults(
 	defineProps<{
-		value: string | null;
+		value?: string | null;
 		collectionField?: string;
 		collectionName?: string;
 		typeAllowList?: string[];

--- a/app/src/interfaces/_system/system-folder/folder.vue
+++ b/app/src/interfaces/_system/system-folder/folder.vue
@@ -34,7 +34,7 @@
 				:key="folder.id!"
 				clickable
 				:folder="folder"
-				:current-folder="value"
+				:current-folder="value ?? null"
 				:disabled="disabledFolders.includes(folder.id!)"
 				:disabled-folders="disabledFolders"
 				@click="emitValue"
@@ -51,8 +51,8 @@ import FolderListItem from './folder-list-item.vue';
 
 const props = withDefaults(
 	defineProps<{
-		value: string | null;
-		disabledFolders: string[];
+		value?: string | null;
+		disabledFolders?: string[];
 		disabled?: boolean;
 		placeholder?: string;
 	}>(),

--- a/app/src/interfaces/select-dropdown/select-dropdown.vue
+++ b/app/src/interfaces/select-dropdown/select-dropdown.vue
@@ -30,7 +30,7 @@ type Option = {
 
 withDefaults(
 	defineProps<{
-		value: string | number | null;
+		value?: string | number | null;
 		disabled?: boolean;
 		choices?: Option[];
 		icon?: string;

--- a/app/src/interfaces/select-icon/select-icon.vue
+++ b/app/src/interfaces/select-icon/select-icon.vue
@@ -14,7 +14,7 @@
 				</template>
 
 				<template #append>
-					<v-icon v-if="value !== null" clickable name="close" @click="setIcon(null)" />
+					<v-icon v-if="value" clickable name="close" @click="setIcon(null)" />
 					<v-icon
 						v-else
 						clickable
@@ -53,7 +53,7 @@ import icons from './icons.json';
 
 withDefaults(
 	defineProps<{
-		value: string | null;
+		value?: string | null;
 		disabled?: boolean;
 		width?: string;
 	}>(),

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -192,7 +192,7 @@ type Item = {
 };
 
 interface Props {
-	role: string | null;
+	role?: string | null;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/src/panels/line-chart/panel-line-chart.vue
+++ b/app/src/panels/line-chart/panel-line-chart.vue
@@ -22,10 +22,10 @@ const props = withDefaults(
 		data?: Record<string, any>[];
 		group?: string;
 		xAxis?: string;
-		function: PanelFunction;
+		function?: PanelFunction;
 		yAxis: string;
 		color?: string;
-		filter: Filter;
+		filter?: Filter;
 		decimals?: number;
 		showAxisLabels?: string;
 		showLegend?: boolean;
@@ -35,6 +35,8 @@ const props = withDefaults(
 	{
 		showHeader: false,
 		data: () => [],
+		function: 'count',
+		filter: () => ({}),
 		showAxisLabels: 'both',
 		showLegend: false,
 		showMarker: true,


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Removes several admin UI prop-validation warnings caused by optional form values being passed through before they are initialized.

The changes keep runtime behavior the same while relaxing the affected Vue prop contracts, adding line-chart option defaults, and allowing `v-select` to accept numeric scalar values used by panel options.

### Testing / verification

Added coverage for numeric scalar `v-select` values resolving to the matching option text without the targeted prop warning.

Also verified the affected admin screens in the browser console, including project settings, users, boolean fields, data-model interface options, and chart panel options.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
