### PR TITLE
Bump axios to 1.16.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -80,7 +80,7 @@
 		"@sebastianwessel/quickjs": "3.0.1",
 		"argon2": "0.40.3",
 		"async": "3.2.4",
-		"axios": "1.15.2",
+		"axios": "1.16.0",
 		"busboy": "1.6.0",
 		"bytes": "3.1.2",
 		"camelcase": "7.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -68,7 +68,7 @@
 		"@vitejs/plugin-vue": "5.2.4",
 		"@vue/test-utils": "2.4.11",
 		"apexcharts": "3.39.0",
-		"axios": "1.15.2",
+		"axios": "1.16.0",
 		"base-64": "1.0.0",
 		"c8": "7.13.0",
 		"caret-pos": "2.0.0",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -32,7 +32,7 @@
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-v8": "3.2.6",
 		"@vue/test-utils": "2.4.11",
-		"axios": "1.15.2",
+		"axios": "1.16.0",
 		"typescript": "5.0.4",
 		"vitest": "3.2.6"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: 3.2.4
         version: 3.2.4
       axios:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.16.0
+        version: 1.16.0
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -652,8 +652,8 @@ importers:
         specifier: 3.39.0
         version: 3.39.0
       axios:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.16.0
+        version: 1.16.0
       base-64:
         specifier: 1.0.0
         version: 1.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: 2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.0.4)))(vue@3.5.38(typescript@5.0.4))
       axios:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.16.0
+        version: 1.16.0
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1377,8 +1377,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       axios:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.16.0
+        version: 1.16.0
       globby:
         specifier: 11.1.0
         version: 11.1.0
@@ -4343,8 +4343,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -12885,7 +12885,7 @@ snapshots:
   aws4@1.13.2:
     optional: true
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -15872,7 +15872,7 @@ snapshots:
 
   mailgun.js@8.2.2:
     dependencies:
-      axios: 1.15.2
+      axios: 1.16.0
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:

--- a/tests/blackbox/package.json
+++ b/tests/blackbox/package.json
@@ -12,7 +12,7 @@
 		"@types/seedrandom": "3.0.5",
 		"@types/supertest": "2.0.12",
 		"autocannon": "7.10.0",
-		"axios": "1.15.2",
+		"axios": "1.16.0",
 		"globby": "11.1.0",
 		"jest": "29.5.0",
 		"jest-environment-node": "29.5.0",


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves multiple CVEs for Axios.

This bumps every direct workspace `axios` pin from 1.15.2 to exact 1.16.0 without adding an override or changing adapter behavior. The server-side bounded request path remains unchanged, including the confined runtime broker's finite request and response size limits.

### Testing / verification

Verified the dependency update covers:
- `api/package.json`
- `app/package.json`
- `packages/composables/package.json`
- `tests/blackbox/package.json`

Also verified:
- no `axios@1.15.2` entries remain in the lockfile
- no Axios fetch adapter, `env.fetch`, or adapter override configuration was added
- the confined broker still passes finite `maxContentLength` and `maxBodyLength` values

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
