### PR TITLE
Normalize empty form interface values to null

### DIFF
--- a/app/src/components/v-form/form-field-interface.test.ts
+++ b/app/src/components/v-form/form-field-interface.test.ts
@@ -1,0 +1,142 @@
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+
+vi.mock('@/composables/use-extension', () => ({
+	useExtension: () => ref({ id: 'input' }),
+}));
+
+import FormFieldInterface from './form-field-interface.vue';
+
+const i18n = createI18n({ legacy: false });
+
+function makeField(overrides: Record<string, any> = {}) {
+	const { meta = {}, schema = {}, ...rest } = overrides;
+
+	return {
+		collection: 'test',
+		field: 'title',
+		type: 'string',
+		name: 'Title',
+		meta: {
+			collection: 'test',
+			field: 'title',
+			type: 'string',
+			interface: 'input',
+			special: null,
+			hidden: false,
+			group: null,
+			sort: 1,
+			width: 'full',
+			...meta,
+		},
+		schema: {
+			name: 'title',
+			table: 'test',
+			data_type: 'varchar',
+			...schema,
+		},
+		...rest,
+	};
+}
+
+const interfaceInputStub = {
+	name: 'interface-input',
+	template: '<div class="interface-input-stub" />',
+	props: ['value'],
+};
+
+const rawEditorStub = {
+	name: 'interface-system-raw-editor',
+	template: '<div class="interface-system-raw-editor-stub" />',
+	props: ['value'],
+};
+
+const baseStubs = {
+	'v-error-boundary': { template: '<div><slot /></div>' },
+	'v-skeleton-loader': true,
+	'v-notice': true,
+	'interface-input': interfaceInputStub,
+	'interface-system-raw-editor': rawEditorStub,
+};
+
+function mountField(props: Record<string, any>) {
+	return mount(FormFieldInterface, {
+		props,
+		global: {
+			plugins: [i18n],
+			stubs: baseStubs,
+		},
+	});
+}
+
+describe('FormFieldInterface normalizes the value passed to the rendered interface', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+	});
+
+	it('resolves to null when modelValue is omitted and the schema has no default_value', () => {
+		const wrapper = mountField({ field: makeField() });
+
+		const child = wrapper.findComponent(interfaceInputStub);
+		expect(child.exists()).toBe(true);
+		expect(child.props('value')).toBeNull();
+	});
+
+	it('passes a falsy zero default_value through unchanged', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: 0 } }),
+		});
+
+		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBe(0);
+	});
+
+	it('passes a falsy false default_value through unchanged', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: false } }),
+		});
+
+		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBe(false);
+	});
+
+	it('passes a falsy empty-string default_value through unchanged', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: '' } }),
+		});
+
+		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBe('');
+	});
+
+	it('passes an explicit null modelValue through unchanged', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: 'fallback' } }),
+			modelValue: null,
+		});
+
+		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBeNull();
+	});
+
+	it('passes an explicit modelValue through unchanged regardless of default_value', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: 'fallback' } }),
+			modelValue: 'operator-set',
+		});
+
+		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBe('operator-set');
+	});
+
+	it('routes the raw editor branch through the original inline expression, leaving the value undefined when neither modelValue nor default_value is set', () => {
+		const wrapper = mountField({
+			field: makeField(),
+			rawEditorEnabled: true,
+			rawEditorActive: true,
+		});
+
+		const child = wrapper.findComponent(rawEditorStub);
+		expect(child.exists()).toBe(true);
+		expect(child.props('value')).toBeUndefined();
+	});
+});

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -14,7 +14,7 @@
 				:autofocus="disabled !== true && autofocus"
 				:disabled="disabled"
 				:loading="loading"
-				:value="modelValue === undefined ? field.schema?.default_value : modelValue"
+				:value="interfaceValue"
 				:width="(field.meta && field.meta.width) || 'full'"
 				:type="field.type"
 				:collection="field.collection"
@@ -57,7 +57,7 @@ interface Props {
 	batchMode?: boolean;
 	batchActive?: boolean;
 	primaryKey?: string | number | null;
-	modelValue?: string | number | boolean | Record<string, any> | Array<any>;
+	modelValue?: string | number | boolean | Record<string, any> | Array<any> | null;
 	loading?: boolean;
 	disabled?: boolean;
 	autofocus?: boolean;
@@ -94,6 +94,13 @@ const componentName = computed(() => {
 	return props.field?.meta?.interface
 		? `interface-${props.field.meta.interface}`
 		: `interface-${getDefaultInterfaceForType(props.field.type!)}`;
+});
+
+const interfaceValue = computed(() => {
+	if (props.modelValue !== undefined) return props.modelValue;
+
+	const defaultValue = props.field.schema?.default_value;
+	return defaultValue === undefined ? null : defaultValue;
 });
 </script>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -18,7 +18,7 @@ const fieldDetailStore = useFieldDetailStore();
 
 const { field, collection } = storeToRefs(fieldDetailStore);
 
-const conditions = syncFieldDetailStoreProperty('field.meta.conditions');
+const conditions = syncFieldDetailStoreProperty('field.meta.conditions', null);
 const interfaceId = computed(() => field.value.meta?.interface ?? null);
 
 const repeaterFields = computed<DeepPartial<Field>[]>(() => [

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -83,7 +83,7 @@ const readonly = syncFieldDetailStoreProperty('field.meta.readonly', false);
 const hidden = syncFieldDetailStoreProperty('field.meta.hidden', false);
 const required = syncFieldDetailStoreProperty('field.meta.required', false);
 const note = syncFieldDetailStoreProperty('field.meta.note');
-const translations = syncFieldDetailStoreProperty('field.meta.translations');
+const translations = syncFieldDetailStoreProperty('field.meta.translations', null);
 const { loading, field } = storeToRefs(fieldDetailStore);
 const type = computed(() => field.value.type);
 const isGenerated = computed(() => field.value.schema?.is_generated);


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents Data Model field configuration forms from passing `undefined` into interface `value` props before a value exists.

`FormFieldInterface` now sends `null` to normal interfaces when both the model value and schema default are missing. The raw-editor path is unchanged because it already accepts `undefined`. The direct field translations and conditions list mounts also default to `null`, matching the list interface contract.

### Testing / verification

Added component coverage for the form-interface value normalization, falsy schema defaults, explicit values, and raw-editor preservation.

Also verified in the admin app that the field-configuration warnings no longer appear for integer options, field-name translations, and conditions.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
