### PR TITLE
App correctness fixes: file preview, user invites, list panel saves

### DIFF
--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -114,17 +114,10 @@
 		</template>
 
 		<div class="file-item">
-			<div class="preview">
-				<file-preview
-					v-if="isBatch === false && item"
-					:src="fileSrc"
-					:mime="item.type"
-					:width="item.width"
-					:height="item.height"
-					:title="item.title"
-				/>
+			<div v-if="isBatch === false && item" class="preview">
+				<file-preview :src="fileSrc" :mime="item.type" :width="item.width" :height="item.height" :title="item.title" />
 
-				<button v-if="isBatch === false && item" class="replace-toggle" @click="replaceFileDialogActive = true">
+				<button class="replace-toggle" @click="replaceFileDialogActive = true">
 					{{ t('replace_file') }}
 				</button>
 			</div>

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-list nav class="users-navigation">
-		<v-list-item to="/users" exact :active="currentRole === null">
+		<v-list-item to="/users" exact :active="!currentRole">
 			<v-list-item-icon><v-icon small name="folder_shared" /></v-list-item-icon>
 			<v-list-item-content>{{ t('all_users') }}</v-list-item-content>
 		</v-list-item>

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -181,7 +181,6 @@ import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
 import { useLayout } from '@cairncms/composables';
-import { Role } from '@cairncms/types';
 import { mergeFilters } from '@cairncms/utils';
 import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
 import useNavigation from '../composables/use-navigation';
@@ -191,13 +190,7 @@ type Item = {
 	[field: string]: any;
 };
 
-interface Props {
-	role?: string | null;
-}
-
-const props = withDefaults(defineProps<Props>(), {
-	role: null,
-});
+const props = defineProps<{ role?: string }>();
 
 const { t } = useI18n();
 
@@ -220,7 +213,7 @@ const { confirmDelete, deleting, batchDelete, batchEditActive } = useBatch();
 const { breadcrumb, title } = useBreadcrumb();
 
 const roleFilter = computed(() => {
-	if (props.role !== null) {
+	if (props.role) {
 		return {
 			_and: [
 				{
@@ -238,7 +231,7 @@ const roleFilter = computed(() => {
 const canInviteUsers = computed(() => {
 	if (serverStore.auth.disableDefault === true) return false;
 
-	const isAdmin = !!userStore.currentUser?.role?.admin_access;
+	const isAdmin = !!userStore.currentUser?.role.admin_access;
 	if (isAdmin) return true;
 
 	const usersCreatePermission = permissionsStore.permissions.find(
@@ -323,7 +316,7 @@ function useBreadcrumb() {
 
 	const title = computed(() => {
 		if (!props.role) return t('user_directory');
-		return roles.value?.find((role: Role) => role.id === props.role)?.name;
+		return roles.value?.find((role) => role.id === props.role)?.name;
 	});
 
 	return { breadcrumb, title };

--- a/app/src/panels/list/panel-list.vue
+++ b/app/src/panels/list/panel-list.vue
@@ -31,6 +31,7 @@ import api from '@/api';
 import { useFieldsStore } from '@/stores/fields';
 import { useInsightsStore } from '@/stores/insights';
 import { unexpectedError } from '@/utils/unexpected-error';
+import { getEndpoint } from '@cairncms/utils';
 
 const props = withDefaults(
 	defineProps<{
@@ -70,7 +71,7 @@ function cancelEdit() {
 
 async function saveEdits(item: Record<string, any>) {
 	try {
-		await api.patch(`/items/${props.collection}/${currentlyEditing.value}`, item);
+		await api.patch(`${getEndpoint(props.collection)}/${currentlyEditing.value}`, item);
 	} catch (err: any) {
 		unexpectedError(err);
 	}

--- a/app/src/views/private/components/users-invite.vue
+++ b/app/src/views/private/components/users-invite.vue
@@ -13,7 +13,7 @@
 						<div class="type-label">{{ t('emails') }}</div>
 						<v-textarea v-model="emails" :nullable="false" placeholder="admin@example.com, user@example.com..." />
 					</div>
-					<div v-if="role === null" class="field">
+					<div v-if="!role" class="field">
 						<div class="type-label">{{ t('role') }}</div>
 						<v-select v-model="roleSelected" :items="roles" />
 					</div>
@@ -32,7 +32,7 @@
 
 			<v-card-actions>
 				<v-button secondary @click="$emit('update:modelValue', false)">{{ t('cancel') }}</v-button>
-				<v-button :disabled="emails === null || emails.length === 0" :loading="loading" @click="inviteUsers">
+				<v-button :disabled="emails.length === 0" :loading="loading" @click="inviteUsers">
 					{{ t('invite') }}
 				</v-button>
 			</v-card-actions>
@@ -121,7 +121,7 @@ async function loadRoles() {
 			value: role.id,
 		}));
 
-	if (roles.value.length > 0 && roleSelected.value === null) {
+	if (roles.value.length > 0 && !roleSelected.value) {
 		roleSelected.value = roles.value[0].value;
 	}
 }


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Fixes three admin app correctness issues around file batch editing, user invites, and Insights list panel edits.

File batch edit no longer renders an empty preview box above the form. The user directory now correctly highlights All Users, and the invite dialog collects a role before submitting so user-directory invites can succeed. Insights list panels now save inline edits for system collections through the collection's correct API endpoint instead of the generic items endpoint.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
