### PR TITLE
Fix form field interface state handling

### DIFF
--- a/app/src/components/v-form/form-field-interface.test.ts
+++ b/app/src/components/v-form/form-field-interface.test.ts
@@ -46,7 +46,7 @@ function makeField(overrides: Record<string, any> = {}) {
 const interfaceInputStub = {
 	name: 'interface-input',
 	template: '<div class="interface-input-stub" />',
-	props: ['value', 'primaryKey'],
+	props: ['value', 'primaryKey', 'batchMode', 'batchActive'],
 };
 
 const rawEditorStub = {
@@ -154,5 +154,17 @@ describe('FormFieldInterface normalizes the value passed to the rendered interfa
 		const wrapper = mountField({ field: makeField() });
 
 		expect(wrapper.findComponent(interfaceInputStub).props('primaryKey')).toBeUndefined();
+	});
+
+	it('forwards batch mode state to the rendered interface', () => {
+		const wrapper = mountField({
+			field: makeField(),
+			batchMode: true,
+			batchActive: true,
+		});
+
+		const child = wrapper.findComponent(interfaceInputStub);
+		expect(child.props('batchMode')).toBe(true);
+		expect(child.props('batchActive')).toBe(true);
 	});
 });

--- a/app/src/components/v-form/form-field-interface.test.ts
+++ b/app/src/components/v-form/form-field-interface.test.ts
@@ -46,7 +46,7 @@ function makeField(overrides: Record<string, any> = {}) {
 const interfaceInputStub = {
 	name: 'interface-input',
 	template: '<div class="interface-input-stub" />',
-	props: ['value'],
+	props: ['value', 'primaryKey'],
 };
 
 const rawEditorStub = {
@@ -128,7 +128,7 @@ describe('FormFieldInterface normalizes the value passed to the rendered interfa
 		expect(wrapper.findComponent(interfaceInputStub).props('value')).toBe('operator-set');
 	});
 
-	it('routes the raw editor branch through the original inline expression, leaving the value undefined when neither modelValue nor default_value is set', () => {
+	it('resolves the raw editor value to null when modelValue is omitted and the schema has no default_value', () => {
 		const wrapper = mountField({
 			field: makeField(),
 			rawEditorEnabled: true,
@@ -137,6 +137,22 @@ describe('FormFieldInterface normalizes the value passed to the rendered interfa
 
 		const child = wrapper.findComponent(rawEditorStub);
 		expect(child.exists()).toBe(true);
-		expect(child.props('value')).toBeUndefined();
+		expect(child.props('value')).toBeNull();
+	});
+
+	it('passes the schema default_value to the raw editor when modelValue is omitted', () => {
+		const wrapper = mountField({
+			field: makeField({ schema: { default_value: 'fallback' } }),
+			rawEditorEnabled: true,
+			rawEditorActive: true,
+		});
+
+		expect(wrapper.findComponent(rawEditorStub).props('value')).toBe('fallback');
+	});
+
+	it('forwards an omitted primaryKey as undefined to the rendered interface', () => {
+		const wrapper = mountField({ field: makeField() });
+
+		expect(wrapper.findComponent(interfaceInputStub).props('primaryKey')).toBeUndefined();
 	});
 });

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -15,6 +15,8 @@
 				:disabled="disabled"
 				:loading="loading"
 				:value="value"
+				:batch-mode="batchMode"
+				:batch-active="batchActive"
 				:width="(field.meta && field.meta.width) || 'full'"
 				:type="field.type"
 				:collection="field.collection"

--- a/app/src/components/v-form/form-field-interface.vue
+++ b/app/src/components/v-form/form-field-interface.vue
@@ -14,7 +14,7 @@
 				:autofocus="disabled !== true && autofocus"
 				:disabled="disabled"
 				:loading="loading"
-				:value="interfaceValue"
+				:value="value"
 				:width="(field.meta && field.meta.width) || 'full'"
 				:type="field.type"
 				:collection="field.collection"
@@ -34,7 +34,7 @@
 
 		<interface-system-raw-editor
 			v-else-if="rawEditorEnabled && rawEditorActive"
-			:value="modelValue === undefined ? field.schema?.default_value : modelValue"
+			:value="value"
 			:type="field.type"
 			@input="$emit('update:modelValue', $event)"
 		/>
@@ -52,32 +52,23 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { FormField } from './types';
 
-interface Props {
-	field: FormField;
-	batchMode?: boolean;
-	batchActive?: boolean;
-	primaryKey?: string | number | null;
-	modelValue?: string | number | boolean | Record<string, any> | Array<any> | null;
-	loading?: boolean;
-	disabled?: boolean;
-	autofocus?: boolean;
-	rawEditorEnabled?: boolean;
-	rawEditorActive?: boolean;
-	direction?: string;
-}
-
-const props = withDefaults(defineProps<Props>(), {
-	batchMode: false,
-	batchActive: false,
-	primaryKey: null,
-	modelValue: undefined,
-	loading: false,
-	disabled: false,
-	autofocus: false,
-	rawEditorEnabled: false,
-	rawEditorActive: false,
-	direction: undefined,
-});
+const props = withDefaults(
+	defineProps<{
+		field: FormField;
+		batchMode?: boolean;
+		batchActive?: boolean;
+		primaryKey?: string | number | null;
+		modelValue?: string | number | boolean | Record<string, any> | Array<any> | null;
+		loading?: boolean;
+		disabled?: boolean;
+		autofocus?: boolean;
+		rawEditorEnabled?: boolean;
+		rawEditorActive?: boolean;
+		direction?: string;
+	}>(),
+	// an absent modelValue must resolve to undefined, not Vue's boolean-prop false cast
+	{ modelValue: undefined }
+);
 
 defineEmits(['update:modelValue', 'setFieldValue']);
 
@@ -96,12 +87,9 @@ const componentName = computed(() => {
 		: `interface-${getDefaultInterfaceForType(props.field.type!)}`;
 });
 
-const interfaceValue = computed(() => {
-	if (props.modelValue !== undefined) return props.modelValue;
-
-	const defaultValue = props.field.schema?.default_value;
-	return defaultValue === undefined ? null : defaultValue;
-});
+const value = computed(() =>
+	props.modelValue === undefined ? props.field.schema?.default_value ?? null : props.modelValue
+);
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Fixes two admin form-field interface correctness issues around raw editor defaults and batch-edit state.

The raw editor now receives the same normalized value as the rendered field interface: the current model value when present, otherwise the schema default, otherwise `null`. This keeps fields without a model value or schema default from forwarding `undefined` through the raw editor path, while preserving explicit falsy values such as `false`, `0`, and an empty string.

This also forwards batch-edit state into the rendered field interface component, so interface extensions can react to `batchMode` and `batchActive` the same way the surrounding form already can.

### Testing / verification

Added tests covering:
- rendered interfaces receive `null` when no model value or schema default exists
- falsy schema defaults and explicit model values pass through unchanged
- the raw editor receives `null` when no model value or schema default exists
- the raw editor receives the schema default when one exists
- omitted primary keys forward as `undefined`
- rendered interfaces receive `batchMode` and `batchActive`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
