### PR TITLE
Compare columns sanitized only during snapshot application

### DIFF
--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -3,12 +3,26 @@ import knex from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import type { MockedFunction } from 'vitest';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { cleanupPermissionsOnFieldDelete } from './fields.js';
+import { cleanupPermissionsOnFieldDelete, FieldsService } from './fields.js';
+import { sanitizeColumn } from '../utils/sanitize-schema.js';
 
 vi.mock('../../src/database/index', () => ({
 	__esModule: true,
 	default: vi.fn(),
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('@cairncms/schema', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@cairncms/schema')>();
+
+	return {
+		...actual,
+		createInspector: vi.fn().mockReturnValue({ columnInfo: vi.fn() }),
+	};
+});
+
+vi.mock('../utils/get-schema.js', () => ({
+	getSchema: vi.fn().mockResolvedValue({ collections: {}, relations: [] }),
 }));
 
 describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
@@ -115,7 +129,7 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 		expect(updates.length).toBe(0);
 	});
 
-	it('does not modify a permission row when only filter JSON or presets reference the deleted field (Decision #12)', async () => {
+	it('does not modify a permission row when only filter JSON or presets reference the deleted field', async () => {
 		tracker.on.select('select "id", "fields" from "directus_permissions" where "collection" = ?').response([
 			{
 				id: 42,
@@ -136,5 +150,110 @@ describe('cleanupPermissionsOnFieldDelete (GHSA-9x5g-62gj-wqf2)', () => {
 		await cleanupPermissionsOnFieldDelete(trx, 'articles', 'secret');
 
 		expect(updates.length).toBe(0);
+	});
+});
+
+describe('updateField column comparison basis', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+	let ddl: string[];
+
+	const fullColumn = {
+		name: 'country_id',
+		table: 'articles',
+		data_type: 'integer',
+		default_value: null,
+		max_length: null,
+		numeric_precision: 32,
+		numeric_scale: 0,
+		is_nullable: true,
+		is_unique: false,
+		is_primary_key: false,
+		is_generated: false,
+		generation_expression: null,
+		has_auto_increment: false,
+		foreign_key_table: 'countries',
+		foreign_key_column: 'id',
+		comment: '',
+	};
+
+	const schema = {
+		collections: {
+			articles: {
+				collection: 'articles',
+				primary: 'id',
+				singleton: false,
+				note: null,
+				sortField: null,
+				accountability: 'all',
+				fields: {
+					country_id: {
+						field: 'country_id',
+						type: 'integer',
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						precision: 32,
+						scale: 0,
+						special: [],
+						note: null,
+						dbType: 'integer',
+						alias: false,
+						validation: null,
+					},
+				},
+			},
+		},
+		relations: [],
+	};
+
+	const snapshotOpts = { bypassLimits: true, autoPurgeSystemCache: false };
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	async function runUpdate(fieldSchema: Record<string, any>, opts?: Record<string, any>) {
+		ddl = [];
+
+		tracker.on.any(/alter table/i).response((q) => {
+			ddl.push(q.sql);
+			return [];
+		});
+
+		const service = new FieldsService({ knex: db as unknown as Knex, schema: schema as any });
+
+		(service as any).schemaInspector = {
+			columnInfo: vi.fn().mockResolvedValue({ ...fullColumn }),
+		};
+
+		await service.updateField(
+			'articles',
+			{ collection: 'articles', field: 'country_id', type: 'integer', schema: fieldSchema } as any,
+			opts as any
+		);
+	}
+
+	it('does not alter the table when a round-tripped payload matches the full column', async () => {
+		await runUpdate({ ...fullColumn });
+
+		expect(ddl.length).toBe(0);
+	});
+
+	it('does not alter the table when snapshot application supplies the sanitized column shape', async () => {
+		await runUpdate(sanitizeColumn({ ...fullColumn } as any), snapshotOpts);
+
+		expect(ddl.length).toBe(0);
+	});
+
+	it('compares against the sanitized column during snapshot application', async () => {
+		await runUpdate({ ...fullColumn }, snapshotOpts);
+
+		expect(ddl.length).toBeGreaterThan(0);
 	});
 });

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -399,7 +399,12 @@ export class FieldsService {
 			if (hookAdjustedField.schema) {
 				const existingColumn = await this.schemaInspector.columnInfo(collection, hookAdjustedField.field);
 
-				if (!isEqual(sanitizeColumn(existingColumn), hookAdjustedField.schema)) {
+				// Snapshot application passes bypassLimits with autoPurgeSystemCache disabled and carries
+				// sanitized schema payloads, so only that path compares against the sanitized column
+				const columnToCompare =
+					opts?.bypassLimits && opts.autoPurgeSystemCache === false ? sanitizeColumn(existingColumn) : existingColumn;
+
+				if (!isEqual(columnToCompare, hookAdjustedField.schema)) {
 					try {
 						await this.knex.schema.alterTable(collection, (table) => {
 							if (!hookAdjustedField.schema) return;

--- a/tests/blackbox/routes/fields/change-fields.test.ts
+++ b/tests/blackbox/routes/fields/change-fields.test.ts
@@ -234,6 +234,36 @@ describe.each(common.PRIMARY_KEY_TYPES)('/fields', (pkType) => {
 					);
 				});
 			});
+
+			describe('can update meta only without schema changes for relational field', () => {
+				it.each(vendors)('%s', async (vendor) => {
+					// Setup
+					const fieldName = 'country_id';
+
+					const payload = (
+						await request(getUrl(vendor))
+							.get(`/fields/${localCollectionStates}/${fieldName}`)
+							.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`)
+					).body.data;
+
+					payload.meta.options = { template: 'updated' };
+
+					// Action
+					const response = await request(getUrl(vendor))
+						.patch(`/fields/${localCollectionStates}/${fieldName}`)
+						.send(payload)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					const response2 = await request(getUrl(vendor))
+						.get(`/fields/${localCollectionStates}/${fieldName}`)
+						.set('Authorization', `Bearer ${common.USER.ADMIN.TOKEN}`);
+
+					// Assert
+					expect(response.statusCode).toEqual(200);
+					expect(response2.statusCode).toEqual(200);
+					expect(response2.body.data).toEqual(payload);
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Reduces spurious column alters when updating field metadata through the admin API.

Field reads return a full schema object, while schema snapshots carry a sanitized schema shape. The field update service previously compared every update payload against the sanitized shape, which meant a round-tripped field payload with extra column properties could look different even when the database column had not changed. For relational fields, that could trigger unnecessary DDL while saving metadata-only changes such as display options.

This PR keeps sanitized column comparison for snapshot application, where the payload is sanitized, and uses the full inspected column for normal field updates. The change is limited to the comparison basis that decides whether DDL should run. It does not change field metadata writes, API authorization, permissions, auth, storage, redirects, token handling, logging, or platform security boundaries.

### Testing / verification

Added tests covering:
- normal field updates do not alter the table when the payload schema matches the full inspected column
- snapshot-style field updates do not alter the table when the payload schema matches the sanitized inspected column
- snapshot-style field updates still compare against the sanitized column shape
- relational field metadata can be updated without a schema change

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
