### PR TITLE
Override shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 			"fast-uri": "3.1.2",
 			"ip-address": "10.1.1",
 			"@tootallnate/once@1": "2.0.1",
-			"@tootallnate/once@2": "2.0.1"
+			"@tootallnate/once@2": "2.0.1",
+			"shell-quote@<1.8.4": "1.8.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ overrides:
   ip-address: 10.1.1
   '@tootallnate/once@1': 2.0.1
   '@tootallnate/once@2': 2.0.1
+  shell-quote@<1.8.4: 1.8.4
 
 importers:
 
@@ -8387,8 +8388,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -13371,7 +13372,7 @@ snapshots:
       date-fns: 2.29.3
       lodash: 4.18.1
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       spawn-command: 0.0.2-1
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -17598,7 +17599,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Resolves CVE-2026-9277.

The vulnerable package is not used by CairnCMS production code, but the alert still applies to the installed developer dependency graph.

Adds a narrow pnpm selector override for `shell-quote@<1.8.4` and resolves the transitive dependency to `shell-quote@1.8.4`. The override acts as a security floor, so it does not add a direct dependency and does not pin future compatible versions above the patched release.

### Testing / verification

Verified the dependency graph:
- `pnpm why -r shell-quote` resolves a single `shell-quote@1.8.4` edge through `concurrently`
- `pnpm-lock.yaml` no longer contains `shell-quote@1.8.3`
- no direct `shell-quote` dependency was added

Verified the affected workspace:
- `pnpm --filter @cairncms/utils build`
- `pnpm --filter @cairncms/utils test`
- `concurrently --version` still resolves and runs

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
