### PR TITLE
Make invite-accept token failures uniform

### DIFF
--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -961,5 +961,120 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+
+		describe('acceptInvite', () => {
+			const FORBIDDEN_DEFAULT_MESSAGE = `You don't have permission to access this.`;
+
+			const expectUniformForbidden = (rejection: any, ...identifiersThatMustNotAppear: string[]) => {
+				expect(rejection).toBeInstanceOf(ForbiddenException);
+				expect(rejection.status).toBe(403);
+				expect(rejection.code).toBe('FORBIDDEN');
+				expect(rejection.message).toBe(FORBIDDEN_DEFAULT_MESSAGE);
+
+				for (const identifier of identifiersThatMustNotAppear) {
+					expect(rejection.message).not.toContain(identifier);
+				}
+			};
+
+			describe('failure modes collapse to uniform ForbiddenException', () => {
+				it('throws uniform ForbiddenException on a malformed JWT', async () => {
+					const rejection = await service.acceptInvite('not-a-jwt', 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection);
+				});
+
+				it('throws uniform ForbiddenException on a wrong-signature JWT', async () => {
+					const wrongSecret = jwt.sign(
+						{ email: 'token@example.test', scope: 'invite' },
+						'completely-different-secret',
+						{
+							issuer: 'cairncms',
+						}
+					);
+
+					const rejection = await service.acceptInvite(wrongSecret, 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection, 'token@example.test');
+				});
+
+				it('throws uniform ForbiddenException on an expired JWT', async () => {
+					const expired = jwt.sign({ email: 'token@example.test', scope: 'invite' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+						expiresIn: '-1s',
+					});
+
+					const rejection = await service.acceptInvite(expired, 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection, 'token@example.test');
+				});
+
+				it('throws uniform ForbiddenException on a valid JWT with wrong scope', async () => {
+					const wrongScope = jwt.sign({ email: 'token@example.test', scope: 'password-reset' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					const rejection = await service.acceptInvite(wrongScope, 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection, 'token@example.test');
+				});
+
+				it('throws uniform ForbiddenException when no account matches the token email', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(null);
+
+					const validToken = jwt.sign({ email: 'attacker@example.test', scope: 'invite' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					const rejection = await service.acceptInvite(validToken, 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection, 'attacker@example.test');
+				});
+
+				it('throws uniform ForbiddenException when the account is not in invited status, without leaking either email', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+						id: 'user-id',
+						role: 'user-role',
+						status: 'active',
+						password: 'hashed-password',
+						email: 'victim@example.test',
+					});
+
+					const validToken = jwt.sign({ email: 'attacker@example.test', scope: 'invite' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					const rejection = await service.acceptInvite(validToken, 'NewPassw0rd!123').catch((err: any) => err);
+
+					expectUniformForbidden(rejection, 'attacker@example.test', 'victim@example.test');
+				});
+			});
+
+			describe('regression — happy path still updates the invited user', () => {
+				it('updates the user with password and active status on a valid invite token', async () => {
+					vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+						id: 'user-id',
+						role: 'user-role',
+						status: 'invited',
+						password: null,
+						email: 'invited@example.test',
+					});
+
+					const updateOneSpy = vi.spyOn(UsersService.prototype, 'updateOne').mockResolvedValueOnce('user-id');
+
+					const validToken = jwt.sign({ email: 'invited@example.test', scope: 'invite' }, 'test-secret-for-jwt', {
+						issuer: 'cairncms',
+					});
+
+					await service.acceptInvite(validToken, 'NewPassw0rd!123');
+
+					expect(updateOneSpy).toHaveBeenCalledTimes(1);
+
+					expect(updateOneSpy).toHaveBeenCalledWith('user-id', {
+						password: 'NewPassw0rd!123',
+						status: 'active',
+					});
+				});
+			});
+		});
 	});
 });

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -12,7 +12,6 @@ import { RecordNotUniqueException } from '../exceptions/database/record-not-uniq
 import { ForbiddenException, InvalidPayloadException, UnprocessableEntityException } from '../exceptions/index.js';
 import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '../types/index.js';
 import isUrlAllowed from '../utils/is-url-allowed.js';
-import { verifyJWT } from '../utils/jwt.js';
 import { stall } from '../utils/stall.js';
 import { Url } from '../utils/url.js';
 import { ItemsService } from './items.js';
@@ -418,17 +417,22 @@ export class UsersService extends ItemsService {
 	}
 
 	async acceptInvite(token: string, password: string): Promise<void> {
-		const { email, scope } = verifyJWT(token, env['SECRET'] as string) as {
-			email: string;
-			scope: string;
-		};
+		let payload: { email: string; scope: string };
+
+		try {
+			payload = jwt.verify(token, env['SECRET'] as string, { issuer: 'cairncms' }) as typeof payload;
+		} catch {
+			throw new ForbiddenException();
+		}
+
+		const { email, scope } = payload;
 
 		if (scope !== 'invite') throw new ForbiddenException();
 
 		const user = await this.getUserByEmail(email);
 
 		if (user?.status !== 'invited') {
-			throw new InvalidPayloadException(`Email address ${email} hasn't been invited.`);
+			throw new ForbiddenException();
 		}
 
 		// Allow unauthenticated update


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Makes invite-accept token failures return a generic response instead of exposing why the invite link failed.

### Testing / verification

Added unit coverage for:

- malformed, wrong-signature, expired, wrong-scope, missing-user, and non-invited-user invite tokens all returning the same generic forbidden response
- token/stored emails not appearing in failed invite-accept responses
- valid invite tokens still activating the invited user with the submitted password

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
