### PR TITLE
Return validation errors for unknown filter and sort fields

### DIFF
--- a/api/src/utils/apply-query.test.ts
+++ b/api/src/utils/apply-query.test.ts
@@ -2,7 +2,7 @@ import type { Accountability, Aggregate, Permission, SchemaOverview } from '@cai
 import knex from 'knex';
 import { describe, expect, it } from 'vitest';
 import { InvalidQueryException } from '../exceptions/invalid-query.js';
-import applyQuery, { applySearch, applySort, validateGroupOperands } from './apply-query.js';
+import applyQuery, { applyFilter, applySearch, applySort, validateGroupOperands } from './apply-query.js';
 
 const PUBLIC_ROLE_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -377,6 +377,62 @@ describe('applySort — unknown column validation', () => {
 
 		it('accepts multiple known fields', () => {
 			expect(() => callApplySort(['title', '-rank'])).not.toThrow();
+		});
+	});
+});
+
+describe('applyFilter — unknown field validation', () => {
+	function callApplyFilter(filter: Record<string, any>) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applyFilter(knexInstance, makeRelationalSchema(), dbQuery, filter, 'notes', {});
+	}
+
+	describe('bug-exposing — unknown filter fields raise InvalidQueryException', () => {
+		it('throws InvalidQueryException for an unknown top-level filter key', () => {
+			expect(() => callApplyFilter({ nonexistent: { _eq: 'x' } })).toThrow(InvalidQueryException);
+		});
+
+		it('throws InvalidQueryException for an unknown key nested under a relation', () => {
+			expect(() => callApplyFilter({ author: { nonexistent: { _eq: 'x' } } })).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the unknown key', () => {
+			expect(() => callApplyFilter({ nonexistent: { _eq: 'x' } })).toThrow(/nonexistent/);
+		});
+	});
+
+	describe('regression — valid filters continue to apply', () => {
+		it('accepts a known top-level field filter', () => {
+			expect(() => callApplyFilter({ title: { _eq: 'hello' } })).not.toThrow();
+		});
+
+		it('accepts a known nested relational field filter', () => {
+			expect(() => callApplyFilter({ author: { name: { _eq: 'Ada' } } })).not.toThrow();
+		});
+	});
+});
+
+describe('applySort — nested relational sort validation', () => {
+	function callApplySort(sort: string[]) {
+		const dbQuery = makeBuilder();
+		const knexInstance = knex.default({ client: 'sqlite3', useNullAsDefault: true });
+		return applySort(knexInstance, makeRelationalSchema(), dbQuery, sort, 'notes', {});
+	}
+
+	describe('bug-exposing — unknown nested sort targets raise InvalidQueryException', () => {
+		it('throws InvalidQueryException for an unknown field on the related collection', () => {
+			expect(() => callApplySort(['author.nonexistent'])).toThrow(InvalidQueryException);
+		});
+
+		it('error message names the unknown sort target', () => {
+			expect(() => callApplySort(['author.nonexistent'])).toThrow(/nonexistent/);
+		});
+	});
+
+	describe('regression — valid nested sorts continue to work', () => {
+		it('accepts a known field on the related collection', () => {
+			expect(() => callApplySort(['author.name'])).not.toThrow();
 		});
 	});
 });

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -337,6 +337,10 @@ export function applySort(
 		const targetFieldName = stripFunction(field!);
 		const targetFieldMeta = schema.collections[targetCollection]?.fields?.[targetFieldName];
 
+		if (!targetFieldMeta) {
+			throw new InvalidQueryException(`Invalid sort column "${targetFieldName}"`);
+		}
+
 		if ((targetFieldMeta?.special as string[] | undefined)?.includes('conceal')) {
 			throw new InvalidQueryException(
 				`Sort operand "${targetFieldName}" is concealed and cannot be used as a sort field.`
@@ -411,7 +415,7 @@ export function applyFilter(
 
 			if (
 				filterPath.length > 1 ||
-				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]!.fields[key]!.type === 'alias')
+				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]?.fields[key]?.type === 'alias')
 			) {
 				const hasMultiRelational = addJoin({
 					path: filterPath,
@@ -468,7 +472,7 @@ export function applyFilter(
 
 			if (
 				filterPath.length > 1 ||
-				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]!.fields[key]!.type === 'alias')
+				(!(key.includes('(') && key.includes(')')) && schema.collections[collection]?.fields[key]?.type === 'alias')
 			) {
 				if (!relation) continue;
 

--- a/api/src/utils/get-column-path.ts
+++ b/api/src/utils/get-column-path.ts
@@ -71,7 +71,7 @@ export function getColumnPath({ path, collection, aliasMap, relations, schema }:
 			// Nested level alias field
 			else if (
 				remainingParts.length === 1 &&
-				schema.collections[parent]!.fields[remainingParts[0]!]!.type === 'alias'
+				schema.collections[parent]?.fields[remainingParts[0]!]?.type === 'alias'
 			) {
 				remainingParts.push(schema.collections[relation!.related_collection!]!.primary);
 				addNestedPkField = schema.collections[relation!.related_collection!]!.primary;


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Unknown filter keys could crash query building before the existing validation path had a chance to run. Top-level unknown filters and nested relational unknown filters both surfaced as internal errors with raw exception text instead of the intended validation error.

This PR routes unknown filter keys through the existing `Invalid filter key` handling by making alias checks tolerate missing fields. It also closes the sibling nested relational path in column-path resolution, where the same missing-field dereference existed before filter validation.

Because that column-path helper is shared with relational sorting, this PR also adds the matching sort-side guard after path resolution. Unknown nested sort targets now fail with the same `Invalid sort column` shape used by top-level sort validation instead of reaching an internal error or database-level failure.

### Testing / verification

Added tests covering:
- unknown top-level filter keys raise `InvalidQueryException`
- unknown nested relational filter keys raise `InvalidQueryException`
- unknown filter errors name the offending key
- valid top-level and nested relational filters still apply
- unknown nested relational sort targets raise `InvalidQueryException`
- valid nested relational sorts still apply

Also verified against a live instance and confirmed:
- top-level unknown filters return 400 instead of 500
- nested unknown relational filters return 400 instead of 500
- nested unknown relational sorts return 400 instead of 500
- valid filters, relational filters, nested sorts, and alias-field filters continue to return 200

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
