### PR TITLE
Declare axios as a runtime dependency of composables

### DIFF
--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -32,13 +32,13 @@
 		"@types/lodash-es": "4.17.7",
 		"@vitest/coverage-v8": "3.2.6",
 		"@vue/test-utils": "2.4.11",
-		"axios": "1.16.0",
 		"typescript": "5.0.4",
 		"vitest": "3.2.6"
 	},
 	"dependencies": {
 		"@cairncms/constants": "workspace:*",
 		"@cairncms/utils": "workspace:*",
+		"axios": "1.16.0",
 		"lodash-es": "4.18.1",
 		"nanoid": "5.0.9",
 		"vue": "3.5.38"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,9 @@ importers:
       '@cairncms/utils':
         specifier: workspace:*
         version: link:../utils
+      axios:
+        specifier: 1.16.0
+        version: 1.16.0
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -827,9 +830,6 @@ importers:
       '@vue/test-utils':
         specifier: 2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.0.4)))(vue@3.5.38(typescript@5.0.4))
-      axios:
-        specifier: 1.16.0
-        version: 1.16.0
       typescript:
         specifier: 5.0.4
         version: 5.0.4


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Declares `axios` as a runtime dependency of `@cairncms/composables`, matching the package's actual import graph.

### Testing / verification

Verified the package metadata change by confirming:
- `axios` moved from the composables dev dependency block to the runtime dependency block
- the lockfile change is limited to the `packages/composables` importer
- the packaged `@cairncms/composables` manifest includes `axios` under `dependencies` and not under `devDependencies`

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
