### PR TITLE
Clone resolved transformation in asset controller

### DIFF
--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -146,11 +146,13 @@ router.get(
 
 		const vary = ['Origin', 'Cache-Control'];
 
-		const transformation: TransformationParams = res.locals['transformation'].key
+		const selectedTransformation: TransformationParams = res.locals['transformation'].key
 			? (res.locals['shortcuts'] as TransformationParams[]).find(
 					(transformation) => transformation['key'] === res.locals['transformation'].key
 			  )
 			: res.locals['transformation'];
+
+		const transformation: TransformationParams = { ...selectedTransformation };
 
 		if (transformation.format === 'auto') {
 			let format: Exclude<TransformationParams['format'], 'auto'>;

--- a/tests/blackbox/routes/assets/system-preset-format-isolation.test.ts
+++ b/tests/blackbox/routes/assets/system-preset-format-isolation.test.ts
@@ -1,0 +1,55 @@
+import { getUrl } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import * as common from '@common/index';
+import { createReadStream } from 'fs';
+import path from 'path';
+import request from 'supertest';
+
+jest.setTimeout(30000);
+
+const assetsDirectory = [__dirname, '..', '..', 'assets'];
+const storages = ['local', 'minio'];
+
+const imageFile = {
+	name: 'directus.png',
+	type: 'image/png',
+};
+
+const imageFilePath = path.join(...assetsDirectory, imageFile.name);
+
+describe('/assets system-preset format negotiation isolation', () => {
+	describe('Two sequential requests for the same system preset with different Accept headers get independent format negotiation', () => {
+		describe.each(storages)('Storage: %s', (storage) => {
+			it.each(vendors)('%s', async (vendor) => {
+				const insertResponse = await request(getUrl(vendor))
+					.post('/files')
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.field('storage', storage)
+					.attach('file', createReadStream(imageFilePath));
+
+				const fileId = insertResponse.body.data.id;
+
+				const webpResponse = await request(getUrl(vendor))
+					.get(`/assets/${fileId}?key=system-medium-contain`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.set('Accept', 'image/webp');
+
+				expect(webpResponse.statusCode).toBe(200);
+				expect(webpResponse.headers['content-type']).toBe('image/webp');
+
+				const avifResponse = await request(getUrl(vendor))
+					.get(`/assets/${fileId}?key=system-medium-contain`)
+					.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					.set('Accept', 'image/avif');
+
+				expect(avifResponse.statusCode).toBe(200);
+				expect(avifResponse.headers['content-type']).toBe('image/avif');
+
+				const ping = await request(getUrl(vendor)).get('/server/ping');
+
+				expect(ping.statusCode).toBe(200);
+				expect(ping.text).toBe('pong');
+			});
+		});
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -20,6 +20,7 @@ exports.list = {
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/items/relational-presets.test.ts' },
 		{ testFilePath: '/routes/assets/format.test.ts' },
+		{ testFilePath: '/routes/assets/system-preset-format-isolation.test.ts' },
 		{ testFilePath: '/routes/assets/read.test.ts' },
 		{ testFilePath: '/routes/assets/limit.test.ts' },
 		{ testFilePath: '/routes/assets/concurrency.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Prevents asset format negotiation from leaking between requests when system presets use `format: auto`.

System asset presets are shared in memory. The asset controller selected a preset by reference, then rewrote its `format` field after inspecting the request's `Accept` header which let one request permanently change the preset format used by later requests. This PR clones the resolved transformation before negotiation, so each request mutates only its own copy.

### Testing / verification

Added a blackbox test covering:
- first request for a system preset with `Accept: image/webp` returns WebP
- second request for the same file and preset with `Accept: image/avif` returns AVIF
- the API remains responsive after the sequence

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
