### PR TITLE
Fix partial PATCH crash in RelationsService.updateOne

### DIFF
--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -271,8 +271,23 @@ export class RelationsService {
 			throw new InvalidPayloadException(`Field "${field}" in collection "${collection}" doesn't have a relationship.`);
 		}
 
+		let effectiveSchema: Relation['schema'];
+
+		if (Object.prototype.hasOwnProperty.call(relation, 'schema') === false) {
+			effectiveSchema = existingRelation.schema;
+		} else if (relation.schema === null) {
+			effectiveSchema = null;
+		} else {
+			effectiveSchema = { ...existingRelation.schema, ...relation.schema } as Relation['schema'];
+		}
+
+		const effectiveRelation = {
+			...existingRelation,
+			schema: effectiveSchema,
+		};
+
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
-		this.helpers.schema.preRelationChange(relation);
+		this.helpers.schema.preRelationChange(effectiveRelation);
 
 		const nestedActionEvents: ActionEventParams[] = [];
 
@@ -291,7 +306,7 @@ export class RelationsService {
 							existingRelation.schema.constraint_name = constraintName;
 						}
 
-						this.alterType(table, relation);
+						this.alterType(table, effectiveRelation);
 
 						const builder = table
 							.foreign(field, constraintName || undefined)
@@ -301,8 +316,8 @@ export class RelationsService {
 								}`
 							);
 
-						if (relation.schema?.on_delete) {
-							builder.onDelete(relation.schema.on_delete);
+						if (effectiveRelation.schema?.on_delete) {
+							builder.onDelete(effectiveRelation.schema.on_delete);
 						}
 					});
 				}
@@ -325,8 +340,8 @@ export class RelationsService {
 						await relationsItemService.createOne(
 							{
 								...(relation.meta || {}),
-								many_collection: relation.collection,
-								many_field: relation.field,
+								many_collection: effectiveRelation.collection,
+								many_field: effectiveRelation.field,
 								one_collection: existingRelation.related_collection || null,
 							},
 							{

--- a/tests/blackbox/routes/relations/partial-patch-crash.test.ts
+++ b/tests/blackbox/routes/relations/partial-patch-crash.test.ts
@@ -1,0 +1,96 @@
+import { getUrl } from '@common/config';
+import { CreateCollection, CreateFieldM2O, DeleteCollection } from '@common/functions';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import request from 'supertest';
+
+const PARENT_COLLECTION = 'test_relations_partial_patch_parent';
+const CHILD_COLLECTION = 'test_relations_partial_patch_child';
+const FK_FIELD = 'parent';
+
+describe(`/relations PATCH partial body`, () => {
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			await DeleteCollection(vendor, { collection: CHILD_COLLECTION });
+			await DeleteCollection(vendor, { collection: PARENT_COLLECTION });
+
+			await CreateCollection(vendor, { collection: PARENT_COLLECTION });
+			await CreateCollection(vendor, { collection: CHILD_COLLECTION });
+
+			await CreateFieldM2O(vendor, {
+				collection: CHILD_COLLECTION,
+				field: FK_FIELD,
+				otherCollection: PARENT_COLLECTION,
+			});
+		}
+	}, 300000);
+
+	afterAll(async () => {
+		for (const vendor of vendors) {
+			await DeleteCollection(vendor, { collection: CHILD_COLLECTION });
+			await DeleteCollection(vendor, { collection: PARENT_COLLECTION });
+		}
+	}, 300000);
+
+	describe('PATCH /relations/:collection/:field with a partial body succeeds and the API process stays alive', () => {
+		it.each(vendors)('%s', async (vendor) => {
+			const alias = 'children_via_partial_patch';
+
+			const response = await request(getUrl(vendor))
+				.patch(`/relations/${CHILD_COLLECTION}/${FK_FIELD}`)
+				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+				.send({ meta: { one_field: alias } });
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.meta.one_field).toBe(alias);
+			expect(response.body.data.schema.on_delete).toBe('SET NULL');
+
+			const ping = await request(getUrl(vendor)).get('/server/ping');
+
+			expect(ping.statusCode).toBe(200);
+			expect(ping.text).toBe('pong');
+		});
+	});
+
+	describe('PATCH /relations/:collection/:field with a full body still succeeds (regression)', () => {
+		it.each(vendors)('%s', async (vendor) => {
+			const alias = 'children_via_full_patch';
+
+			const response = await request(getUrl(vendor))
+				.patch(`/relations/${CHILD_COLLECTION}/${FK_FIELD}`)
+				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+				.send({
+					collection: CHILD_COLLECTION,
+					field: FK_FIELD,
+					related_collection: PARENT_COLLECTION,
+					meta: { one_field: alias },
+					schema: { on_delete: 'CASCADE' },
+				});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.meta.one_field).toBe(alias);
+			expect(response.body.data.schema.on_delete).toBe('CASCADE');
+
+			const ping = await request(getUrl(vendor)).get('/server/ping');
+
+			expect(ping.statusCode).toBe(200);
+			expect(ping.text).toBe('pong');
+		});
+	});
+
+	describe('PATCH /relations/:collection/:field with an explicit schema: null does not crash the API process', () => {
+		it.each(vendors)('%s', async (vendor) => {
+			const response = await request(getUrl(vendor))
+				.patch(`/relations/${CHILD_COLLECTION}/${FK_FIELD}`)
+				.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+				.send({ schema: null });
+
+			expect(response.statusCode).toBe(200);
+
+			const ping = await request(getUrl(vendor)).get('/server/ping');
+
+			expect(ping.statusCode).toBe(200);
+			expect(ping.text).toBe('pong');
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -8,6 +8,7 @@ exports.list = {
 		{ testFilePath: '/routes/collections/crud.test.ts' },
 		{ testFilePath: '/routes/fields/change-fields.test.ts' },
 		{ testFilePath: '/routes/fields/crud.test.ts' },
+		{ testFilePath: '/routes/relations/partial-patch-crash.test.ts' },
 	],
 	after: [
 		{ testFilePath: '/schema/timezone/timezone.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents partial relation PATCH requests from terminating the API process.

`PATCH /relations/:collection/:field` accepts partial updates. The relation service treated the partial request body as if it were a full relation record while rebuilding the foreign-key constraint, so a metadata-only PATCH could dereference missing relation identity fields and crash the server. This PR normalizes the effective relation from the existing relation record before schema work, while preserving existing FK schema when `schema` is omitted.

### Testing / verification

Added a blackbox test covering:
- metadata-only relation PATCH applies the metadata update and leaves the API alive
- metadata-only relation PATCH preserves existing `on_delete`
- full relation PATCH still applies schema updates
- explicit `schema: null` does not crash the API process

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
