### PR TITLE
Bump Vitest to 3.2.6

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -189,14 +189,14 @@
 		"@types/supertest": "2.0.12",
 		"@types/uuid-validate": "0.0.1",
 		"@types/wellknown": "0.5.4",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"copyfiles": "2.4.1",
 		"esbuild": "0.17.17",
 		"form-data": "4.0.4",
 		"knex-mock-client": "2.0.0",
 		"supertest": "6.3.3",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"optionalDependencies": {
 		"@keyv/redis": "2.5.7",

--- a/api/src/middleware/authenticate.test.ts
+++ b/api/src/middleware/authenticate.test.ts
@@ -200,7 +200,7 @@ test('Throws InvalidCredentialsException when static token is used, but user doe
 	const res = {} as Response;
 	const next = vi.fn();
 
-	expect(handler(req, res, next)).rejects.toEqual(new InvalidCredentialsException());
+	await expect(handler(req, res, next)).rejects.toEqual(new InvalidCredentialsException());
 	expect(next).toHaveBeenCalledTimes(0);
 });
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -456,7 +456,7 @@ describe('Integration Tests', () => {
 						schema: schemas[schema].schema,
 					});
 
-					expect(() =>
+					await expect(
 						itemsService.readOne(rawItems[0]!.id, { filter: { name: { _eq: 'something' } } })
 					).rejects.toThrow("You don't have permission to access this.");
 
@@ -678,7 +678,7 @@ describe('Integration Tests', () => {
 						schema: schemas[schema].schema,
 					});
 
-					expect(() =>
+					await expect(
 						itemsService.readOne(rawItems[0]!.id, {
 							fields: ['id', 'items.*'],
 							deep: { items: { _filter: { title: { _eq: childItems[0]!.title } } } as NestedDeepQuery },
@@ -706,7 +706,7 @@ describe('Integration Tests', () => {
 						schema: customSchema,
 					});
 
-					expect(() => itemsService.readOne(rawItems[0]!.id)).rejects.toThrow(
+					await expect(itemsService.readOne(rawItems[0]!.id)).rejects.toThrow(
 						"You don't have permission to access this."
 					);
 
@@ -740,7 +740,7 @@ describe('Integration Tests', () => {
 						schema: schemas[schema].schema,
 					});
 
-					expect(() => itemsService.readOne(rawItems[0]!.id)).rejects.toThrow(
+					await expect(itemsService.readOne(rawItems[0]!.id)).rejects.toThrow(
 						"You don't have permission to access this."
 					);
 

--- a/api/src/services/schema.test.ts
+++ b/api/src/services/schema.test.ts
@@ -79,7 +79,7 @@ describe('Services / Schema', () => {
 
 			const service = new SchemaService({ knex: db, accountability: { role: 'test', admin: false } });
 
-			expect(service.snapshot()).rejects.toThrowError(ForbiddenException);
+			await expect(service.snapshot()).rejects.toThrowError(ForbiddenException);
 		});
 
 		it('should return snapshot for admin user', async () => {
@@ -87,7 +87,7 @@ describe('Services / Schema', () => {
 
 			const service = new SchemaService({ knex: db, accountability: { role: 'admin', admin: true } });
 
-			expect(service.snapshot()).resolves.toEqual(testSnapshot);
+			await expect(service.snapshot()).resolves.toEqual(testSnapshot);
 		});
 	});
 
@@ -106,7 +106,7 @@ describe('Services / Schema', () => {
 
 			const service = new SchemaService({ knex: db, accountability: { role: 'test', admin: false } });
 
-			expect(service.apply(snapshotDiffWithHash)).rejects.toThrowError(ForbiddenException);
+			await expect(service.apply(snapshotDiffWithHash)).rejects.toThrowError(ForbiddenException);
 			expect(vi.mocked(applyDiff)).not.toHaveBeenCalledOnce();
 		});
 
@@ -152,7 +152,7 @@ describe('Services / Schema', () => {
 		it('should throw ForbiddenException for non-admin user', async () => {
 			const service = new SchemaService({ knex: db, accountability: { role: 'test', admin: false } });
 
-			expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).rejects.toThrowError(
+			await expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).rejects.toThrowError(
 				ForbiddenException
 			);
 		});
@@ -160,7 +160,7 @@ describe('Services / Schema', () => {
 		it('should return diff for admin user', async () => {
 			const service = new SchemaService({ knex: db, accountability: { role: 'admin', admin: true } });
 
-			expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).resolves.toEqual({
+			await expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).resolves.toEqual({
 				collections: [testCollectionDiff],
 				fields: [],
 				relations: [],
@@ -170,7 +170,7 @@ describe('Services / Schema', () => {
 		it('should return null for empty diff', async () => {
 			const service = new SchemaService({ knex: db, accountability: { role: 'admin', admin: true } });
 
-			expect(service.diff(testSnapshot, { currentSnapshot: testSnapshot, force: true })).resolves.toBeNull();
+			await expect(service.diff(testSnapshot, { currentSnapshot: testSnapshot, force: true })).resolves.toBeNull();
 		});
 	});
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -843,7 +843,7 @@ describe('Integration Tests', () => {
 
 			describe('GHSA-jr94-gj3h-c8rf', () => {
 				it('rejects an invalid reset_url BEFORE the user lookup (non-existing user)', async () => {
-					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(null);
+					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail');
 
 					await expect(service.requestPasswordReset('attacker@example.com', 'https://evil.com')).rejects.toBeInstanceOf(
 						InvalidPayloadException
@@ -853,13 +853,7 @@ describe('Integration Tests', () => {
 				});
 
 				it('rejects an invalid reset_url BEFORE the user lookup (inactive user)', async () => {
-					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
-						id: 'user-id',
-						role: 'user-role',
-						status: 'suspended',
-						password: 'hashed-password',
-						email: 'suspended@example.com',
-					});
+					const getUserSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail');
 
 					await expect(
 						service.requestPasswordReset('suspended@example.com', 'https://evil.com')

--- a/api/src/utils/stall.test.ts
+++ b/api/src/utils/stall.test.ts
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks';
 import type { SpyInstance } from 'vitest';
 import { afterAll, beforeAll, expect, test, vi } from 'vitest';
 import { stall } from './stall.js';

--- a/app/package.json
+++ b/app/package.json
@@ -108,7 +108,7 @@
 		"tinymce": "7.2.1",
 		"typescript": "5.0.4",
 		"vite": "5.4.21",
-		"vitest": "1.6.1",
+		"vitest": "3.2.6",
 		"vue": "3.5.38",
 		"vue-i18n": "9.14.5",
 		"vue-router": "4.6.4",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -30,11 +30,11 @@
 	"devDependencies": {
 		"@cairncms/types": "workspace:*",
 		"@types/lodash-es": "4.17.7",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"@vue/test-utils": "2.4.11",
 		"axios": "1.15.2",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"dependencies": {
 		"@cairncms/constants": "workspace:*",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -29,7 +29,7 @@
 	},
 	"devDependencies": {
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"dependencies": {
 		"zod": "3.23.8"

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -30,9 +30,9 @@
 	"devDependencies": {
 		"@cairncms/types": "workspace:*",
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"joi": "17.9.1",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -69,9 +69,9 @@
 		"@types/fs-extra": "11.0.1",
 		"@types/inquirer": "9.0.3",
 		"@types/node": "22.19.17",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"engines": {
 		"node": "^18.0.0 || >=20.0.0"

--- a/packages/extensions-server-api/package.json
+++ b/packages/extensions-server-api/package.json
@@ -34,6 +34,6 @@
 	"devDependencies": {
 		"@types/node": "22.19.17",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -49,6 +49,6 @@
 	"devDependencies": {
 		"@types/node": "22.19.17",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/format-title/package.json
+++ b/packages/format-title/package.json
@@ -27,8 +27,8 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -29,9 +29,9 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.17.17",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"dependencies": {
 		"@cairncms/utils": "workspace:*"

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -33,8 +33,8 @@
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -34,8 +34,8 @@
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -33,8 +33,8 @@
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -32,8 +32,8 @@
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -35,8 +35,8 @@
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/storage-driver-s3/src/index.test.ts
+++ b/packages/storage-driver-s3/src/index.test.ts
@@ -306,6 +306,7 @@ describe('#fullPath', () => {
 
 describe('#read', () => {
 	beforeEach(() => {
+		driver['getClient'] = vi.fn().mockReturnValue(driver['client']);
 		vi.mocked(driver['client'].send).mockReturnValue({ Body: new Readable() } as unknown as void);
 		vi.mocked(isReadableStream).mockReturnValue(true);
 	});
@@ -365,7 +366,7 @@ describe('#read', () => {
 	test('Throws an error when returned stream is not a readable stream', async () => {
 		vi.mocked(isReadableStream).mockReturnValue(false);
 
-		expect(driver.read(sample.path.input, sample.range)).rejects.toThrowError(
+		await expect(driver.read(sample.path.input, sample.range)).rejects.toThrowError(
 			new Error(`No stream returned for file "${sample.path.input}"`)
 		);
 	});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -28,8 +28,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "22.19.17",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -33,8 +33,8 @@
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",
 		"@types/semver": "7.3.13",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/packages/utils/node/ensure-extension-dirs.test.ts
+++ b/packages/utils/node/ensure-extension-dirs.test.ts
@@ -19,9 +19,9 @@ describe('ensureExtensionDirs', () => {
 		expect(await ensureExtensionDirs(rootDir.name, NESTED_EXTENSION_TYPES)).toBe(undefined);
 	});
 
-	it('throws an error when a folder can not be opened', () => {
-		expect(async () => {
-			await ensureExtensionDirs('/.', NESTED_EXTENSION_TYPES);
-		}).rejects.toThrow(`Extension folder "/interfaces" couldn't be opened`);
+	it('throws an error when a folder can not be opened', async () => {
+		await expect(ensureExtensionDirs('/.', NESTED_EXTENSION_TYPES)).rejects.toThrow(
+			`Extension folder "/interfaces" couldn't be opened`
+		);
 	});
 });

--- a/packages/utils/node/readable-stream-to-string.test.ts
+++ b/packages/utils/node/readable-stream-to-string.test.ts
@@ -6,6 +6,6 @@ import { readableStreamToString } from './readable-stream-to-string.js';
 test.each([Readable.from('test', { encoding: 'utf8' }), Readable.from(Buffer.from([0x74, 0x65, 0x73, 0x74]))])(
 	'Returns readable stream as string',
 	async (readableStream) => {
-		expect(readableStreamToString(readableStream)).resolves.toBe('test');
+		await expect(readableStreamToString(readableStream)).resolves.toBe('test');
 	}
 );

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -54,9 +54,9 @@
 		"@types/lodash-es": "4.17.7",
 		"@types/node": "22.19.17",
 		"@types/tmp": "0.2.6",
-		"@vitest/coverage-v8": "1.6.1",
+		"@vitest/coverage-v8": "3.2.6",
 		"concurrently": "8.0.1",
 		"typescript": "5.0.4",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,8 +464,8 @@ importers:
         specifier: 0.5.4
         version: 0.5.4
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -485,8 +485,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
     optionalDependencies:
       '@keyv/redis':
         specifier: 2.5.7
@@ -772,8 +772,8 @@ importers:
         specifier: 5.4.21
         version: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
       vue:
         specifier: 3.5.38
         version: 3.5.38(typescript@5.0.4)
@@ -821,8 +821,8 @@ importers:
         specifier: 4.17.7
         version: 4.17.7
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       '@vue/test-utils':
         specifier: 2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.0.4)))(vue@3.5.38(typescript@5.0.4))
@@ -833,8 +833,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/constants:
     dependencies:
@@ -846,8 +846,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/create-cairncms-extension:
     dependencies:
@@ -870,8 +870,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       joi:
         specifier: 17.9.1
         version: 17.9.1
@@ -879,8 +879,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/extensions:
     dependencies:
@@ -895,8 +895,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/extensions-sdk:
     dependencies:
@@ -983,14 +983,14 @@ importers:
         specifier: 22.19.17
         version: 22.19.17
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/extensions-server-api:
     devDependencies:
@@ -1001,20 +1001,20 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/format-title:
     devDependencies:
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/pressure:
     dependencies:
@@ -1026,14 +1026,14 @@ importers:
         specifier: 4.17.17
         version: 4.17.17
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/schema:
     dependencies:
@@ -1070,14 +1070,14 @@ importers:
         specifier: 22.19.17
         version: 22.19.17
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-azure:
     dependencies:
@@ -1095,14 +1095,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-cloudinary:
     dependencies:
@@ -1123,14 +1123,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-gcs:
     dependencies:
@@ -1148,14 +1148,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-local:
     dependencies:
@@ -1170,14 +1170,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/storage-driver-s3:
     dependencies:
@@ -1201,14 +1201,14 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/types:
     devDependencies:
@@ -1265,14 +1265,14 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   packages/utils:
     dependencies:
@@ -1317,8 +1317,8 @@ importers:
         specifier: 0.2.6
         version: 0.2.6
       '@vitest/coverage-v8':
-        specifier: 1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))
       concurrently:
         specifier: 8.0.1
         version: 8.0.1
@@ -1326,8 +1326,8 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   sdk:
     devDependencies:
@@ -1350,8 +1350,8 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
       vitest:
-        specifier: 1.6.1
-        version: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
 
   tests/blackbox:
     devDependencies:
@@ -2087,6 +2087,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -3688,6 +3692,9 @@ packages:
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chroma-js@2.4.4':
     resolution: {integrity: sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==}
 
@@ -3722,6 +3729,9 @@ packages:
 
   '@types/deep-diff@1.0.2':
     resolution: {integrity: sha512-WD2O611C7Oz7RSwKbSls8LaznKfWfXh39CHY9Amd8FhQz+NJRe20nUHhYpOopVq9M2oqDZd4L6AzqJIXQycxiA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/destroy@1.0.0':
     resolution: {integrity: sha512-nE3ePJLWPRu/qFHN8mj3fWnkr9K9ezwoiG4yOis2DuLeAawlnOOT/pM29JQkityrwfEvkblU5O9iS1bsiMqtDw==}
@@ -4040,25 +4050,43 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@1.6.1':
-    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+  '@vitest/coverage-v8@3.2.6':
+    resolution: {integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==}
     peerDependencies:
-      vitest: 1.6.1
+      '@vitest/browser': 3.2.6
+      vitest: 3.2.6
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/expect@1.6.1':
-    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/runner@1.6.1':
-    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
-  '@vitest/snapshot@1.6.1':
-    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
 
-  '@vitest/spy@1.6.1':
-    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
 
-  '@vitest/utils@1.6.1':
-    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@vue/compiler-core@3.5.38':
     resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
@@ -4135,10 +4163,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -4281,8 +4305,12 @@ packages:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -4350,6 +4378,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-64@0.1.0:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
 
@@ -4402,6 +4434,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4528,9 +4564,9 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -4554,8 +4590,9 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -5119,8 +5156,8 @@ packages:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-extend@0.6.0:
@@ -5527,10 +5564,6 @@ packages:
     resolution: {integrity: sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==}
     engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exif-reader@1.2.0:
     resolution: {integrity: sha512-C9jsLWxaUh9/gNwo9Ouf9jxP0vGn/2vkhu89wbPFyFfpfl8WPbwLrvrb7h9Q6oVvkyvA+e4lXgOllW+/bAk0RQ==}
 
@@ -5541,6 +5574,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -5814,9 +5851,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -5836,10 +5870,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -6087,10 +6117,6 @@ packages:
   human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -6581,6 +6607,9 @@ packages:
   js-sdsl@4.4.2:
     resolution: {integrity: sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -6798,10 +6827,6 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  local-pkg@0.5.1:
-    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
-    engines: {node: '>=14'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -6866,8 +6891,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -7044,6 +7069,10 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.4:
     resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
@@ -7415,10 +7444,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -7519,14 +7544,12 @@ packages:
   path@0.12.7:
     resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pbf@3.3.0:
     resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
@@ -8659,8 +8682,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@2.1.1:
-    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
@@ -8805,6 +8828,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -8864,15 +8891,19 @@ packages:
   tinymce@7.2.1:
     resolution: {integrity: sha512-ADd1cvdIuq6NWyii0ZOZRuu+9sHIdQfcRNWBcBps2K8vy7OjlRkX6iw7zz1WlL9kY4z4L1DvIP+xOrVX/46aHA==}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyqueue@2.0.3:
     resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
 
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
@@ -9011,10 +9042,6 @@ packages:
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
   type-fest@0.18.1:
@@ -9190,9 +9217,9 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
-  vite-node@1.6.1:
-    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@5.4.21:
@@ -9226,19 +9253,22 @@ packages:
       terser:
         optional: true
 
-  vitest@1.6.1:
-    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.1
-      '@vitest/ui': 1.6.1
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -9487,10 +9517,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -10703,6 +10729,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -12080,6 +12108,11 @@ snapshots:
   '@types/caseless@0.12.5':
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chroma-js@2.4.4': {}
 
   '@types/codemirror@5.60.7':
@@ -12117,6 +12150,8 @@ snapshots:
       - postcss
 
   '@types/deep-diff@1.0.2': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/destroy@1.0.0':
     dependencies:
@@ -12499,10 +12534,11 @@ snapshots:
       vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
       vue: 3.5.38(typescript@5.0.4)
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
       debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -12510,42 +12546,54 @@ snapshots:
       istanbul-reports: 3.2.0
       magic-string: 0.30.21
       magicast: 0.3.5
-      picocolors: 1.1.1
       std-env: 3.10.0
-      strip-literal: 2.1.1
-      test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@1.6.1':
+  '@vitest/expect@3.2.6':
     dependencies:
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      chai: 4.5.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
-  '@vitest/runner@1.6.1':
+  '@vitest/mocker@3.2.6(vite@5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1))':
     dependencies:
-      '@vitest/utils': 1.6.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
-  '@vitest/snapshot@1.6.1':
-    dependencies:
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-
-  '@vitest/spy@1.6.1':
-    dependencies:
-      tinyspy: 2.2.1
-
-  '@vitest/utils@1.6.1':
-    dependencies:
-      diff-sequences: 29.6.3
+      '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.5.38':
     dependencies:
@@ -12634,10 +12682,6 @@ snapshots:
       negotiator: 0.6.3
 
   acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
-  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -12785,7 +12829,13 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
-  assertion-error@1.1.0: {}
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -12904,6 +12954,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-64@0.1.0: {}
 
   base-64@1.0.0: {}
@@ -12967,6 +13019,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -13125,15 +13181,13 @@ snapshots:
   caseless@0.12.0:
     optional: true
 
-  chai@4.5.0:
+  chai@5.3.3:
     dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@2.4.2:
     dependencies:
@@ -13154,9 +13208,7 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
+  check-error@2.1.3: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -13557,9 +13609,7 @@ snapshots:
 
   deep-diff@1.0.2: {}
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -14138,23 +14188,13 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   exif-reader@1.2.0: {}
 
   exit@0.1.2: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -14499,8 +14539,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-func-name@2.0.2: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -14526,8 +14564,6 @@ snapshots:
       pump: 3.0.4
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -14824,8 +14860,6 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@4.3.1: {}
-
-  human-signals@5.0.0: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -15518,6 +15552,8 @@ snapshots:
 
   js-sdsl@4.4.2: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -15742,11 +15778,6 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
-  local-pkg@0.5.1:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 1.3.1
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -15801,9 +15832,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
+  loupe@3.2.1: {}
 
   lowercase-keys@2.0.0: {}
 
@@ -15837,8 +15866,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   mailgun.js@8.2.2:
@@ -16033,6 +16062,10 @@ snapshots:
   mimic-response@3.1.0: {}
 
   min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.1.4:
     dependencies:
@@ -16493,10 +16526,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -16585,11 +16614,9 @@ snapshots:
       process: 0.11.10
       util: 0.10.4
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
 
-  pathval@1.1.1: {}
+  pathval@2.0.1: {}
 
   pbf@3.3.0:
     dependencies:
@@ -17918,7 +17945,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@2.1.1:
+  strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
 
@@ -18144,6 +18171,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.4
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -18194,11 +18227,13 @@ snapshots:
 
   tinymce@7.2.1: {}
 
-  tinypool@0.8.4: {}
+  tinypool@1.1.1: {}
 
   tinyqueue@2.0.3: {}
 
-  tinyspy@2.2.1: {}
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -18331,8 +18366,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
-
-  type-detect@4.1.0: {}
 
   type-fest@0.18.1: {}
 
@@ -18499,12 +18532,12 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@1.6.1(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1):
+  vite-node@3.2.4(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
-      pathe: 1.1.2
-      picocolors: 1.1.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
       vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -18528,27 +18561,30 @@ snapshots:
       sass: 1.62.0
       terser: 5.46.1
 
-  vitest@1.6.1(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1):
+  vitest@3.2.6(@types/node@22.19.17)(happy-dom@14.12.3)(sass@1.62.0)(terser@5.46.1):
     dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.5
-      chai: 4.5.0
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
       debug: 4.4.3
-      execa: 8.0.1
-      local-pkg: 0.5.1
+      expect-type: 1.3.0
       magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
-      strip-literal: 2.1.1
       tinybench: 2.9.0
-      tinypool: 0.8.4
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
       vite: 5.4.21(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
-      vite-node: 1.6.1(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
+      vite-node: 3.2.4(@types/node@22.19.17)(sass@1.62.0)(terser@5.46.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -18556,6 +18592,7 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus
@@ -18813,7 +18850,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   zod@3.23.8: {}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -39,7 +39,7 @@
 		"sqlite3": "5.1.6",
 		"tsup": "8.5.1",
 		"typescript": "5.4.5",
-		"vitest": "1.6.1"
+		"vitest": "3.2.6"
 	},
 	"engines": {
 		"node": ">=22.0.0"


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves CVE-2026-47429 for Vitest.

This bumps every direct workspace `vitest` and `@vitest/coverage-v8` pin from 1.6.1 to exact 3.2.6 without adding a root override. The update also refreshes tests that relied on Vitest 1 behavior such as async assertions are now awaited, the S3 read test mocks the fresh client used by `read()`, the stall test spies the same `perf_hooks.performance` object used by the implementation, and password-reset tests no longer leave unconsumed one-shot mocks queued for later cases.

### Testing / verification

Updated existing tests covering:
- S3 reads through the fresh client returned by `getClient()`
- password reset rejection before user lookup
- stall timing against the imported `perf_hooks.performance` object
- async `.rejects` and `.resolves` assertions that Vitest 3 warns must be awaited

Also verified:
- no `vitest@1.6.1` or `@vitest/coverage-v8@1.6.1` entries remain in the lockfile
- no Vitest UI, browser mode, network host, `allowWrite`, or `allowExec` configuration was added

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
