### PR TITLE
Harden extension entrypoint generation and fix payload test mock

### DIFF
--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -8,6 +8,7 @@ import { getHelpers } from '../../src/database/helpers/index.js';
 import { PayloadService } from '../../src/services/index.js';
 
 vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
 }));
 

--- a/packages/utils/node/generate-extensions-entrypoint.test.ts
+++ b/packages/utils/node/generate-extensions-entrypoint.test.ts
@@ -342,5 +342,31 @@ describe('generateExtensionsEntrypoint', () => {
 
 			warn.mockRestore();
 		});
+
+		it('escapes line separators in names and specifiers so the generated literal stays valid', async () => {
+			const u2028 = String.fromCharCode(0x2028);
+			const u2029 = String.fromCharCode(0x2029);
+
+			writeFileSync(path.join(dir, 'good.mjs'), 'export default { id: "good" };');
+
+			const extensions: Extension[] = [
+				{ path: dir, name: `evil${u2028}${u2029}"\nname`, type: 'display', entrypoint: 'good.mjs', local: true },
+				{ path: dir, name: 'pathy', type: 'display', entrypoint: `nope${u2028}.mjs`, local: true },
+			];
+
+			const source = generateExtensionsEntrypoint(extensions);
+
+			// A raw separator would terminate the string literal, so neither reaches the source.
+			expect(source).not.toContain(u2028);
+			expect(source).not.toContain(u2029);
+			// They are emitted as escapes instead, from both the name and the import specifier.
+			expect(source).toContain('\\u2028');
+			expect(source).toContain('\\u2029');
+
+			// The generated module still parses and the valid extension loads (the bad-path one is skipped).
+			const mod = await evaluate(extensions);
+			await mod.ready;
+			expect(mod.displays).toEqual([{ id: 'good' }]);
+		});
 	});
 });

--- a/packages/utils/node/generate-extensions-entrypoint.ts
+++ b/packages/utils/node/generate-extensions-entrypoint.ts
@@ -7,6 +7,19 @@ import { pathToRelativeUrl } from './path-to-relative-url.js';
 
 const APP_OR_HYBRID_TYPES = [...APP_EXTENSION_TYPES, ...HYBRID_EXTENSION_TYPES];
 
+// U+2028 and U+2029 terminate a string literal in older engines, and JSON.stringify leaves them raw.
+const LINE_SEPARATORS = new RegExp(`[${String.fromCharCode(0x2028, 0x2029)}]`, 'g');
+
+/**
+ * Serialize a string as a JS string literal for the generated entrypoint, escaping the line
+ * separators JSON.stringify leaves raw. Manifest names and entrypoint paths reach the generated
+ * code from extension package.json, which the manifest schema validates only as a string, so every
+ * embedded literal is emitted through here.
+ */
+function jsString(value: string): string {
+	return JSON.stringify(value).replace(LINE_SEPARATORS, (char) => `\\u${char.charCodeAt(0).toString(16)}`);
+}
+
 // Emitted once when there is at least one extension to load. Each extension is
 // imported dynamically inside loadExtension's try/catch and registered inside a
 // per-extension try/catch, so one extension that throws while evaluating or
@@ -64,7 +77,7 @@ export function generateExtensionsEntrypoint(extensions: Extension[]): string {
 			loads.push({
 				name: extension.name,
 				specifier: `./${entry}`,
-				push: (ref) => `pushConfig(${JSON.stringify(extension.name)}, ${pluralize(type)}, ${ref}.default);`,
+				push: (ref) => `pushConfig(${jsString(extension.name)}, ${pluralize(type)}, ${ref}.default);`,
 			});
 		}
 	}
@@ -79,22 +92,20 @@ export function generateExtensionsEntrypoint(extensions: Extension[]): string {
 			specifier: `./${entry}`,
 			push: (ref) =>
 				appTypes
-					.map(
-						(type) => `pushEntries(${JSON.stringify(extension.name)}, ${pluralize(type)}, ${ref}.${pluralize(type)});`
-					)
+					.map((type) => `pushEntries(${jsString(extension.name)}, ${pluralize(type)}, ${ref}.${pluralize(type)});`)
 					.join(''),
 		});
 	}
 
 	const promiseAll = `Promise.all([${loads
-		.map((load) => `loadExtension(${JSON.stringify(load.name)}, () => import(${JSON.stringify(load.specifier)}))`)
+		.map((load) => `loadExtension(${jsString(load.name)}, () => import(${jsString(load.specifier)}))`)
 		.join(',')}])`;
 
 	const thenBody = loads
 		.map(
 			(load, i) =>
 				`if (mods[${i}]) { try { ${load.push(`mods[${i}]`)} } catch (error) { ` +
-				`console.warn('Failed to register extension ' + ${JSON.stringify(load.name)}, error); } }`
+				`console.warn('Failed to register extension ' + ${jsString(load.name)}, error); } }`
 		)
 		.join('');
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Fixes two post-merge issues from the confined-runtime integration.

In particular, the payload service test mock now matches the database module shape used by the merged code and the app-extension entrypoint generator now safely emits all extension-controlled strings as JavaScript string literals.

### Testing / verification

Added a generator regression test covering hostile manifest values:

- extension name containing a quote, newline, `U+2028`, and `U+2029`
- entrypoint specifier containing `U+2028`
- generated source contains no raw line separators
- generated source contains escaped `\\u2028` and `\\u2029`
- the generated module still parses and loads the valid extension while skipping the bad-path extension

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
