### PR TITLE
Guard kanban drag handler against missing sort field

### DIFF
--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -256,6 +256,8 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			if (gField === null || pkField === undefined || event.removed) return;
 
 			if (event.moved) {
+				if (!sortField.value) return;
+
 				const item = group.items[event.moved.oldIndex]?.id;
 				const to = group.items[event.moved.newIndex]?.id;
 
@@ -272,7 +274,7 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 					return item;
 				});
 
-				if (group.items.length > 0) {
+				if (sortField.value && group.items.length > 0) {
 					const item = event.added.element;
 					const before = group.items[event.added.newIndex - 1] as Item | undefined;
 					const after = group.items[event.added.newIndex] as Item | undefined;


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents Kanban from sending sort requests for collections that do not have a configured sort field.

Kanban can still move cards between columns because that only updates the grouped field on the item. Within-column ordering now only calls the sort endpoint when the collection actually supports manual sorting, avoiding the 400 response from `/utils/sort/<collection>` while leaving sort-enabled collections unchanged.

### Testing / verification

Manual verification covered a Kanban collection without a sort field, where cross-column moves still persisted and within-column reordering stayed unavailable, and the same collection after adding a sort field, where within-column ordering worked as expected.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
