### PR TITLE
Extension documentation updates

### DIFF
--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -248,7 +248,7 @@ const result = await client.request(customEndpoint<MyResponse>({
 }));
 ```
 
-Useful for endpoints exposed by [custom extensions](/docs/develop/extensions/endpoints/) where a typed command does not exist.
+Useful for endpoints exposed by [custom extensions](/docs/develop/extensions/server-extensions/endpoints/) where a typed command does not exist.
 
 ### `withOptions`
 

--- a/docs/api/system-collections/flows.md
+++ b/docs/api/system-collections/flows.md
@@ -140,6 +140,6 @@ The bespoke `/flows/trigger/<id>` endpoint is REST-only. There is no GraphQL equ
 ## Where to go next
 
 - [Flows](/docs/guides/flows/) — operator-facing reference for designing flows, the trigger types, and the operation catalog.
-- [Operations](/docs/develop/extensions/operations/) — building custom operations as extensions.
-- [Hooks](/docs/develop/extensions/hooks/) — the lower-level event surface that flows are built on top of.
+- [Operations](/docs/develop/extensions/server-extensions/operations/) — building custom operations as extensions.
+- [Hooks](/docs/develop/extensions/server-extensions/hooks/) — the lower-level event surface that flows are built on top of.
 - [Filters and queries](/docs/api/filters-and-queries/) — the query DSL for filtering flow and operation lists.

--- a/docs/api/system-collections/insights-and-ui.md
+++ b/docs/api/system-collections/insights-and-ui.md
@@ -119,6 +119,6 @@ The notification email side effect fires on the GraphQL mutation just as it does
 ## Where to go next
 
 - [Insights](/docs/guides/insights/) — operator-side reference for designing dashboards and configuring panel types.
-- [Panels](/docs/develop/extensions/panels/) — building custom panel types as extensions.
+- [Panels](/docs/develop/extensions/app-extensions/panels/) — building custom panel types as extensions.
 - [Filters and queries](/docs/api/filters-and-queries/) — the query DSL stored in panel `options` fields and used to filter notification feeds.
 - [Email templates](/docs/develop/email-templates/) — customizing the notification email template.

--- a/docs/api/system-collections/platform-and-utilities.md
+++ b/docs/api/system-collections/platform-and-utilities.md
@@ -119,17 +119,58 @@ GET /extensions
       "version": "1.2.0"
     },
     {
+      "name": "shout-operation",
+      "type": "operation",
+      "local": true,
+      "status": "loaded",
+      "runtime": "confined-server",
+      "capabilities": { "log": true, "items": "current-user" }
+    },
+    {
+      "name": "metrics-bundle",
+      "type": "bundle",
+      "local": true,
+      "status": "partial",
+      "runtime": "confined-server",
+      "entries": [
+        { "name": "metric-card", "type": "panel", "status": "loaded" },
+        {
+          "name": "metric-feed",
+          "type": "endpoint",
+          "status": "failed",
+          "reason": { "code": "route-collision", "detail": "the confined endpoint route is already registered" },
+          "capabilities": { "endpoint": { "access": "authenticated" }, "request": { "urls": ["https://api.example.com"], "methods": ["GET"] } }
+        }
+      ]
+    },
+    {
       "name": "broken-endpoint",
       "type": "endpoint",
       "local": true,
       "status": "failed",
       "reason": { "code": "ENTRYPOINT_NOT_FOUND", "detail": "Cannot find the extension entrypoint." }
     }
-  ]
+  ],
+  "meta": {
+    "confinedRuntime": {
+      "state": "available",
+      "posture": {
+        "mode": "auto",
+        "decision": "run",
+        "applied": ["network-namespace", "permission-model"],
+        "missing": ["cgroup-memory"],
+        "cgroupMechanic": null
+      }
+    }
+  }
 }
 ```
 
-Each entry has `name`, `type`, `local`, and `status`. A server extension that registered into the API has status `loaded`. An app extension that was found and built into the app bundle has status `discovered`, since it runs in the browser rather than the server. An extension that errored during discovery, build, or registration has status `failed` and carries a `reason` object with a stable `code` and a `detail` that has been run through the platform's error redaction, so the diagnostics never expose raw paths or secrets from the underlying error. The optional `version` and `entries` fields appear when available.
+Each row has `name`, `type`, `local`, and `status`. A server extension that registered into the API has status `loaded`. An app extension that was found and built into the app bundle has status `discovered`, since it runs in the browser rather than the server. An extension that errored during discovery, build, or registration has status `failed` and carries a `reason` object with a stable `code` and a `detail` that has been run through the platform's error redaction, so the diagnostics never expose raw paths or secrets from the underlying error. A bundle whose entries did not all load has status `partial`.
+
+A confined (sandboxed) extension also carries `runtime: "confined-server"` and the `capabilities` it declared. A bundle lists its nested extensions under `entries`, each with its own `name`, `type`, `status`, optional `reason`, and `capabilities`. The optional `version` field appears when available.
+
+The `meta.confinedRuntime` object reports the global confined-runtime state (`not-required`, `available`, or `unavailable`) and, when available, the resolved OS hardening `posture`: the `mode` (`auto` or `required`), the `decision` (`run` or `refuse`), the hardening layers `applied` and `missing`, and the `cgroupMechanic` in use.
 
 This is the only `/extensions` route that requires authentication. The source route below is reachable without a token.
 

--- a/docs/develop/email-templates.md
+++ b/docs/develop/email-templates.md
@@ -132,5 +132,5 @@ A flow that sends this template would set:
 ## Where to go next
 
 - [Configuration](/docs/manage/configuration/) covers `EXTENSIONS_PATH`, `EMAIL_FROM`, and the broader email transport configuration.
-- [Operations](/docs/develop/extensions/operations/) covers custom flow operations if you want a richer API for sending email than the built-in Send Email operation provides.
+- [Operations](/docs/develop/extensions/server-extensions/operations/) covers custom flow operations if you want a richer API for sending email than the built-in Send Email operation provides.
 - [Custom migrations](/docs/develop/custom-migrations/) is the other convention-based developer customization path documented here.

--- a/docs/develop/extensions/app-extensions/composables.md
+++ b/docs/develop/extensions/app-extensions/composables.md
@@ -1,0 +1,79 @@
+---
+title: Composables
+description: The Vue composables the SDK provides for app extensions.
+sidebar:
+  label: Composables
+  order: 7
+---
+
+App extensions are Vue components, and the SDK ships a set of composables for what an extension commonly needs: calling the API as the current user, reading collection metadata, fetching items, and reaching the admin app's stores. Import them from `@cairncms/extensions-sdk`.
+
+## useApi
+
+```ts
+import { useApi } from '@cairncms/extensions-sdk';
+
+const api = useApi();
+const response = await api.get('/items/articles');
+```
+
+`useApi()` returns an Axios instance wired to the admin app's session. Requests carry the logged-in user's credentials and go to the same API the app uses, so an app extension reads and writes exactly what the current user is permitted to. This is the primary way an app extension talks to the API.
+
+## useStores
+
+```ts
+import { useStores } from '@cairncms/extensions-sdk';
+
+const { useCollectionsStore, useFieldsStore, usePermissionsStore } = useStores();
+const collections = useCollectionsStore();
+```
+
+`useStores()` returns the admin app's Pinia store accessors. Use them for app state that is not a plain API call: the collections and fields stores for schema metadata, the permissions store to check the current user's access, and the others the app exposes. Each accessor is a Pinia store hook.
+
+## useCollection
+
+```ts
+import { useCollection } from '@cairncms/extensions-sdk';
+
+const { info, fields, primaryKeyField } = useCollection('articles');
+```
+
+`useCollection(collection)` takes a collection name (a string or a ref) and returns reactive metadata about it: `info` (the collection record), `fields`, `defaults`, and `primaryKeyField`. Use it when a component needs a collection's shape without fetching its items.
+
+## useItems
+
+```ts
+import { useItems } from '@cairncms/extensions-sdk';
+import { ref } from 'vue';
+
+const collection = ref('articles');
+const query = {
+  fields: ref(['id', 'title']),
+  limit: ref(25),
+  sort: ref(['title']),
+  search: ref(null),
+  filter: ref(null),
+  page: ref(1),
+};
+
+const { items, totalCount, getItems } = useItems(collection, query);
+await getItems();
+```
+
+`useItems(collection, query)` fetches items with pagination. It takes a collection ref and a query object whose `fields`, `limit`, `sort`, `search`, `filter`, and `page` are each their own ref, and returns the reactive `items`, `totalPages`, `itemCount`, and `totalCount`, plus `getItems()`, `getItemCount()`, and `getTotalCount()` to run or rerun the fetch. It is the composable layouts and panels build on.
+
+## The rest
+
+The SDK also re-exports:
+
+- **`useSync`** — wraps a prop and its `update:` event into a writable computed, the standard way to make a prop two-way inside a component.
+- **`useLayout`** — resolves a registered layout by id, used when one extension hosts another's layout.
+- **`useFilterFields`** — derives the set of fields a filter applies to.
+- **`useExtensions`** — returns the reactive registry of loaded app extensions.
+
+Import any of them from `@cairncms/extensions-sdk`.
+
+## Where to go next
+
+- [App extensions](/docs/develop/extensions/app-extensions/) covers the browser lane and the runtime model.
+- The individual type pages show these composables in context.

--- a/docs/develop/extensions/app-extensions/displays.md
+++ b/docs/develop/extensions/app-extensions/displays.md
@@ -2,6 +2,7 @@
 title: Display extensions
 description: Custom read-only field renderers for the admin app.
 sidebar:
+  label: Displays
   order: 3
 ---
 
@@ -10,6 +11,8 @@ A display is the read-only counterpart to an interface. Where an interface is th
 CairnCMS ships built-in displays (raw, formatted value, datetime, color, image, filesize, and so on); a display extension adds a new one.
 
 A display extension has two parts: a configuration object that registers the display with the app, and a Vue component that renders the value. Both live inside a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/).
+
+Like every app extension, a display runs unsandboxed in the admin browser under the logged-in user's permissions. See [App extensions](/docs/develop/extensions/app-extensions/) for the runtime model, the Vue baseline, and browser egress.
 
 ## Anatomy
 
@@ -214,5 +217,5 @@ Build with `npm run build`, then install or symlink the package into a CairnCMS 
 
 ## Where to go next
 
-- [Interfaces](/docs/develop/extensions/interfaces/) cover the editing-side counterpart — how a field's value is captured.
+- [Interfaces](/docs/develop/extensions/app-extensions/interfaces/) cover the editing-side counterpart — how a field's value is captured.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/app-extensions/index.md
+++ b/docs/develop/extensions/app-extensions/index.md
@@ -1,0 +1,41 @@
+---
+title: App extensions
+description: The browser lane, Vue components that run in the admin app under the logged-in user's permissions.
+sidebar:
+  label: Overview
+  order: 0
+---
+
+App extensions extend the admin app. They are written as Vue components and run in the browser, in the same page as the rest of the admin app. There are five types: interface, display, layout, module, and panel.
+
+## How app extensions run
+
+An app extension runs inside the logged-in user's browser session. When it reads or writes data, it calls the API as that user, so it can do whatever that user can do through the API, and no more. The browser is not a security boundary: the code, the admin app, and the user's session all share the same page. An app extension is as capable as the person running it.
+
+That makes the app lane the wrong place for anything that must hold regardless of who is signed in. Logic that has to be enforced, secrets that must not reach the browser, and access beyond the current user's permissions belong on the server. See [Server extensions](/docs/develop/extensions/server-extensions/), and the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) when that server code should be confined.
+
+## Browser egress
+
+Because an app extension runs in the browser, its outbound network requests go through the admin app's Content Security Policy. The default policy limits `connect-src` to the app's own origin plus the built-in map origins, with no external wildcard, so an app extension that tries to fetch an external API or CDN directly from the browser is blocked.
+
+To use external data, route it through a same-origin endpoint instead. A confined server endpoint, or a bundle's endpoint entry, fetches the external API server-side, and your app extension calls that endpoint on its own origin. This keeps the browser egress and the declared external origins on the server. A confined endpoint cannot hold a secret in this version, so a call that needs a secret belongs in a full-authority endpoint or a confined operation with `optionDelivery`. An operator can widen the policy with `CONTENT_SECURITY_POLICY_DIRECTIVES__CONNECT_SRC` when a specific external origin must be reachable from the browser, but the same-origin endpoint is the default pattern. See [Security hardening](/docs/manage/security-hardening/) for the operator side.
+
+## The Vue baseline
+
+App extensions share the admin app's Vue runtime rather than bundling their own. The host Vue is the floor an app extension builds against, and `vue` is a shared dependency, so an extension binds to the host's version at build time.
+
+The practical consequence: when the host Vue or the SDK changes, rebuild the extension. A `dist` built against an older toolchain can fail to mount against a newer host runtime. Building against the current SDK keeps the artifact aligned with the host.
+
+## The types
+
+- **[Interface](/docs/develop/extensions/app-extensions/interfaces/)** is a custom field editing widget. Use this to add new ways to enter or edit data on the item form.
+- **[Display](/docs/develop/extensions/app-extensions/displays/)** is a custom read-only renderer for a field. Use this for a different way to show a value in lists, tables, and detail views without changing how it is edited.
+- **[Layout](/docs/develop/extensions/app-extensions/layouts/)** is a custom collection page layout, alongside the built-in Table, Cards, Calendar, Map, and Kanban.
+- **[Module](/docs/develop/extensions/app-extensions/modules/)** is a top-level area in the module bar. Use this when you need an entire workspace that does not fit into the existing modules.
+- **[Panel](/docs/develop/extensions/app-extensions/panels/)** is a custom panel type for Insights dashboards.
+
+## Where to go next
+
+- The type pages above cover each app type's API, file structure, and a minimal example.
+- [Composables](/docs/develop/extensions/app-extensions/composables/) covers the SDK composables for data and stores. [UI components](/docs/develop/extensions/app-extensions/ui-components/) covers the component library and theme tokens.
+- [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain: scaffold, build, install, hot reload, debug, publish.

--- a/docs/develop/extensions/app-extensions/interfaces.md
+++ b/docs/develop/extensions/app-extensions/interfaces.md
@@ -2,12 +2,15 @@
 title: Interface extensions
 description: Custom field editing widgets for the admin app.
 sidebar:
+  label: Interfaces
   order: 2
 ---
 
 An interface is the editing widget for a field — what users see and interact with when entering or modifying a value on the item form. CairnCMS ships a long list of built-in interfaces (input, dropdown, datetime, tags, color, and so on); a custom interface adds a new one.
 
 An interface extension has two parts: a configuration object that registers the interface with the app, and a Vue component that renders the editing UI. Both live inside a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/).
+
+Like every app extension, an interface runs unsandboxed in the admin browser under the logged-in user's permissions. See [App extensions](/docs/develop/extensions/app-extensions/) for the runtime model, the Vue baseline, and browser egress.
 
 ## Anatomy
 
@@ -162,5 +165,5 @@ Build with `npm run build`, then install the resulting package or symlink it int
 
 ## Where to go next
 
-- [Displays](/docs/develop/extensions/displays/) cover the read-only counterpart — how a field's value is rendered in non-edit contexts like list rows.
+- [Displays](/docs/develop/extensions/app-extensions/displays/) cover the read-only counterpart — how a field's value is rendered in non-edit contexts like list rows.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full, including how to install and reload extensions during development.

--- a/docs/develop/extensions/app-extensions/layouts.md
+++ b/docs/develop/extensions/app-extensions/layouts.md
@@ -2,12 +2,15 @@
 title: Layout extensions
 description: Custom collection page layouts for the admin app.
 sidebar:
+  label: Layouts
   order: 4
 ---
 
-A layout controls how items in a collection are browsed in the app. CairnCMS ships built-in layouts (Tabular, Cards, Calendar, Map); a layout extension adds a new one.
+A layout controls how items in a collection are browsed in the app. CairnCMS ships built-in layouts (Tabular, Cards, Calendar, Map, Kanban); a layout extension adds a new one.
 
 A layout is the most structurally complex of the app extensions. It has four Vue components — a main component plus three slots — and a `setup` function that builds shared state for all of them. All five live inside a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/).
+
+Like every app extension, a layout runs unsandboxed in the admin browser under the logged-in user's permissions. See [App extensions](/docs/develop/extensions/app-extensions/) for the runtime model, the Vue baseline, and browser egress.
 
 ## Anatomy
 
@@ -65,6 +68,7 @@ The fields available on a layout configuration object:
 - **`setup`** — a function that builds shared state for all four components. Receives the standard layout props as the first argument and a context object (with `emit`) as the second. Returns an object whose properties are merged into every component's props.
 - **`smallHeader`** — when `true`, the page header is rendered in a more compact style.
 - **`headerShadow`** — when `false`, the drop shadow under the header is suppressed. Useful when the layout has its own header treatment.
+- **`sidebarShadow`** — when `false`, the drop shadow on the layout sidebar is suppressed.
 
 ## The setup function
 
@@ -215,6 +219,6 @@ Build with `npm run build`, then install or symlink the package into a CairnCMS 
 
 ## Where to go next
 
-- [Interfaces](/docs/develop/extensions/interfaces/) and [Displays](/docs/develop/extensions/displays/) cover field-level customization.
-- [Modules](/docs/develop/extensions/modules/) cover entirely new top-level workspaces, beyond the scope of one collection.
+- [Interfaces](/docs/develop/extensions/app-extensions/interfaces/) and [Displays](/docs/develop/extensions/app-extensions/displays/) cover field-level customization.
+- [Modules](/docs/develop/extensions/app-extensions/modules/) cover entirely new top-level workspaces, beyond the scope of one collection.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/app-extensions/modules.md
+++ b/docs/develop/extensions/app-extensions/modules.md
@@ -2,6 +2,7 @@
 title: Module extensions
 description: Custom top-level modules for the module bar.
 sidebar:
+  label: Modules
   order: 5
 ---
 
@@ -10,6 +11,8 @@ A module is a top-level area of the admin app. CairnCMS ships six built-in modul
 Modules are the broadest extension type. Where an interface affects a single field and a layout affects a single collection page, a module is an entire workspace with its own routes, navigation, and page structure. Reach for a module when none of the existing surfaces fit and you need a custom area inside the app.
 
 A module extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). It registers a set of routes, each rendered by a Vue component.
+
+Like every app extension, a module runs unsandboxed in the admin browser under the logged-in user's permissions. See [App extensions](/docs/develop/extensions/app-extensions/) for the runtime model, the Vue baseline, and browser egress.
 
 ## Anatomy
 
@@ -190,6 +193,6 @@ Build with `npm run build` and install or symlink the package. Then enable the m
 
 ## Where to go next
 
-- [Endpoints](/docs/develop/extensions/endpoints/) cover the API-side counterpart for modules that need their own server routes.
-- [Hooks](/docs/develop/extensions/hooks/) cover server-side reactions to platform events; useful when a module needs to listen for or modify platform behavior.
+- [Endpoints](/docs/develop/extensions/server-extensions/endpoints/) cover the API-side counterpart for modules that need their own server routes.
+- [Hooks](/docs/develop/extensions/server-extensions/hooks/) cover server-side reactions to platform events; useful when a module needs to listen for or modify platform behavior.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/app-extensions/panels.md
+++ b/docs/develop/extensions/app-extensions/panels.md
@@ -2,12 +2,15 @@
 title: Panel extensions
 description: Custom dashboard panels for Insights.
 sidebar:
+  label: Panels
   order: 6
 ---
 
 A panel is a unit of analytics or interaction inside an Insights dashboard. CairnCMS ships six built-in panel types (Label, List, Metric, Time Series, Global Variable, Global Relational Variable); a panel extension adds a new one.
 
 A panel extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). It registers a panel type with a Vue component, a configuration schema, and an optional query function that the platform calls to fetch the panel's data.
+
+Like every app extension, a panel runs unsandboxed in the admin browser under the logged-in user's permissions. See [App extensions](/docs/develop/extensions/app-extensions/) for the runtime model, the Vue baseline, and browser egress.
 
 ## Anatomy
 

--- a/docs/develop/extensions/app-extensions/ui-components.md
+++ b/docs/develop/extensions/app-extensions/ui-components.md
@@ -1,0 +1,55 @@
+---
+title: UI components
+description: The component library and theme tokens available to app extensions.
+sidebar:
+  label: UI components
+  order: 8
+---
+
+The admin app registers its component library globally, so an app extension can use those components in its own Vue templates without importing them. They are the same components the app is built from, so an extension that uses them looks and behaves like the rest of the application and stays consistent across themes.
+
+```vue
+<template>
+  <v-notice type="warning">Heads up.</v-notice>
+  <v-button @click="save">Save</v-button>
+</template>
+```
+
+A globally registered `VButton` is used as `<v-button>` in a template.
+
+## Commonly used components
+
+This is a working subset, grouped by purpose. The registered set is larger.
+
+- **Inputs and forms** — `v-input`, `v-textarea`, `v-select`, `v-checkbox`, `v-radio`, `v-slider`, `v-form`, `v-field-template`, `v-template-input`, `v-upload`, `v-date-picker`.
+- **Actions** — `v-button`, `v-icon`, `v-chip`.
+- **Containers and overlays** — `v-card`, `v-sheet`, `v-drawer`, `v-dialog`, `v-menu`, `v-overlay`, `v-divider`, `v-detail`, `v-tabs`, `v-tab`.
+- **Lists and tables** — `v-list`, `v-list-item`, `v-table`, `v-pagination`, `v-item-group`.
+- **Feedback and status** — `v-notice`, `v-error`, `v-info`, `v-progress-circular`, `v-progress-linear`, `v-skeleton-loader`, `v-badge`, `v-avatar`.
+- **Rendering helpers** — `render-template` (renders a display template for an item), `render-display` (renders a single field display).
+
+The component registry is the current catalog. If you need a component that is not listed here, check what the app registers before building your own.
+
+## Theme tokens
+
+Use the theme's CSS variables for color, spacing, and radius rather than hard-coded values, so an extension follows the active theme automatically. The common tokens:
+
+- **Color** — `--primary`, `--primary-alt`, `--background-page`, `--background-normal`, `--background-subdued`, `--background-input`, `--foreground-normal`, `--foreground-subdued`.
+- **Shape** — `--border-radius`, `--border-radius-outline`.
+
+```vue
+<style scoped>
+.badge {
+  background-color: var(--primary);
+  color: var(--foreground-inverted);
+  border-radius: var(--border-radius);
+}
+</style>
+```
+
+A component or field that hard-codes a hex color breaks under a different theme. Reaching for a token keeps it theme-aware.
+
+## Where to go next
+
+- [App extensions](/docs/develop/extensions/app-extensions/) covers the browser lane.
+- [Composables](/docs/develop/extensions/app-extensions/composables/) covers the data and store composables that pair with these components.

--- a/docs/develop/extensions/bundles.md
+++ b/docs/develop/extensions/bundles.md
@@ -2,6 +2,7 @@
 title: Bundle extensions
 description: Combine several extensions into a single distributable package.
 sidebar:
+  label: Bundles
   order: 10
 ---
 
@@ -159,6 +160,43 @@ export default defineHook(({ action }, { logger }) => {
 ```
 
 Build with `npm run build`. The resulting package can be installed once and brings both extensions along.
+
+## Confined bundles
+
+A bundle can run its server entries in the sandbox. Declare `runtime: confined-server` once at the bundle root, next to `type: "bundle"`. A bundle entry never declares its own runtime. Each server entry then declares the `capabilities` it uses, a hook entry its `events`, and an operation entry its `optionDelivery`, while app entries declare none of these:
+
+```json
+{
+  "cairncms:extension": {
+    "type": "bundle",
+    "runtime": "confined-server",
+    "path": { "app": "dist/app.js", "api": "dist/api.js" },
+    "entries": [
+      {
+        "type": "panel",
+        "name": "metric-card",
+        "source": "src/metric-card/index.ts"
+      },
+      {
+        "type": "endpoint",
+        "name": "metric-feed",
+        "source": "src/metric-feed/index.ts",
+        "capabilities": {
+          "endpoint": { "access": "authenticated" },
+          "request": { "urls": ["https://api.example.com"], "methods": ["GET"] }
+        }
+      }
+    ],
+    "host": "^1.0.0"
+  }
+}
+```
+
+The app entry (`metric-card`) runs in the browser and carries no capabilities. The server entry (`metric-feed`) runs confined, is authored with `defineJsonEndpoint`, and declares only what it uses. The panel can call that endpoint on the same origin, which is the supported pattern for an app extension that needs external data without a direct cross-origin fetch from the browser.
+
+The confined gate is all-or-nothing for the shared server artifact: one bad server entry fails the whole server side before any entry registers. If the artifact passes the gate but some entries then fail to register, such as a route collision, the bundle loads with a `partial` status, and the diagnostics show which entries loaded and which did not. `partial` is a status the runtime reports, not a manifest field you set.
+
+See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page for the host API, the capability vocabulary, and the per-entry rules.
 
 ## Where to go next
 

--- a/docs/develop/extensions/creating-extensions.md
+++ b/docs/develop/extensions/creating-extensions.md
@@ -84,7 +84,7 @@ The generated `package.json` calls the SDK's CLI:
 }
 ```
 
-Internally, the CLI uses Rollup to bundle the extension into a single entrypoint.
+Internally, most builds use Rollup to bundle the extension into a single entrypoint. Confined server artifacts use a separate self-contained build path instead, covered in [Confined extensions](#confined-extensions).
 
 The build command supports several flags:
 
@@ -124,6 +124,12 @@ export default {
 ```
 
 The supported option is `plugins`, which is an array of Rollup plugins added on top of the SDK's built-in plugins.
+
+### App extensions and the Vue baseline
+
+An app extension does not bundle its own copy of Vue. It shares the admin app's Vue runtime, and because `vue` is a shared dependency, the build binds the extension to the host's Vue version. The host Vue is the floor the extension builds against.
+
+So a host-Vue or SDK change means rebuilding the extension. A `dist` built against an older toolchain can fail to mount against a newer host runtime, and rebuilding against the current SDK realigns it.
 
 ## TypeScript
 
@@ -307,9 +313,9 @@ For Operation extensions (which have both an app and an api side), use `app.js` 
 
 This path is convenient for one-off extensions that do not need to live in their own package.
 
-## Server dependencies and native modules
+## Full-authority server dependencies and native modules
 
-Server extensions (hooks, endpoints, operations, and the API side of a bundle) run as normal Node code in the API process. When the SDK builds a server extension, it compiles your own source but does not bundle the packages you depend on. Each declared dependency stays as a regular import and resolves from the extension package's own `node_modules` at runtime.
+Full-authority server extensions (hooks, endpoints, operations, and the API side of a bundle) run as normal Node code in the API process. When the SDK builds one, it compiles your own source but does not bundle the packages you depend on. Each declared dependency stays as a regular import and resolves from the extension package's own `node_modules` at runtime. A confined extension is different: its build is self-contained with no externals, so native modules and unbundled runtime dependencies are not available to it. See [Confined extensions](#confined-extensions).
 
 This is what lets server extensions use native modules. A bundler cannot inline a compiled binary, so a package like `sharp` could not be bundled. Because the server build leaves declared dependencies external instead, your extension ships its own copy and it loads like any other Node dependency.
 
@@ -352,10 +358,41 @@ Operators install with `npm install <name>` and CairnCMS auto-discovers it.
 
 The CairnCMS extension naming convention exists so the loader can find packages without configuration. A package named `cairncms-extension-my-fancy-thing` is auto-discovered; a package named `my-fancy-thing` is not.
 
+## Confined extensions
+
+A standalone operation, endpoint, or hook can run its server code in the sandbox instead of the API process, and a confined bundle runs its server entries in the sandbox while its app entries still run in the browser. Scaffold a confined extension with the SDK's `create` command and the `--confined` flag. From a fresh start, run it through `npx`:
+
+```bash
+npx @cairncms/extensions-sdk create operation my-op --confined
+```
+
+The confined runtime supports the operation, endpoint, hook, and bundle types. The interactive `npm init cairncms-extension` scaffolder does not offer it, so use the `create` command for a confined extension. The authoring API is covered on each server type page and in the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) reference.
+
+A confined extension is checked at two stages, build and load.
+
+**Build.** The confined build bundles the server entry into a single self-contained artifact. It runs with Node builtins not externalized, so a `node:` import or any other unresolved import fails the build rather than failing at runtime. It then containment-checks the bundled inputs: an input that resolves inside the package or to a published dependency under `node_modules` is allowed, while a `workspace:`, `file:`, or `link:` dependency that resolves outside the package is refused. So a confined extension needs its dependencies installed as published `node_modules` entries before publication, not linked from a workspace.
+
+**Load.** When the API loads a confined extension, it re-reads the manifest, scans the declared server source, and probes the built artifact inside the sandbox before admitting it. The static source scan runs here, at load, not at build. A failed gate is recorded as a load failure in the diagnostics with a sanitized reason.
+
+See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page for the runtime model, the host API, and the full set of constraints.
+
+## CLI reference
+
+Two binaries are involved. The scaffolder bootstraps a new package, and the SDK CLI runs inside one.
+
+The scaffolder is `npm init cairncms-extension` (also `npx create-cairncms-extension` or `npx cce`). It prompts for type, name, and language and does not read CLI arguments. It does not offer the confined runtime, so use the `create` command below for a confined extension.
+
+The SDK CLI is `cairncms-extension`, available once `@cairncms/extensions-sdk` is installed. The generated `package.json` wires it into `npm run build`. Its commands:
+
+- **`cairncms-extension create <type> <name>`** — scaffold an extension. Flags: `--language <javascript|typescript>` and `--confined` (for an operation, endpoint, hook, or bundle). See [Confined extensions](#confined-extensions).
+- **`cairncms-extension add`** — add an entry to an existing bundle. See [Working on a bundle](#working-on-a-bundle).
+- **`cairncms-extension build`** — bundle the extension. Flags: `-w`/`--watch`, `--sourcemap`, `--no-minify`, `-t`/`--type`, `-i`/`--input`, `-o`/`--output`. See [Building](#building).
+- **`cairncms-extension link <path>`** — symlink the extension into a CairnCMS install's extensions folder. See [Symlinking a local extension](#symlinking-a-local-extension).
+
 ## Where to go next
 
 - The individual extension type pages cover the API and minimum example for each:
-  - [Interface](/docs/develop/extensions/interfaces/), [Display](/docs/develop/extensions/displays/), [Layout](/docs/develop/extensions/layouts/), [Module](/docs/develop/extensions/modules/), [Panel](/docs/develop/extensions/panels/)
-  - [Hook](/docs/develop/extensions/hooks/), [Endpoint](/docs/develop/extensions/endpoints/)
-  - [Operation](/docs/develop/extensions/operations/)
+  - [Interface](/docs/develop/extensions/app-extensions/interfaces/), [Display](/docs/develop/extensions/app-extensions/displays/), [Layout](/docs/develop/extensions/app-extensions/layouts/), [Module](/docs/develop/extensions/app-extensions/modules/), [Panel](/docs/develop/extensions/app-extensions/panels/)
+  - [Hook](/docs/develop/extensions/server-extensions/hooks/), [Endpoint](/docs/develop/extensions/server-extensions/endpoints/)
+  - [Operation](/docs/develop/extensions/server-extensions/operations/)
   - [Bundle](/docs/develop/extensions/bundles/)

--- a/docs/develop/extensions/index.md
+++ b/docs/develop/extensions/index.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-description: The extension system in CairnCMS — types, categories, and how to choose between them.
+description: The extension system in CairnCMS, its types, the three runtimes they run in, and how to choose between them.
 sidebar:
   label: Overview
   order: 0
@@ -8,52 +8,57 @@ sidebar:
 
 CairnCMS is built to be extended. The same APIs and components that power the platform are available to you, so a custom extension can add new capabilities without forking the codebase.
 
-This page covers the extension types CairnCMS ships with and how to choose between them. The next page, [Creating extensions](/docs/develop/extensions/creating-extensions/), covers the toolchain — scaffolding, building, installing, and publishing.
+This page covers the extension types CairnCMS ships with, the three runtimes they run in, and how to choose between them. The next page, [Creating extensions](/docs/develop/extensions/creating-extensions/), covers the toolchain: scaffolding, building, installing, and publishing.
+
+## How extensions run
+
+Before you pick a type, it helps to know where your code runs. CairnCMS has three runtimes, and the runtime decides what your code can reach.
+
+- **In the browser.** App extensions (interface, display, layout, module, panel) are Vue components that run in the admin app, inside the logged-in user's browser. They act through the API with that user's own permissions, and can do whatever that user can do, no more and no less. The browser is not a security boundary. See [App extensions](/docs/develop/extensions/app-extensions/).
+- **In the API, with full authority.** A server extension (hook, endpoint, operation) runs in the API's Node process. By default it has full access to services, the database, and the environment. This is the home for code that needs native modules, raw services, or schema changes. It is the default when a server extension declares no runtime.
+- **In the API, sandboxed.** The same server types can opt into the confined runtime by declaring `runtime: confined-server`. The code then runs in a sandboxed child with no host imports and no raw Node. Every privileged effect goes through a brokered `host.*` call that the platform gates against the capabilities the extension declares. See [Sandbox](/docs/develop/extensions/server-extensions/sandbox/).
+
+A server extension is full-authority unless it opts into the sandbox. Prefer the sandbox for new server extensions when the brokered API covers what they need, and reach for full authority only for what the sandbox cannot host. [Server extensions](/docs/develop/extensions/server-extensions/) covers the choice in full.
 
 ## Extension types
 
-CairnCMS supports nine extension types, grouped into four categories.
+CairnCMS supports nine extension types in three groups.
 
 ### App extensions
 
-App extensions extend the admin app. They are written as Vue components and run in the browser.
+Vue components that run in the admin browser. See [App extensions](/docs/develop/extensions/app-extensions/) for the lane.
 
-- **[Interface](/docs/develop/extensions/interfaces/)** — a custom field editing widget. Use this to add new ways to enter or edit data on the item form.
-- **[Display](/docs/develop/extensions/displays/)** — a custom read-only renderer for a field. Use this when you need a different way to show a value in lists, tables, and detail views without changing how it is edited.
-- **[Layout](/docs/develop/extensions/layouts/)** — a custom collection page layout, alongside the built-in Table, Cards, Calendar, and Map.
-- **[Module](/docs/develop/extensions/modules/)** — a brand-new top-level area in the module bar. Use this when you need an entire workspace that does not fit into the existing modules.
-- **[Panel](/docs/develop/extensions/panels/)** — a custom panel type for Insights dashboards.
+- **[Interface](/docs/develop/extensions/app-extensions/interfaces/)** is a custom field editing widget. Use this to add new ways to enter or edit data on the item form.
+- **[Display](/docs/develop/extensions/app-extensions/displays/)** is a custom read-only renderer for a field. Use this when you need a different way to show a value in lists, tables, and detail views without changing how it is edited.
+- **[Layout](/docs/develop/extensions/app-extensions/layouts/)** is a custom collection page layout, alongside the built-in Table, Cards, Calendar, Map, and Kanban.
+- **[Module](/docs/develop/extensions/app-extensions/modules/)** is a top-level area in the module bar. Use this when you need an entire workspace that does not fit into the existing modules.
+- **[Panel](/docs/develop/extensions/app-extensions/panels/)** is a custom panel type for Insights dashboards.
 
-### API extensions
+### Server extensions
 
-API extensions extend the server. They are written in JavaScript or TypeScript and run in Node.
+Code that runs in the API in Node, either full-authority or sandboxed. See [Server extensions](/docs/develop/extensions/server-extensions/) for the lane.
 
-- **[Hook](/docs/develop/extensions/hooks/)** — a way to react to or modify platform events. Hooks come in four flavours: `filter` (blocking, can transform or veto), `action` (non-blocking, runs after), `init` (runs once at startup), and `schedule` (runs on a cron schedule).
-- **[Endpoint](/docs/develop/extensions/endpoints/)** — a custom HTTP route mounted alongside the built-in API. Use this when you need to expose logic that does not map to a collection's CRUD endpoints.
-
-### Hybrid extensions
-
-Hybrid extensions have both an app component and a server component.
-
-- **[Operation](/docs/develop/extensions/operations/)** — a custom flow operation. The app side renders the operation's configuration form in the flow editor; the API side runs the logic when the flow executes.
+- **[Hook](/docs/develop/extensions/server-extensions/hooks/)** reacts to or modifies platform events. Full-authority hooks come in five types: `filter` (blocking, can transform or veto), `action` (non-blocking, runs after), `init` (runs once at startup), `schedule` (runs on a cron schedule), and `embed` (injects HTML into the admin app's head or body). Sandboxed hooks support filters and actions.
+- **[Endpoint](/docs/develop/extensions/server-extensions/endpoints/)** is a custom HTTP route mounted alongside the built-in API. Use this when you need to expose logic that does not map to a collection's CRUD endpoints.
+- **[Operation](/docs/develop/extensions/server-extensions/operations/)** is a custom flow operation. It is hybrid: the app side renders the operation's configuration form in the flow editor, and the server side runs the logic when the flow executes. The server side is what chooses full authority or the sandbox.
 
 ### Bundle
 
-- **[Bundle](/docs/develop/extensions/bundles/)** — a wrapper that ships several extensions of any type as a single package. Use this when several extensions share dependencies, are released together, or implement a single coherent feature across the app and API.
+- **[Bundle](/docs/develop/extensions/bundles/)** is a wrapper that ships multiple, mixed extensions as a single package. Use this when several extensions share dependencies, are released together, or implement a single coherent feature across the app and server. A bundle spans both groups.
 
 ## Choosing an extension type
 
 A short decision rubric:
 
-- The user needs a new way to **edit a field's value** → Interface.
-- The user needs a new way to **display a field's value** in non-edit contexts → Display.
-- The user needs a new way to **browse a whole collection** → Layout.
-- The user needs an **entirely new workspace** unrelated to existing modules → Module.
-- A dashboard needs a new **visualization or interaction** → Panel.
-- The server needs to **react to or modify a platform event** → Hook.
-- The server needs to **expose a custom HTTP route** → Endpoint.
-- A flow needs a **new step** → Operation.
-- Several extensions ship together → Bundle.
+- The user needs a new way to **edit a field's value**, use an Interface.
+- The user needs a new way to **display a field's value** in non-edit contexts, use a Display.
+- The user needs a new way to **browse a whole collection**, use a Layout.
+- The user needs an **entirely new workspace** unrelated to existing modules, use a Module.
+- A dashboard needs a new **visualization or interaction**, use a Panel.
+- The server needs to **react to or modify a platform event**, use a Hook.
+- The server needs to **expose a custom HTTP route**, use an Endpoint.
+- A flow needs a **new step**, use an Operation.
+- Several extensions ship together, use a Bundle.
 
 If you find yourself wanting to ship app and server logic that should be released together, reach for a Bundle rather than separate top-level extensions.
 
@@ -61,8 +66,8 @@ If you find yourself wanting to ship app and server logic that should be release
 
 A couple of developer-facing customization paths exist outside the extension system. They use simple file-folder conventions rather than the SDK's `define*` API:
 
-- **[Custom migrations](/docs/develop/custom-migrations/)** — drop migration `.js` files into `EXTENSIONS_PATH/migrations` and they run alongside built-in migrations.
-- **[Email templates](/docs/develop/email-templates/)** — drop Liquid templates into `EXTENSIONS_PATH/templates` and reference them from the Send Email flow operation or by name from any code that sends mail.
+- **[Custom migrations](/docs/develop/custom-migrations/)** let you drop migration `.js` files into `EXTENSIONS_PATH/migrations` and they run alongside built-in migrations.
+- **[Email templates](/docs/develop/email-templates/)** let you drop Liquid templates into `EXTENSIONS_PATH/templates` and reference them from the Send Email flow operation or by name from any code that sends mail.
 
 These are not extension types and do not require the SDK or a build step. They are documented separately for that reason.
 
@@ -70,13 +75,15 @@ These are not extension types and do not require the SDK or a build step. They a
 
 CairnCMS discovers extensions from three sources:
 
-- **Package extensions** — installed from npm into the project's `node_modules`. Any package whose name matches `cairncms-extension-<name>`, `@<scope>/cairncms-extension-<name>`, or `@cairncms/extension-<name>` is auto-discovered.
-- **Local package extensions** — full package directories (each with its own `package.json`) placed inside `EXTENSIONS_PATH`. Bundles are installed this way.
-- **Local file extensions** — pre-built extension files placed in type subfolders inside `EXTENSIONS_PATH` (for example, `EXTENSIONS_PATH/interfaces/<name>/index.js`). Used for non-bundle extension types when you do not need a separate package.
+- **Package extensions** are installed from npm into the project's `node_modules`. Any package whose name matches `cairncms-extension-<name>`, `@<scope>/cairncms-extension-<name>`, or `@cairncms/extension-<name>` is auto-discovered.
+- **Local package extensions** are full package directories (each with its own `package.json`) placed inside `EXTENSIONS_PATH`. Bundles are installed this way.
+- **Local file extensions** are pre-built extension files placed in type subfolders inside `EXTENSIONS_PATH` (for example, `EXTENSIONS_PATH/interfaces/<name>/index.js`). Used for non-bundle extension types when you do not need a separate package.
 
 The [Creating extensions](/docs/develop/extensions/creating-extensions/) page walks through all three.
 
 ## Where to go next
 
+- [App extensions](/docs/develop/extensions/app-extensions/) covers the browser lane and links to each app type.
+- [Server extensions](/docs/develop/extensions/server-extensions/) covers the Node lane and the full-authority versus sandboxed choice.
+- [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) is the reference for the confined runtime: the host API, capabilities, and diagnostics.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain end to end: scaffold, build, install, hot reload, debug, publish.
-- The individual type pages above cover each extension type's API, file structure, and minimum example.

--- a/docs/develop/extensions/server-extensions/endpoints.md
+++ b/docs/develop/extensions/server-extensions/endpoints.md
@@ -2,12 +2,13 @@
 title: Endpoint extensions
 description: Custom HTTP endpoints registered with the API.
 sidebar:
+  label: Endpoints
   order: 8
 ---
 
 An endpoint extension adds custom HTTP routes to the CairnCMS API. Reach for one when you need behavior that does not map to a collection's CRUD endpoints, for example, a complex aggregation, a third-party integration, a webhook receiver that doesn't fit the flow trigger model, or a custom business operation that should be exposed as a single REST call.
 
-An endpoint extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). It runs server-side in the same Node process as the rest of the API, with full access to the platform's services and database connection.
+An endpoint extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). By default it runs server-side in the same Node process as the rest of the API, with full access to the platform's services and database connection. It can also run sandboxed in the confined runtime, covered in the [Confined variant](#confined-variant) section below.
 
 ## Anatomy
 
@@ -194,8 +195,53 @@ export default defineEndpoint({
 
 After build and install, the endpoint is reachable at `GET /article-stats/by-author`. Permissions on the `articles` collection are applied automatically because the service was constructed with the request's `accountability`.
 
+## Confined variant
+
+An endpoint runs full-authority by default. To run it in the sandbox, declare `runtime: confined-server` in the manifest and author it with `defineJsonEndpoint` from `@cairncms/extensions-server-api` instead of an Express router.
+
+A confined endpoint has no router. The handler is the whole endpoint. It receives the request as plain data, `{ method, path, query, body }`, and returns `{ status?, body }`, where `status` is the HTTP status code and `body` is the response body:
+
+```ts
+import { defineJsonEndpoint } from '@cairncms/extensions-server-api';
+
+export default defineJsonEndpoint({
+  id: 'greet',
+  async handler(request, { host }) {
+    if (request.method !== 'GET') {
+      return { status: 405, body: { error: 'method not allowed' } };
+    }
+
+    await host.log.info('greeting a caller');
+
+    return { status: 200, body: { message: 'Hello from the sandbox' } };
+  },
+});
+```
+
+The manifest declares the runtime, the endpoint's access level, and any other capabilities:
+
+```json
+{
+  "cairncms:extension": {
+    "type": "endpoint",
+    "path": "dist/index.js",
+    "source": "src/index.js",
+    "host": "^1.0.0",
+    "runtime": "confined-server",
+    "capabilities": {
+      "endpoint": { "access": "authenticated" },
+      "log": true
+    }
+  }
+}
+```
+
+The `endpoint.access` value sets the auth gate. `authenticated` returns 401 to an anonymous caller, while `public` admits anyone. There is no app-only access level. An outbound call from the handler uses `host.request.send` and reaches only the origins declared in the `request` capability.
+
+See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page for the full host API and the capability vocabulary.
+
 ## Where to go next
 
-- [Hooks](/docs/develop/extensions/hooks/) cover server-side reactions to platform events. Use a hook when you need to react to a built-in operation rather than expose a new HTTP route.
-- [Operations](/docs/develop/extensions/operations/) cover custom flow operations. Use an operation when the work belongs inside a flow.
+- [Hooks](/docs/develop/extensions/server-extensions/hooks/) cover server-side reactions to platform events. Use a hook when you need to react to a built-in operation rather than expose a new HTTP route.
+- [Operations](/docs/develop/extensions/server-extensions/operations/) cover custom flow operations. Use an operation when the work belongs inside a flow.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/server-extensions/hooks.md
+++ b/docs/develop/extensions/server-extensions/hooks.md
@@ -2,12 +2,13 @@
 title: Hook extensions
 description: Filter, action, init, schedule, and embed hooks for extending the API event lifecycle.
 sidebar:
+  label: Hooks
   order: 7
 ---
 
 A hook extension lets server-side code react to events in the platform, such as items being created, users logging in, the server starting up, scheduled times being reached, and so on. Hooks are the primary way to add logic that runs alongside CairnCMS's built-in operations rather than replacing them.
 
-A hook extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). It runs server-side in the same Node process as the rest of the API, with full access to the platform's services and database connection.
+A hook extension is a single npm package created by the [extensions toolchain](/docs/develop/extensions/creating-extensions/). By default it runs server-side in the same Node process as the rest of the API, with full access to the platform's services and database connection. It can also run sandboxed in the confined runtime, covered in the [Confined variant](#confined-variant) section below.
 
 ## Anatomy
 
@@ -196,6 +197,8 @@ CairnCMS events follow a `<type>.<event>` or `<collection>.items.<event>` naming
 | `database.error` | the database error | `client` |
 | `auth.login` | the login payload | `status`, `user`, `provider` |
 | `auth.jwt` | the auth token | `status`, `user`, `provider`, `type` |
+| `auth.create` | the SSO user about to be created | `identifier`, `provider`, `providerPayload` |
+| `auth.update` | the SSO user update payload | `identifier`, `provider`, `providerPayload` |
 | `authenticate` | the empty accountability object | `req` |
 | `(<collection>.)items.query` | the items query | `collection` |
 | `(<collection>.)items.read` | the read item | `query`, `collection` |
@@ -205,6 +208,8 @@ CairnCMS events follow a `<type>.<event>` or `<collection>.items.<event>` naming
 | `<system-collection>.create` | the new item | `collection` |
 | `<system-collection>.update` | the updated item | `keys`, `collection` |
 | `<system-collection>.delete` | the keys of the item | `collection` |
+
+The auth events carry credentials. The `auth.jwt` payload is the session token. For `auth.create` and `auth.update`, the payload can include `auth_data` (a stored refresh token), and the `providerPayload` meta holds the identity provider's access token, SAML assertion, or raw user info. A hook on these events must not log or persist those values unless it is deliberately handling credentials.
 
 ### Action events
 
@@ -272,8 +277,46 @@ export default defineHook(({ filter }) => {
 
 After build and install, this filter fires whenever an article is created (through the API, the app, or a flow), generating a slug if the editor did not supply one. Returning the modified `input` is what causes the platform to continue with the new value.
 
+## Confined variant
+
+A hook runs full-authority by default. To run it in the sandbox, declare `runtime: confined-server` in the manifest and author it with `defineEventHook` from `@cairncms/extensions-server-api` instead of `defineHook`.
+
+A confined hook supports filter and action events only. The `init`, `schedule`, and `embed` register functions have no confined equivalent and stay full-authority. Rather than a register callback, `defineEventHook` takes `{ id, filters?, actions? }`, keyed by exact platform event name. A filter handler returns the payload (transformed, unchanged, or `undefined` for no change), and a throw blocks the event. An action handler returns nothing and never blocks:
+
+```ts
+import { defineEventHook } from '@cairncms/extensions-server-api';
+
+export default defineEventHook({
+  id: 'stamp-items',
+  filters: {
+    'items.create': async (payload, meta, { host }) => {
+      await host.log.info('stamping a new item');
+      return payload;
+    },
+  },
+});
+```
+
+The same events must be declared in the manifest, where they are the operator-reviewable subscription surface. The handler keys and the manifest events must match, or the entry fails to load:
+
+```json
+{
+  "cairncms:extension": {
+    "type": "hook",
+    "path": "dist/index.js",
+    "source": "src/index.js",
+    "host": "^1.0.0",
+    "runtime": "confined-server",
+    "capabilities": { "log": true },
+    "events": { "filter": ["items.create"] }
+  }
+}
+```
+
+See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page for the full host API, the capability vocabulary, and the event rules.
+
 ## Where to go next
 
-- [Endpoints](/docs/develop/extensions/endpoints/) cover custom HTTP routes when you need to expose a new API surface rather than react to existing ones.
-- [Operations](/docs/develop/extensions/operations/) cover custom flow operations when the work belongs inside a configurable, user-built flow.
+- [Endpoints](/docs/develop/extensions/server-extensions/endpoints/) cover custom HTTP routes when you need to expose a new API surface rather than react to existing ones.
+- [Operations](/docs/develop/extensions/server-extensions/operations/) cover custom flow operations when the work belongs inside a configurable, user-built flow.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/server-extensions/index.md
+++ b/docs/develop/extensions/server-extensions/index.md
@@ -1,0 +1,44 @@
+---
+title: Server extensions
+description: The Node lane, code that runs in the API process either with full authority or sandboxed.
+sidebar:
+  label: Overview
+  order: 0
+---
+
+Server extensions extend the API. They are written in JavaScript or TypeScript and run in the API's Node process. There are three types: hook, endpoint, and operation. An operation is hybrid, with a server side that runs there and an app side that renders its configuration form in the flow editor.
+
+A server extension runs in one of two runtimes. The runtime is a per-extension choice, declared in the manifest.
+
+## Full authority
+
+By default, a server extension runs with full authority. It loads in the API process with full access to services, the database, and the environment, the same reach the platform's own code has. This is the default when the manifest declares no `runtime`.
+
+Full authority is the home for what the sandbox cannot host: native modules, raw service or database access, schema changes, and the `init`, `schedule`, and `embed` hook lifecycle. A full-authority extension is unconfined, so the operator is responsible for the decision to run it, as well as the implications.
+
+## Sandboxed
+
+A server extension opts into the sandbox by declaring `runtime: confined-server`. The code then runs in a confined child process with no host imports and no raw Node. Every privileged effect goes through a brokered `host.*` call that the platform gates against the capabilities the extension declares, so the operator can see and bound what the extension can reach before it runs.
+
+Endpoint handlers and operation server handlers run confined. An operation's app-side configuration form still runs in the browser, as it does for any operation. Confined hooks support filter and action events, while the `init`, `schedule`, and `embed` lifecycles stay full-authority, with no confined equivalent.
+
+The [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page is the full reference: the host API, the capability vocabulary, and the diagnostics.
+
+## Which to choose
+
+Prefer the sandbox for new server extensions when the brokered host API covers what they need. It bounds what the code can reach, makes that reach reviewable in the manifest, and keeps a faulty or compromised extension from holding the whole API process.
+
+Reach for full authority when the sandbox cannot host the work: a native module, a raw service, a schema mutation, or a hook lifecycle the broker does not expose. Choosing full authority is choosing to run unconfined code, so weigh it as that.
+
+## The types
+
+- **[Hook](/docs/develop/extensions/server-extensions/hooks/)** reacts to or modifies platform events. Full-authority hooks register five functions: `filter`, `action`, `init`, `schedule`, and `embed`. Confined hooks support filters and actions.
+- **[Endpoint](/docs/develop/extensions/server-extensions/endpoints/)** is a custom HTTP route mounted alongside the built-in API.
+- **[Operation](/docs/develop/extensions/server-extensions/operations/)** is a custom flow operation, with a server side that runs the logic and an app side that configures it.
+
+## Where to go next
+
+- [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) is the confined runtime reference.
+- [Internal services](/docs/develop/extensions/server-extensions/services/) is the full-authority services reference.
+- The type pages above cover each server type's API, both full-authority and confined.
+- [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain: scaffold, build, install, hot reload, debug, publish.

--- a/docs/develop/extensions/server-extensions/operations.md
+++ b/docs/develop/extensions/server-extensions/operations.md
@@ -2,6 +2,7 @@
 title: Operation extensions
 description: Custom flow operations for the automation system.
 sidebar:
+  label: Operations
   order: 9
 ---
 
@@ -253,8 +254,60 @@ export default defineOperationApi({
 
 After build and install, the new operation appears in the operation picker. Editors configure it by selecting which two prior operation outputs to join and which field to match on.
 
+## Confined variant
+
+An operation runs full-authority by default. To run its server side in the sandbox, declare `runtime: confined-server` in the manifest and author the API entrypoint with `defineFlowOperation` from `@cairncms/extensions-server-api` instead of `defineOperationApi`. The app entrypoint does not change.
+
+The handler signature changes with it. A confined handler receives `(payload, context)`, where `payload` is `{ options, input }` and `context` carries a brokered `host` instead of `services`, `database`, and the rest. Every privileged effect goes through a `host.*` call, and most return an `ExtensionResult` the handler branches on (logging is fire-and-forget):
+
+```ts
+import { defineFlowOperation } from '@cairncms/extensions-server-api';
+
+type Options = { status: string };
+
+export default defineFlowOperation<Options>({
+  id: 'list-articles',
+  async handler(payload, { host }) {
+    const result = await host.items.read('articles', {
+      filter: { status: { _eq: payload.options.status } },
+      fields: ['id', 'title'],
+      limit: 50,
+    });
+
+    if (!result.ok) {
+      await host.log.warn('article read failed', { code: result.error.code });
+      return { articles: [] };
+    }
+
+    return { articles: result.value };
+  },
+});
+```
+
+The manifest declares the runtime and the capabilities the handler uses:
+
+```json
+{
+  "cairncms:extension": {
+    "type": "operation",
+    "path": { "app": "dist/app.js", "api": "dist/api.js" },
+    "source": { "app": "src/app.ts", "api": "src/api.ts" },
+    "host": "^1.0.0",
+    "runtime": "confined-server",
+    "capabilities": {
+      "items": "current-user",
+      "log": true
+    }
+  }
+}
+```
+
+The `items: "current-user"` mode reads as the user who triggered the flow, so the operation sees exactly what that user could read through the API. Keep the app-side options honest about the declared capabilities, and do not offer a configuration the broker would reject, such as a request method outside `request.methods`. To pass a secret to the handler without the guest ever seeing it, mark the option with `optionDelivery`.
+
+See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) page for the full host API, the capability vocabulary, `optionDelivery`, and the accountability modes.
+
 ## Where to go next
 
 - [Flows](/docs/guides/flows/) covers flows from a user perspective for understanding where your operation slots in.
-- [Hooks](/docs/develop/extensions/hooks/) and [Endpoints](/docs/develop/extensions/endpoints/) cover the other two server-side extension types.
+- [Hooks](/docs/develop/extensions/server-extensions/hooks/) and [Endpoints](/docs/develop/extensions/server-extensions/endpoints/) cover the other two server-side extension types.
 - [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the toolchain in full.

--- a/docs/develop/extensions/server-extensions/sandbox.md
+++ b/docs/develop/extensions/server-extensions/sandbox.md
@@ -1,0 +1,191 @@
+---
+title: Sandbox
+description: The confined server runtime, its host API, capabilities, and diagnostics.
+sidebar:
+  label: Sandbox
+  order: 20
+---
+
+:::note[The sandbox is under active development]
+Its capability surface is expanding. The host API and capabilities on this page describe the current version, and not the complete, finished contract. Expect the brokered API to gain capabilities, and several of the current restrictions to lift, in future releases.
+:::
+
+The sandbox is the confined server runtime. A server extension opts into it by declaring `runtime: confined-server`, and its code then runs in a confined child process instead of the API process. The confined process has no host imports and no raw Node. Every privileged effect goes through a brokered `host.*` call that the platform gates against the capabilities the extension declares.
+
+This page is the reference for that runtime: how it runs, the boundary it enforces, how to author against it, the host API, the capability vocabulary, the build and load path, and the diagnostics. For the choice between full authority and the sandbox, see [Server extensions](/docs/develop/extensions/server-extensions/).
+
+## How the sandbox runs
+
+A confined extension runs in a short-lived child process, one per invocation. The API spawns a child host that loads a QuickJS engine compiled to WebAssembly, evaluates the extension's built artifact inside it, runs the handler, and returns the result.
+
+The guest code never touches the host directly. It has no `fetch`, no filesystem, no Node builtins, and no imports from the platform. When it needs a privileged effect it calls a `host.*` method. That call is framed and sent over a dedicated channel to a broker in the API, which checks the call against the declared capabilities, performs the effect, and frames a reply back. The guest sees only the reply.
+
+Inside the engine, the guest runs under per-invocation CPU, memory, and stack limits, with the console silenced and a cap on the number of timers it can create. A run that exceeds its CPU, memory, or stack limit is terminated.
+
+## The boundary
+
+The boundary is the engine. A confined guest runs inside a QuickJS engine with no host imports, no Node, no `fetch`, and no filesystem, so it cannot reach the API process, the database, the environment, or the network by itself. Its only way out is a `host.*` call, and every call is checked by the broker against the capabilities the extension declares. This is the sandbox: it is present in every mode and on every host, and it does not depend on the operating system. The OS hardening below is additional containment, not what makes the sandbox a sandbox.
+
+## Defense in depth: OS hardening
+
+A confined extension runs in its own child process, not in-process with the API. That lets the platform wrap the process in operating-system isolation, a layer an in-process sandbox cannot add. This hardening is extra containment around an already-closed boundary:
+
+- a network namespace that severs the child's own network access,
+- the Node permission model with a read scoped to the child's runtime directory,
+- a cgroup memory cap.
+
+How strictly these layers are enforced is set with the `EXTENSIONS_SANDBOX_OS_HARDENING` environment variable.
+
+- `auto`, the default, applies each layer where the host supports it and reports where it is missing. A missing layer never blocks an extension, because the engine boundary already contains the guest.
+- `required` refuses to start a confined extension unless the escape-containment core is present, that core being the network namespace and the Node permission model with its runtime-directory-scoped read. Use it on hosts where the extra isolation must be guaranteed. The cgroup memory cap is applied and reported when available but is never required.
+
+The resolved posture for every confined extension is visible in the diagnostics.
+
+## Authoring a confined extension
+
+A confined extension swaps the authoring entrypoint and declares its runtime and capabilities in the manifest. The handler receives a `host` instead of reaching for platform internals.
+
+The entrypoints come from `@cairncms/extensions-server-api`:
+
+```ts
+import { defineFlowOperation } from '@cairncms/extensions-server-api';
+
+export default defineFlowOperation({
+  id: 'my-op',
+  async handler(payload, { host }) {
+    const result = await host.request.send({ url: 'https://api.example.com/status' });
+
+    if (!result.ok) {
+      await host.log.warn('status request failed', { code: result.error.code });
+      return { reached: false };
+    }
+
+    return { reached: true, status: result.value.status };
+  },
+});
+```
+
+The matching manifest declares the runtime and the capabilities the handler uses:
+
+```json
+{
+  "name": "cairncms-extension-my-op",
+  "cairncms:extension": {
+    "type": "operation",
+    "path": { "app": "dist/app.js", "api": "dist/api.js" },
+    "source": { "app": "src/app.ts", "api": "src/api.ts" },
+    "host": "^1.0.0",
+    "runtime": "confined-server",
+    "capabilities": {
+      "log": true,
+      "request": { "urls": ["https://api.example.com"], "methods": ["GET"] }
+    }
+  }
+}
+```
+
+The three confined entrypoints, all from `@cairncms/extensions-server-api`:
+
+- `defineFlowOperation({ id, handler })`. The handler is `(payload, context)`, where `payload` is `{ options, input }` and it returns the operation's output. See [Operations](/docs/develop/extensions/server-extensions/operations/).
+- `defineJsonEndpoint({ id, handler })`. The handler is `(request, context)`, where `request` is `{ method, path, query, body }`, and it returns `{ status?, body }`. The handler is the whole endpoint, with no router. See [Endpoints](/docs/develop/extensions/server-extensions/endpoints/).
+- `defineEventHook({ id, filters?, actions? })`. `filters` and `actions` are keyed by exact platform event name. A filter handler is `(payload, meta, context)` and returns the payload (or `undefined` for no change). An action handler is `(meta, context)` and returns nothing. See [Hooks](/docs/develop/extensions/server-extensions/hooks/).
+
+In every case `context` is `{ extensionId, contributionId, activation, accountability, host }`. The contribution `id` must equal the extension or entry name. The load gate enforces this.
+
+## The host API
+
+Every privileged effect is a method on `host`. Each returns an `ExtensionResult` (except `host.log`, which is fire-and-forget), so a caller branches on the outcome rather than catching exceptions.
+
+```ts
+type ExtensionResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: { code: ExtensionHostErrorCode; message: string; details?: Record<string, unknown> } };
+
+type ExtensionHostErrorCode =
+  | 'denied'
+  | 'not_found'
+  | 'invalid_request'
+  | 'unsupported'
+  | 'timeout'
+  | 'rate_limited'
+  | 'internal';
+```
+
+The methods:
+
+- `host.log.debug | info | warn | error(message, meta?)` writes a structured log line on the host. Logging is fire-and-forget and needs the `log` capability.
+- `host.request.send(request)` makes an outbound HTTP request from the host and returns `ExtensionResult<{ status, headers, body }>`. The `request` is `{ url, method?, headers?, body?, timeoutMs?, auth? }`. It needs the `request` capability, and the URL's origin must be one the manifest declares.
+- `host.items.read(collection, query?)` returns `ExtensionResult<T[]>` and `host.items.readOne(collection, key, query?)` returns `ExtensionResult<T | null>`. The `query` is `{ fields?, filter?, sort?, limit?, offset?, page?, search? }`. Both need the `items` capability. Reads are read-only in this version.
+- `host.settings.get(key)` returns `ExtensionResult<T | ExtensionSecretReference | null>` and needs the `settings` capability. No settings are declared readable to confined extensions in this version, so it resolves to `null` today.
+- `host.template.renderLiquid(template, data?, options?)` renders a Liquid template on the host and returns `ExtensionResult<string>`. The `options` may set custom `delimiters`. It needs the `template` capability.
+
+A call whose capability is not declared, or whose target is not allowed by the declared capability, comes back as `{ ok: false, error: { code: 'denied' } }` rather than throwing.
+
+## Reading data: accountability modes
+
+`host.items` reads under one of two accountability modes, fixed per extension by the `items` capability. It is not chosen per invocation.
+
+- `items: 'current-user'` reads as whoever triggered the work. A manual flow runs as the user who clicked Run Flow, an event-triggered flow as the user whose action fired the event, an authenticated request as the caller's token. Field permissions apply exactly as on a REST read, and the read fails closed: a forbidden field is a hard denial, and the primary key must be among the readable fields. A null accountability, such as an anonymous webhook or a schedule, is denied in this mode. Prefer this mode.
+- `items: 'system'` reads with unrestricted system authority, for genuinely user-less flows such as schedules and anonymous webhooks. It is still confined and still read-only, and it is visible in the diagnostics as an elevated opt-in.
+
+There is no per-flow identity. A flow runs as its trigger. For user-less work that should stay least-privilege, use a dedicated service user on an authenticated trigger and keep `current-user`.
+
+## Capabilities
+
+The manifest `capabilities` block is the operator-reviewable list of what the extension can reach. A capability that is not declared is denied at the broker. The vocabulary:
+
+| Capability | Shape | Status in this version                                    |
+|---|---|-----------------------------------------------------------|
+| `log` | `true` | Present. Enables `host.log`.                              |
+| `request` | `{ urls: string[], methods?: string[] }` | Present. Enables `host.request.send`.                     |
+| `template` | `true` | Present. Enables `host.template.renderLiquid`.            |
+| `items` | `'current-user' \| 'system'` | Present, read-only. Enables `host.items`.                 |
+| `settings` | `('read' \| 'write')[]` | `read` enables `host.settings.get`, which resolves to `null` today (no readable settings are declared yet). |
+| `endpoint` | `{ access: 'public' \| 'authenticated' }` | Present. Sets the auth gate for a confined endpoint.      |
+| `files` | `'current-user' \| 'system'` | Declarable for forward compatibility, not exposed in the host API.    |
+| `schema` | `('read' \| 'write')[]` | Declarable for forward compatibility, not exposed in the host API.    |
+| `secrets` | `true` | Declarable for forward compatibility, not exposed in the host API.    |
+| `jobs` | `true` | Declarable for forward compatibility, not exposed in the host API.    |
+
+These four capabilities validate and load, but the host API exposes no method for them in this version, so there is nothing to call. They are reserved for forward compatibility and operator review. Do not build on them yet.
+
+### Request origins and methods
+
+The `request` capability bounds outbound HTTP to a declared set.
+
+- `urls` is a list of bare origins, each an `http://` or `https://` origin with no path, query, fragment, or credentials. At least one is required. A request is matched against the list by exact origin equality, with a case-insensitive host.
+- `methods` is an optional list drawn from `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`. It defaults to `['GET']`. A request with an undeclared method is denied.
+
+A "reach any API" design is not expressible. The operator enumerates every origin up front, and the extension can reach only those.
+
+### Endpoint access
+
+A confined endpoint declares `endpoint: { access: ... }`. `authenticated` returns 401 to an anonymous caller. `public` admits anonymous callers. There is no app-only access level.
+
+### Hook events
+
+A confined hook declares the events it subscribes to in `events`, as `{ filter?: string[], action?: string[] }`, with at least one list. Each list holds up to sixteen exact platform event names. The declared events are the operator-reviewable subscription surface, and an entry whose handlers do not match its declared events fails to load. Confined hooks subscribe to filter and action events only.
+
+### Sensitive operation options
+
+An operation can mark sensitive option fields with `optionDelivery`, a record of `{ <optionKey>: { delivery: 'reference' } }`. A field marked this way is delivered to the handler as a reference the broker resolves on the host, so the secret value is never serialized into the guest. The handler can pass that reference to `host.request.send` as `auth`, so a confined operation can call a secret-protected external API without the secret ever entering the guest.
+
+`optionDelivery` is operations-only in this version, and settings are dark, so an endpoint or panel has no source for a secret reference yet. A confined endpoint or panel that calls an external API must use a non-secret or public one for now.
+
+## Building and loading
+
+A confined extension is checked twice: once when it is built, and again when the API loads it.
+
+At build time, the confined build bundles the server entry into a single self-contained artifact that exposes the contract's global. The build runs with Node builtins not externalized, so a `node:` import or any other unresolved import fails the build rather than being left to fail at runtime. Every bundled input is then containment-checked against the package root: an input that resolves inside the package, or to a published dependency under `node_modules`, is allowed, while a `workspace:`, `file:`, or `link:` dependency that resolves to a directory outside the package is refused. So a confined build needs its dependencies installed as published `node_modules` entries, not linked from a workspace. The build output is deterministic, so the same inputs produce a byte-stable artifact.
+
+At load time, the API re-reads the manifest under a capped read, re-checks the confined declaration and the extension's identity against the bytes it just read, resolves the declared server source set, runs a static source scan over it, and then probes the built artifact inside the sandbox to confirm the declared contract has a real binding. The gate is fail-closed: any unreadable, oversized, malformed, or contradictory input refuses, and the row is recorded as a load failure with a sanitized reason. A confined bundle probes its one shared artifact against all of its declared server entries at once, so one bad entry fails the bundle's server side.
+
+The source scanner runs at load time, not at build time. The two checks are complementary: the build keeps host imports and stray dependencies out of the artifact, and the load gate re-verifies the manifest, scans the declared source, and proves the artifact runs before the extension is admitted.
+
+To scaffold a confined extension, pass `--confined` to the create command. [Creating extensions](/docs/develop/extensions/creating-extensions/) covers the command path.
+
+## Diagnostics
+
+The resolved state of every extension is on the Settings > Extensions page. Each extension can be opened to display the runtime label: Sandboxed, Full authority, or Browser app. A sandboxed entry row shows its declared capabilities, and a `partial` status when some of its entries loaded and others did not.
+
+An Advanced Diagnostics section holds the OS-hardening posture: the resolved mode, the decision to run or refuse, which hardening layers were applied, which are missing, and the cgroup mechanic when one is used. The same diagnostics are available from the `GET /extensions` API.

--- a/docs/develop/extensions/server-extensions/services.md
+++ b/docs/develop/extensions/server-extensions/services.md
@@ -1,0 +1,62 @@
+---
+title: Internal services
+description: The platform services available to full-authority server extensions.
+sidebar:
+  label: Services
+  order: 10
+---
+
+A full-authority server extension (a hook, endpoint, or operation with no `runtime`) receives a `context` object carrying the platform's internal services. They are the same services the API uses, so working through them respects permissions, validation, and the event pipeline rather than going straight to the database.
+
+This page is the full-authority path. A confined extension does not get raw services. It reads through `host.items` instead. See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) reference.
+
+## Reaching the services
+
+The services arrive on the handler context, alongside `getSchema`:
+
+```js
+export default (router, { services, getSchema }) => {
+  router.get('/recent', async (req, res) => {
+    const { ItemsService } = services;
+
+    const articles = new ItemsService('articles', {
+      schema: await getSchema(),
+      accountability: req.accountability,
+    });
+
+    res.json(await articles.readByQuery({ sort: ['-date_created'], limit: 10 }));
+  });
+};
+```
+
+Most service constructors take an options object with a `schema` (from `getSchema()`) and an optional `accountability`. `ItemsService` also takes the collection name as its first argument. A few are specialized: `SchemaService`, for example, takes no `schema`. Check the service class when in doubt.
+
+## Accountability and permissions
+
+The `accountability` you pass decides whose permissions apply.
+
+- **Pass the request or trigger accountability** (`req.accountability` in an endpoint, the trigger's `accountability` in an operation or hook) to run as that user. Permissions, validation, and field access all apply as they would on a normal API call.
+- **Omit `accountability` or pass `null`** to bypass permission checks entirely. The service then runs with system authority. Use this deliberately, only for work that must run regardless of any user, and never with caller-supplied input that should have been permission-checked.
+
+## ItemsService
+
+`ItemsService` is the one you reach for most. It is CRUD over a collection's items: `createOne`, `createMany`, `readOne`, `readMany`, `readByQuery`, `updateOne`, `updateMany`, `updateByQuery`, `upsertOne`, `upsertMany`, `deleteOne`, `deleteMany`, and `deleteByQuery`. The read methods accept a query object the same shape the REST API uses (`fields`, `filter`, `sort`, `limit`, and so on).
+
+When a handler writes through `ItemsService` to a collection whose own event it is handling, pass `{ emitEvents: false }` to the write so it does not trigger itself recursively.
+
+## The other services
+
+The same `services` object exposes the rest of the platform's service layer, constructed the same way. The common ones:
+
+- **`CollectionsService`** — create, read, update, and delete collections.
+- **`FieldsService`** — manage fields on a collection.
+- **`RelationsService`** — manage relations between collections.
+- **`FilesService`** — import and upload files (`importOne`, `uploadOne`), plus the standard item methods.
+- **`UsersService`** — manage users.
+
+The registry holds more (activity, notifications, revisions, settings, shares, and so on). The `services` object is the current catalog. Construct most of them with `{ schema, accountability }`, and check the class for the specialized ones.
+
+## Where to go next
+
+- [Hooks](/docs/develop/extensions/server-extensions/hooks/), [Endpoints](/docs/develop/extensions/server-extensions/endpoints/), and [Operations](/docs/develop/extensions/server-extensions/operations/) show the services in their handler context.
+- [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) covers the confined alternative, `host.items`.

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -179,7 +179,7 @@ CairnCMS sets standard security response headers via Helmet. Most can be tuned p
 
 - **`HSTS_ENABLED`** — emit the `Strict-Transport-Security` header. Default `false`. Enable in production when serving over HTTPS.
 - **`HSTS_*`** — pass-through to Helmet's HSTS options (`HSTS_MAX_AGE`, `HSTS_INCLUDE_SUBDOMAINS`, `HSTS_PRELOAD`).
-- **`CONTENT_SECURITY_POLICY_*`** — pass-through to Helmet's CSP option shape. The default CSP allows the admin app to load its own assets and connect to the API origin.
+- **`CONTENT_SECURITY_POLICY_*`** — pass-through to Helmet's CSP option shape. The default policy limits the admin app's `connect-src` to first-party (`'self'`) plus the built-in map origins (OpenStreetMap tiles, OpenMapTiles fonts, and Mapbox), with no external wildcard. Setting `CONTENT_SECURITY_POLICY_DIRECTIVES__CONNECT_SRC` fully replaces that list, so include `'self'` and any map origins you still rely on. This bounds where an app extension can connect from the browser. See [Security hardening](/docs/manage/security-hardening/) for the extension egress details.
 - **`ASSETS_CONTENT_SECURITY_POLICY`** — separate CSP applied only to `/assets/*` responses. Useful when serving user-uploaded content with a stricter policy than the rest of the API.
 - **`IMPORT_IP_DENY_LIST`** — comma-separated exact IP addresses blocked from URL imports (SSRF defense). Matches are literal string comparisons; CIDR notation is not supported. Default blocks `0.0.0.0` and the EC2/cloud metadata endpoint `169.254.169.254`. The `0.0.0.0` entry has a special meaning: when present, all loopback addresses and any address bound to the host's own network interfaces are also blocked. To block other addresses, list each one explicitly.
 
@@ -351,6 +351,18 @@ Asset transformation settings:
 - **`EXTENSIONS_AUTO_RELOAD`** — when `true`, the API watches extension files and reloads on change, including when `NODE_ENV=development`. Default `false`. See the [Creating extensions](/docs/develop/extensions/creating-extensions/) page for the development workflow.
 - **`EXTENSIONS_CACHE_TTL`** — `Cache-Control` max-age applied to the `/extensions/*` bundle responses. Unset by default (no client cache).
 - **`PACKAGE_FILE_LOCATION`** — directory containing the project `package.json` (used to discover npm-installed extensions). Default `.`.
+
+### Sandboxed extensions
+
+These govern the sandboxed server runtime that a confined extension runs in. It is separate from the Flows Run Script sandbox documented below. The size variables accept a byte count or a size string such as `64MB`, and the timeout accepts a millisecond count or a duration string such as `10s`. See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) reference for the runtime model.
+
+- **`EXTENSIONS_SANDBOX_OS_HARDENING`** — `auto` or `required`. Default `auto`. Under `auto`, the OS hardening layers are applied wherever the host supports them and never block a confined extension from running. Under `required`, the runtime refuses to start a confined extension on a host that cannot provide the escape-containment core (the network namespace and the Node permission model).
+- **`EXTENSIONS_SANDBOX_MAX_MEMORY`** — per-invocation memory cap for the QuickJS guest heap. Default `64MB`. Bounded between 16MB and 512MB. When cgroup hardening is available, the whole-process memory limit is derived from this value plus the child's base RSS and headroom.
+- **`EXTENSIONS_SANDBOX_TIMEOUT`** — per-invocation wall-clock timeout for a confined child process. Default `10s`. Bounded between 1s and 5m.
+- **`EXTENSIONS_SANDBOX_MAX_PROCESSES`** — maximum number of concurrent confined child processes. Defaults to an adaptive value up to `4`, lowered on smaller hosts. An explicit value is bounded between 1 and 32 and fails closed if it would overcommit the sandbox memory budget.
+- **`EXTENSIONS_SANDBOX_MAX_RESULT`** — maximum serialized size of a handler result. Default `1MB`. Bounded between 1KB and 16MB.
+- **`EXTENSIONS_SANDBOX_MAX_HOST_API_CALL`** — maximum serialized size of a single `host.*` call payload. Default `256KB`. Bounded between 1KB and 4MB.
+- **`EXTENSIONS_SANDBOX_MAX_ARTIFACT`** — maximum size of a built confined artifact the loader will read. Default `8MB`. Bounded between 1KB and 32MB.
 
 ## Flows
 

--- a/docs/manage/security-hardening.md
+++ b/docs/manage/security-hardening.md
@@ -197,6 +197,26 @@ The redaction layers target secrets, not arbitrary PII. Operator-controlled debu
 
 For audit-heavy projects, leave activity logging on (the default) and configure the role's accountability tracking to include revisions, not just activity. Revisions let you reconstruct an item's full history; activity records what happened.
 
+## Extensions
+
+Extensions run third-party code inside the platform, so the security model depends on which runtime an extension uses. The [extension docs](/docs/develop/extensions/) cover the runtimes in full. The operator-facing summary:
+
+- **App extensions** run in the admin browser under the logged-in user's own permissions. They are not a security boundary, so treat an installed app extension as code you trust with that user's session.
+- **Full-authority server extensions** run in the API process with full access to services, the database, and the environment. They are unconfined. Install only what you are willing to run with that reach.
+- **Confined server extensions** run sandboxed. This is the boundary that lets you run a server extension without granting it the API process.
+
+### The confined sandbox
+
+A confined server extension runs in a QuickJS engine with no host imports, no Node, no `fetch`, and no filesystem. Every privileged effect goes through a brokered `host.*` call gated by the capabilities the extension declares in its manifest, so what an extension can reach is visible and bounded before it runs.
+
+The platform adds OS-level hardening around the sandbox child process where the host supports it: a network namespace, the Node permission model with a scoped read, and a cgroup memory cap. `EXTENSIONS_SANDBOX_OS_HARDENING` governs how strictly these are enforced. Under `auto`, the default, they are best-effort and never block an extension, because the engine boundary already contains the guest. Under `required`, the runtime refuses to start a confined extension on a host that cannot provide the escape-containment core (the network namespace and the Node permission model). See the [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) reference for the runtime model and [Configuration](/docs/manage/configuration/) for the sandbox variables.
+
+### App extension egress
+
+An app extension runs in the admin browser, so its outbound network access is governed by the admin app's Content Security Policy, not by the sandbox. The default `connect-src` is limited to first-party (`'self'`) plus the built-in map origins, with no external wildcard. An app extension that tries to fetch an external CDN or third-party API directly from the browser is blocked by that policy.
+
+The supported pattern is to route external data through a same-origin endpoint. A confined endpoint, or a bundle's confined endpoint entry, fetches the external API server-side under its declared `request` origins, and the app extension calls that endpoint on its own origin. If an operator genuinely needs the browser to reach a specific external origin, they can set `CONTENT_SECURITY_POLICY_DIRECTIVES__CONNECT_SRC`, which fully replaces the default list. See [Configuration](/docs/manage/configuration/).
+
 ## Where to go next
 
 - [Configuration](/docs/manage/configuration/) is the reference for every environment variable mentioned here.

--- a/docs/manage/upgrades.md
+++ b/docs/manage/upgrades.md
@@ -151,6 +151,10 @@ If you skip the rebuild on a major upgrade, the extension may still load, but it
 
 Bundles use the same `host` field; rebuilding a bundle rebuilds all of its entries.
 
+App extensions carry an extra consideration. They share the admin app's Vue runtime rather than bundling their own, so a host-Vue or SDK change can require rebuilding them even within a compatible `host` range. If an app extension fails to mount after an upgrade, rebuild it against the current SDK before investigating further. See [Creating extensions](/docs/develop/extensions/creating-extensions/).
+
+Confined extensions depend on the capability vocabulary and the brokered host API, which can grow or change across major versions. A confined extension may need its manifest `capabilities` or its `host.*` usage updated when those evolve. The [Sandbox](/docs/develop/extensions/server-extensions/sandbox/) reference documents the current capability set.
+
 ## Where to go next
 
 - [Backups](/docs/manage/backups/) — the prerequisite for any upgrade you would actually be willing to roll back from.

--- a/packages/extensions-server-api/LICENSE
+++ b/packages/extensions-server-api/LICENSE
@@ -1,0 +1,16 @@
+MIT License
+
+Copyright 2026 CairnCMS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/extensions-server-api/README.md
+++ b/packages/extensions-server-api/README.md
@@ -1,0 +1,52 @@
+# @cairncms/extensions-server-api
+
+The authoring API for sandboxed (confined) CairnCMS server extensions. It provides the `define*` entrypoints for confined flow operations, JSON endpoints, and event hooks, plus the types for the brokered `host.*` API the platform passes to every handler.
+
+## Install
+
+The scaffolder adds this package for you when you create a confined server extension:
+
+```sh
+npm init cairncms-extension
+```
+
+To add it to an existing project:
+
+```sh
+npm install --save-dev @cairncms/extensions-server-api
+```
+
+The confined build bundles this package away as an identity helper, so it is a development dependency, not a runtime one.
+
+## Usage
+
+A confined server extension exports a contribution defined with one of the `define*` helpers. The handler receives a `host` and never imports platform internals:
+
+```ts
+import { defineFlowOperation } from '@cairncms/extensions-server-api';
+
+export default defineFlowOperation({
+  id: 'my-op',
+  async handler(payload, { host }) {
+    const result = await host.request.send({ url: 'https://api.example.com/status' });
+
+    if (!result.ok) return { reached: false };
+
+    return { reached: true, status: result.value.status };
+  },
+});
+```
+
+The three entrypoints:
+
+- `defineFlowOperation` for a flow operation.
+- `defineJsonEndpoint` for an HTTP endpoint, where the handler is the whole endpoint and returns `{ status?, body }`.
+- `defineEventHook` for filter and action event hooks.
+
+Every privileged effect goes through the brokered `host.*` API (`host.log`, `host.request`, `host.items`, `host.settings`, `host.template`), gated by the capabilities the extension declares in its manifest. Most of these calls return an `ExtensionResult` envelope, so a handler branches on the outcome rather than catching exceptions. Logging is fire-and-forget and resolves to nothing.
+
+For the full host API, the capability vocabulary, and the runtime model, see the [Sandbox documentation](https://cairncms.dev/docs/develop/extensions/server-extensions/sandbox/).
+
+## License
+
+[MIT](./LICENSE).


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Reorganizes the extension docs into app and server lanes, adds the sandbox reference, documents confined variants for server extension types, and fills in missing references for composables, UI components, internal services, CLI usage, configuration, diagnostics, browser egress, and upgrade notes. It also adds the missing README and MIT license file for `@cairncms/extensions-server-api`.

### Testing / verification

Verified the docs against source for:
- sandbox guarantees, OS hardening, environment variables, and diagnostics metadata
- confined capabilities, host API behavior, endpoint access, hook events, and operation `optionDelivery`
- app extension CSP egress defaults and `CONTENT_SECURITY_POLICY_DIRECTIVES__CONNECT_SRC`
- SDK composable exports and signatures
- app extension config fields for interfaces, displays, layouts, modules, and panels
- full-authority service constructor and accountability behavior
- SDK CLI commands and flag values
- bundle manifest shape, confined bundle rules, and `partial` diagnostics semantics

Also verified:
- moved extension pages are relinked under the app and server folders
- new overview, sandbox, composables, UI components, and services pages are linked from the lane overviews
- emitted hook events include the documented `auth.create` and `auth.update` events
- `@cairncms/extensions-server-api` now has package README and LICENSE files matching its package metadata

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
