### PR TITLE
Localize the presentation-notice empty-text fallback

### DIFF
--- a/app/src/interfaces/presentation-notice/presentation-notice.vue
+++ b/app/src/interfaces/presentation-notice/presentation-notice.vue
@@ -1,12 +1,16 @@
 <template>
 	<div class="presentation-notice">
 		<v-notice :icon="icon" :type="color">
-			<div v-md="text" />
+			<div v-md="text ?? t('interfaces.presentation-notice.no_text')" />
 		</v-notice>
 	</div>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
 withDefaults(
 	defineProps<{
 		color?: string;
@@ -16,7 +20,6 @@ withDefaults(
 	{
 		color: 'normal',
 		icon: 'info',
-		text: 'No text configured...',
 	}
 );
 </script>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1659,6 +1659,7 @@ interfaces:
     notice: Notice
     description: Display a short notice
     text: Enter notice content here...
+    no_text: No text configured...
   list-o2m:
     one-to-many: One to Many
     description: Select multiple related items


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Localizes the empty presentation-notice fallback in the admin app. The interface previously supplied `No text configured...` as a hard-coded prop default, so users saw English whenever a notice had no configured text. This PR moves that fallback to `interfaces.presentation-notice.no_text`, adds the English base translation key, and leaves configured notice content plus the existing color and icon defaults unchanged.

This PR is limited to admin app presentation text. It does not change saved field configuration, API behavior, permissions, auth, storage, redirects, token handling, logging, or platform security boundaries.

### Testing / verification

Verified:
- the empty notice path references `interfaces.presentation-notice.no_text`
- `en-US.yaml` defines the matching `no_text` key in the presentation-notice block
- configured notice content still renders through the existing markdown binding
- the interface registry still loads
- the app build completes

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
