### PR TITLE
Use typed option defaults and remove no-op schema entries

### DIFF
--- a/app/src/interfaces/_system/system-display-template/index.ts
+++ b/app/src/interfaces/_system/system-display-template/index.ts
@@ -18,9 +18,6 @@ export default defineInterface({
 				width: 'full',
 				interface: 'input',
 			},
-			schema: {
-				default_value: null,
-			},
 		},
 	],
 });

--- a/app/src/interfaces/_system/system-inline-fields/system-inline-fields.vue
+++ b/app/src/interfaces/_system/system-inline-fields/system-inline-fields.vue
@@ -80,7 +80,6 @@ const repeaterFields = computed(() => {
 					placeholder: t('field_key_placeholder'),
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('field_name'),
@@ -93,7 +92,6 @@ const repeaterFields = computed(() => {
 					placeholder: t('field_name_placeholder'),
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('type'),
@@ -106,7 +104,6 @@ const repeaterFields = computed(() => {
 					choices: translate(FIELD_TYPES_SELECT),
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('interface_label'),
@@ -119,7 +116,6 @@ const repeaterFields = computed(() => {
 					typeField: 'type',
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('note'),
@@ -132,7 +128,6 @@ const repeaterFields = computed(() => {
 					placeholder: t('interfaces.list.field_note_placeholder'),
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('field_width'),
@@ -154,7 +149,6 @@ const repeaterFields = computed(() => {
 					],
 				},
 			},
-			schema: null,
 		},
 		{
 			name: t('required'),

--- a/app/src/interfaces/file-image/index.ts
+++ b/app/src/interfaces/file-image/index.ts
@@ -22,9 +22,6 @@ export default defineInterface({
 				interface: 'system-folder',
 				note: '$t:interfaces.system-folder.field_hint',
 			},
-			schema: {
-				default_value: undefined,
-			},
 		},
 		{
 			field: 'crop',

--- a/app/src/interfaces/file/index.ts
+++ b/app/src/interfaces/file/index.ts
@@ -22,9 +22,6 @@ export default defineInterface({
 				interface: 'system-folder',
 				note: '$t:interfaces.system-folder.field_hint',
 			},
-			schema: {
-				default_value: undefined,
-			},
 		},
 	],
 	recommendedDisplays: ['file'],

--- a/app/src/interfaces/files/index.ts
+++ b/app/src/interfaces/files/index.ts
@@ -23,9 +23,6 @@ export default defineInterface({
 					interface: 'system-folder',
 					note: '$t:interfaces.system-folder.field_hint',
 				},
-				schema: {
-					default_value: undefined,
-				},
 			},
 			{
 				field: 'template',

--- a/app/src/interfaces/input-code/index.ts
+++ b/app/src/interfaces/input-code/index.ts
@@ -75,9 +75,6 @@ export default defineInterface({
 						placeholder: '$t:interfaces.input-code.placeholder',
 					},
 				},
-				schema: {
-					default_value: null,
-				},
 			},
 		];
 

--- a/app/src/interfaces/input-rich-text-html/index.ts
+++ b/app/src/interfaces/input-rich-text-html/index.ts
@@ -252,9 +252,6 @@ export default defineInterface({
 					interface: 'system-folder',
 					note: '$t:interfaces.input-rich-text-html.folder_note',
 				},
-				schema: {
-					default_value: undefined,
-				},
 			},
 			{
 				field: 'imageToken',

--- a/app/src/interfaces/input-rich-text-md/index.ts
+++ b/app/src/interfaces/input-rich-text-md/index.ts
@@ -107,9 +107,6 @@ export default defineInterface({
 					interface: 'system-folder',
 					note: '$t:interfaces.system-folder.field_hint',
 				},
-				schema: {
-					default_value: undefined,
-				},
 			},
 			{
 				field: 'imageToken',

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -90,7 +90,6 @@ const repeaterFields: DeepPartial<Field>[] = [
 				placeholder: t('field_name_placeholder'),
 			},
 		},
-		schema: null,
 	},
 	{
 		name: t('field_width'),
@@ -113,7 +112,6 @@ const repeaterFields: DeepPartial<Field>[] = [
 				],
 			},
 		},
-		schema: null,
 	},
 	{
 		name: t('type'),
@@ -127,7 +125,6 @@ const repeaterFields: DeepPartial<Field>[] = [
 				choices: translate(FIELD_TYPES_SELECT),
 			},
 		},
-		schema: null,
 	},
 	{
 		name: t('interface_label'),
@@ -141,7 +138,6 @@ const repeaterFields: DeepPartial<Field>[] = [
 				typeField: 'type',
 			},
 		},
-		schema: null,
 	},
 	{
 		name: t('note'),
@@ -155,7 +151,6 @@ const repeaterFields: DeepPartial<Field>[] = [
 				placeholder: t('interfaces.list.field_note_placeholder'),
 			},
 		},
-		schema: null,
 	},
 	{
 		name: t('required'),

--- a/app/src/panels/metric/index.test.ts
+++ b/app/src/panels/metric/index.test.ts
@@ -1,0 +1,19 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import metric from './index';
+
+describe('metric panel options', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('uses typed defaults for the abbreviate and decimals options', () => {
+		const optionFields = typeof metric.options === 'function' ? metric.options({ options: {} }) : metric.options ?? [];
+
+		const abbreviate = optionFields.find((field) => field.field === 'abbreviate');
+		const decimals = optionFields.find((field) => field.field === 'decimals');
+
+		expect(abbreviate?.schema?.default_value).toBe(false);
+		expect(decimals?.schema?.default_value).toBe(0);
+	});
+});

--- a/app/src/panels/metric/index.ts
+++ b/app/src/panels/metric/index.ts
@@ -201,7 +201,7 @@ export default definePanel({
 				type: 'boolean',
 				name: '$t:abbreviate_value',
 				schema: {
-					default_value: 'false',
+					default_value: false,
 				},
 				meta: {
 					interface: 'boolean',
@@ -220,7 +220,7 @@ export default definePanel({
 					},
 				},
 				schema: {
-					default_value: '0',
+					default_value: 0,
 				},
 			},
 			{

--- a/app/src/panels/relational-variable/index.ts
+++ b/app/src/panels/relational-variable/index.ts
@@ -23,7 +23,6 @@ export default definePanel({
 					placeholder: '$t:field_name_placeholder',
 				},
 			},
-			schema: null,
 		},
 		{
 			field: 'collection',

--- a/app/src/panels/variable/index.ts
+++ b/app/src/panels/variable/index.ts
@@ -29,7 +29,6 @@ export default definePanel({
 						placeholder: t('field_name_placeholder'),
 					},
 				},
-				schema: null,
 			},
 			{
 				name: t('type'),
@@ -42,7 +41,6 @@ export default definePanel({
 						choices: translate(FIELD_TYPES_SELECT),
 					},
 				},
-				schema: null,
 			},
 			{
 				name: t('default_value'),
@@ -53,7 +51,6 @@ export default definePanel({
 					readonly: !panel.options?.type,
 					width: 'half',
 				},
-				schema: {},
 			},
 			{
 				name: t('interface_label'),
@@ -66,7 +63,6 @@ export default definePanel({
 						typeField: 'type',
 					},
 				},
-				schema: null,
 			},
 			{
 				name: t('options'),

--- a/packages/schema/src/types/column.ts
+++ b/packages/schema/src/types/column.ts
@@ -2,7 +2,7 @@ export interface Column {
 	name: string;
 	table: string;
 	data_type: string;
-	default_value: string | null;
+	default_value: string | number | boolean | null;
 	max_length: number | null;
 	numeric_precision: number | null;
 	numeric_scale: number | null;


### PR DESCRIPTION
## Related Issue or Discussion

- n/a
## Scope

- What problem does this PR solve?

Fixes typed defaults for metric panel options and cleans up dead option-schema entries in admin app extension definitions. The metric panel previously stored `false` and `0` defaults as strings, which made a new metric panel's abbreviate toggle behave as enabled by default. This PR stores those defaults as real boolean and number values, widens the schema column default type to match the values the app already uses, and removes no-op `schema` blocks that carried no default behavior.

### Testing / verification

Added a test covering:
- metric panel `abbreviate` defaults to strict `false`
- metric panel `decimals` defaults to strict `0`

Verified:
- the metric regression test fails against the old string defaults and passes with typed defaults
- the edited interface, panel, and schema files no longer contain the removed no-op schema entries
- the interface registry still loads
- the schema and app builds complete

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
