### PR TITLE
WIP: Add the foundation for declared extension settings

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -16,6 +16,7 @@ import collectionsRouter from './controllers/collections.js';
 import configRouter from './controllers/config.js';
 import dashboardsRouter from './controllers/dashboards.js';
 import extensionsRouter from './controllers/extensions.js';
+import extensionSettingsRouter from './controllers/extension-settings.js';
 import fieldsRouter from './controllers/fields.js';
 import filesRouter from './controllers/files.js';
 import flowsRouter from './controllers/flows.js';
@@ -298,6 +299,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.use('/config', configRouter);
 	app.use('/dashboards', dashboardsRouter);
 	app.use('/extensions', extensionsRouter);
+	app.use('/extension-settings', extensionSettingsRouter);
 	app.use('/fields', fieldsRouter);
 	app.use('/files', filesRouter);
 	app.use('/flows', flowsRouter);

--- a/api/src/controllers/extension-settings.ts
+++ b/api/src/controllers/extension-settings.ts
@@ -1,0 +1,84 @@
+import express from 'express';
+import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import { respond } from '../middleware/respond.js';
+import { ExtensionSettingsService } from '../services/extension-settings.js';
+import asyncHandler from '../utils/async-handler.js';
+
+const router = express.Router();
+
+router.use(
+	asyncHandler(async (req, _res, next) => {
+		if (req.accountability?.admin !== true) throw new ForbiddenException();
+		return next();
+	})
+);
+
+router.post(
+	'/',
+	asyncHandler(async (req, res, next) => {
+		const { subject, scope, scope_key, key, value } = req.body ?? {};
+
+		if (
+			typeof subject !== 'string' ||
+			typeof scope !== 'string' ||
+			typeof scope_key !== 'string' ||
+			typeof key !== 'string'
+		) {
+			throw new InvalidPayloadException('"subject", "scope", "scope_key", and "key" are required strings.');
+		}
+
+		if (value === undefined) throw new InvalidPayloadException('"value" is required.');
+
+		const service = new ExtensionSettingsService({ accountability: req.accountability, schema: req.schema });
+		await service.set(subject, scope as 'global' | 'collection', scope_key, key, value);
+
+		res.locals['payload'] = { data: null };
+		return next();
+	}),
+	respond
+);
+
+router.get(
+	'/',
+	asyncHandler(async (req, res, next) => {
+		const subject = req.query['subject'];
+		if (typeof subject !== 'string') throw new InvalidPayloadException('"subject" is required.');
+
+		const scope = req.query['scope'];
+
+		if (scope !== undefined && scope !== 'global' && scope !== 'collection') {
+			throw new InvalidPayloadException('"scope" must be "global" or "collection".');
+		}
+
+		const scopeKey = req.query['scope_key'];
+
+		if (scopeKey !== undefined && typeof scopeKey !== 'string') {
+			throw new InvalidPayloadException('"scope_key" must be a string.');
+		}
+
+		const service = new ExtensionSettingsService({ accountability: req.accountability, schema: req.schema });
+		const data = await service.get(subject, scope as 'global' | 'collection' | undefined, scopeKey);
+
+		res.locals['payload'] = { data };
+		return next();
+	}),
+	respond
+);
+
+router.delete(
+	'/',
+	asyncHandler(async (req, res, next) => {
+		const subject = req.body?.subject;
+		if (typeof subject !== 'string') throw new InvalidPayloadException('"subject" is required.');
+
+		const service = new ExtensionSettingsService({ accountability: req.accountability, schema: req.schema });
+
+		const removed = await service.deleteBySubject(subject);
+
+		res.locals['payload'] = { data: { removed } };
+		return next();
+	}),
+	respond
+);
+
+export default router;

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { isInternalTable } from '../database/internal-tables.js';
 import { ForbiddenException, RouteNotFoundException } from '../exceptions/index.js';
 import collectionExists from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
@@ -15,7 +16,8 @@ router.post(
 	'/:collection',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		if (req.singleton) {
 			throw new RouteNotFoundException(req.path);
@@ -58,7 +60,8 @@ router.post(
 );
 
 const readHandler = asyncHandler(async (req, res, next) => {
-	if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+	if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+		throw new ForbiddenException();
 
 	const service = new ItemsService(req.collection, {
 		accountability: req.accountability,
@@ -97,7 +100,8 @@ router.get(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -120,7 +124,8 @@ router.patch(
 	collectionExists,
 	validateBatch('update'),
 	asyncHandler(async (req, res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -166,7 +171,8 @@ router.patch(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		if (req.singleton) {
 			throw new RouteNotFoundException(req.path);
@@ -200,7 +206,8 @@ router.delete(
 	collectionExists,
 	validateBatch('delete'),
 	asyncHandler(async (req, _res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -225,7 +232,8 @@ router.delete(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, _res, next) => {
-		if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+		if (req.params['collection']!.startsWith('directus_') || isInternalTable(req.params['collection']!))
+			throw new ForbiddenException();
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,

--- a/api/src/database/internal-tables.test.ts
+++ b/api/src/database/internal-tables.test.ts
@@ -100,6 +100,34 @@ describe('internal-table classification', () => {
 		expect(Object.keys(schema.collections)).not.toContain(FIXTURE);
 	});
 
+	it('getSchema excludes every registered internal table, so a newly registered table is auto-covered', async () => {
+		const columns = {
+			id: { column_name: 'id', data_type: 'integer', is_nullable: false, is_generated: false },
+		};
+
+		const registered = getInternalTables();
+
+		const overview: Record<string, { primary: string; columns: typeof columns }> = {
+			[NORMAL]: { primary: 'id', columns },
+		};
+
+		for (const table of registered) overview[table] = { primary: 'id', columns };
+
+		mockInspector.overview.mockResolvedValue(overview);
+		tracker.on.select('directus_collections').response([]);
+		tracker.on.select('directus_fields').response([]);
+		vi.spyOn(RelationsService.prototype, 'readAll').mockResolvedValue([]);
+
+		const schema = await getSchema({ database: db, bypassCache: true });
+
+		expect(registered).toContain('cairncms_extension_settings');
+		expect(Object.keys(schema.collections)).toContain(NORMAL);
+
+		for (const table of registered) {
+			expect(Object.keys(schema.collections)).not.toContain(table);
+		}
+	});
+
 	it('CollectionsService.readByQuery excludes an internal table on both the physical and metadata paths', async () => {
 		mockInspector.tableInfo.mockResolvedValue([{ name: FIXTURE }, { name: NORMAL }]);
 

--- a/api/src/database/internal-tables.test.ts
+++ b/api/src/database/internal-tables.test.ts
@@ -1,0 +1,167 @@
+import knex from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockInspector } = vi.hoisted(() => ({
+	mockInspector: {
+		overview: vi.fn(),
+		tableInfo: vi.fn(),
+		foreignKeys: vi.fn(),
+	},
+}));
+
+vi.mock('@cairncms/schema', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@cairncms/schema')>()),
+	createInspector: () => mockInspector,
+}));
+
+import { ForbiddenException } from '../exceptions/index.js';
+import { CollectionsService } from '../services/collections.js';
+import { ExportService, ImportService } from '../services/import-export.js';
+import { ItemsService } from '../services/items.js';
+import { RelationsService } from '../services/relations.js';
+import { getSchema } from '../utils/get-schema.js';
+import { getInternalTables, isInternalTable, registerInternalTable } from './internal-tables.js';
+
+class Client_PG extends MockClient {}
+
+const FIXTURE = 'cairncms_internal_test_fixture';
+const NORMAL = 'articles';
+
+const admin = { role: 'admin', admin: true } as any;
+const emptySchema = { collections: {}, relations: [] } as any;
+
+const collectionMeta = (collection: string) => ({
+	accountability: 'all',
+	collection,
+	group: null,
+	hidden: false,
+	icon: null,
+	item_duplication_fields: null,
+	note: null,
+	singleton: false,
+	translations: null,
+});
+
+const relationMeta = (many_collection: string, one_collection: string, many_field: string) => ({
+	id: 1,
+	many_collection,
+	many_field,
+	one_collection,
+	one_field: null,
+	one_collection_field: null,
+	one_allowed_collections: null,
+	junction_field: null,
+	sort_field: null,
+	one_deselect_action: 'nullify',
+});
+
+describe('internal-table classification', () => {
+	let db: any;
+	let tracker: Tracker;
+
+	beforeEach(() => {
+		db = vi.mocked(knex.default({ client: Client_PG }));
+		tracker = createTracker(db);
+		registerInternalTable(FIXTURE);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+		mockInspector.overview.mockReset();
+		mockInspector.tableInfo.mockReset();
+		mockInspector.foreignKeys.mockReset();
+		vi.restoreAllMocks();
+	});
+
+	it('classifies a registered table and exposes it through the iterating accessor', () => {
+		expect(isInternalTable(FIXTURE)).toBe(true);
+		expect(isInternalTable(NORMAL)).toBe(false);
+		expect(getInternalTables()).toContain(FIXTURE);
+	});
+
+	it('getSchema excludes a registered internal table from SchemaOverview.collections', async () => {
+		const columns = {
+			id: { column_name: 'id', data_type: 'integer', is_nullable: false, is_generated: false },
+		};
+
+		mockInspector.overview.mockResolvedValue({
+			[FIXTURE]: { primary: 'id', columns },
+			[NORMAL]: { primary: 'id', columns },
+		});
+
+		tracker.on.select('directus_collections').response([]);
+		tracker.on.select('directus_fields').response([]);
+		vi.spyOn(RelationsService.prototype, 'readAll').mockResolvedValue([]);
+
+		const schema = await getSchema({ database: db, bypassCache: true });
+
+		expect(Object.keys(schema.collections)).toContain(NORMAL);
+		expect(Object.keys(schema.collections)).not.toContain(FIXTURE);
+	});
+
+	it('CollectionsService.readByQuery excludes an internal table on both the physical and metadata paths', async () => {
+		mockInspector.tableInfo.mockResolvedValue([{ name: FIXTURE }, { name: NORMAL }]);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			collectionMeta(FIXTURE),
+			collectionMeta(NORMAL),
+		] as any);
+
+		const service = new CollectionsService({ knex: db, schema: emptySchema, accountability: admin });
+		const names = (await service.readByQuery()).map((collection) => collection.collection);
+
+		expect(names).toContain(NORMAL);
+		expect(names).not.toContain(FIXTURE);
+	});
+
+	it('RelationsService.readAll excludes relations on or pointing to an internal table', async () => {
+		mockInspector.foreignKeys.mockResolvedValue([]);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			relationMeta(FIXTURE, NORMAL, 'owner'),
+			relationMeta(NORMAL, FIXTURE, 'fixture_ref'),
+			relationMeta(NORMAL, 'directus_users', 'author'),
+		] as any);
+
+		const service = new RelationsService({ knex: db, schema: emptySchema, accountability: admin });
+		const relations = await service.readAll();
+
+		expect(relations.some((relation) => relation.collection === FIXTURE)).toBe(false);
+		expect(relations.some((relation) => relation.related_collection === FIXTURE)).toBe(false);
+		expect(relations.some((relation) => relation.collection === NORMAL && relation.field === 'author')).toBe(true);
+	});
+
+	it('RelationsService.readOne fails closed when the queried collection is internal', async () => {
+		mockInspector.foreignKeys.mockResolvedValue([]);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([relationMeta(FIXTURE, NORMAL, 'owner')] as any);
+
+		const service = new RelationsService({ knex: db, schema: emptySchema, accountability: admin });
+
+		await expect(service.readOne(FIXTURE, 'owner')).rejects.toBeInstanceOf(ForbiddenException);
+	});
+
+	it('RelationsService.readOne fails closed when the relation points at an internal table', async () => {
+		mockInspector.foreignKeys.mockResolvedValue([]);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			relationMeta(NORMAL, FIXTURE, 'fixture_ref'),
+		] as any);
+
+		const service = new RelationsService({ knex: db, schema: emptySchema, accountability: admin });
+
+		await expect(service.readOne(NORMAL, 'fixture_ref')).rejects.toBeInstanceOf(ForbiddenException);
+	});
+
+	it('ImportService.import and ExportService.exportToFile fail closed for an internal table', async () => {
+		const importService = new ImportService({ knex: db, schema: emptySchema, accountability: admin });
+		const exportService = new ExportService({ knex: db, schema: emptySchema, accountability: admin });
+
+		await expect(importService.import(FIXTURE, 'application/json', null as any)).rejects.toBeInstanceOf(
+			ForbiddenException
+		);
+
+		await expect(exportService.exportToFile(FIXTURE, {}, 'json')).rejects.toBeInstanceOf(ForbiddenException);
+	});
+});

--- a/api/src/database/internal-tables.ts
+++ b/api/src/database/internal-tables.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal-table classification registry: the single source of truth for which physical
+ * tables are Cairn-owned internal platform storage, as opposed to operator data or
+ * `directus_*` system tables. A registered internal table is hidden from every
+ * schema-enumeration and generic-access surface, deny-by-default and uniformly, with no
+ * per-surface opt-in.
+ */
+
+const internalTables = new Set<string>();
+
+export function isInternalTable(collection: string): boolean {
+	return internalTables.has(collection);
+}
+
+export function getInternalTables(): string[] {
+	return [...internalTables];
+}
+
+export function registerInternalTable(collection: string): void {
+	internalTables.add(collection);
+}

--- a/api/src/database/internal-tables.ts
+++ b/api/src/database/internal-tables.ts
@@ -6,7 +6,7 @@
  * per-surface opt-in.
  */
 
-const internalTables = new Set<string>();
+const internalTables = new Set<string>(['cairncms_extension_settings']);
 
 export function isInternalTable(collection: string): boolean {
 	return internalTables.has(collection);

--- a/api/src/database/migrations/20260623A-add-extension-settings.ts
+++ b/api/src/database/migrations/20260623A-add-extension-settings.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.createTable('cairncms_extension_settings', (table) => {
+		table.uuid('id').primary().notNullable();
+		table.string('extension', 255).notNullable();
+		table.string('scope', 16).notNullable();
+		table.string('scope_key', 64).notNullable().defaultTo('');
+		table.string('key', 64).notNullable();
+		table.text('value').notNullable();
+
+		table.unique(['extension', 'scope', 'scope_key', 'key'], {
+			indexName: 'cairncms_extension_settings_subject_unique',
+		});
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.dropTable('cairncms_extension_settings');
+}

--- a/api/src/extensions.test.ts
+++ b/api/src/extensions.test.ts
@@ -2010,7 +2010,7 @@ describe('the settings subject gate in the loader', () => {
 		expect((instance as any).isSettingsEligible(plain)).toBe(false);
 	});
 
-	it('refuses a non-owner that shares an owner name, keying eligibility by identity not name', async () => {
+	it('resolves the owner and eligibility by identity, not by a shared name', async () => {
 		const instance = new ExtensionManager();
 		const owner = settingsOwner('shared-owner', 'cairncms-extension-shared');
 		const nonOwner = endpointExtension('shared-plain', 'cairncms-extension-shared', false);
@@ -2020,5 +2020,7 @@ describe('the settings subject gate in the loader', () => {
 
 		expect((instance as any).isSettingsEligible(owner)).toBe(true);
 		expect((instance as any).isSettingsEligible(nonOwner)).toBe(false);
+		expect((instance as any).getSettingsOwner('cairncms-extension-shared')).toBe(owner);
+		expect((instance as any).getSettingsOwner('cairncms-extension-absent')).toBeUndefined();
 	});
 });

--- a/api/src/extensions.test.ts
+++ b/api/src/extensions.test.ts
@@ -1956,3 +1956,69 @@ describe('findSharedDepAsset', () => {
 		expect(findSharedDepAsset('vue', ['vue.runtime.esm-bundler-BsuNjI30.js'])).toBeUndefined();
 	});
 });
+
+describe('the settings subject gate in the loader', () => {
+	const declaration = { preview_url: { type: 'string', scope: 'global' } } as any;
+
+	function settingsOwner(dir: string, name: string): Extension {
+		return { ...endpointExtension(dir, name, false), settings: declaration };
+	}
+
+	it('marks a valid unique settings owner eligible without removing it from the load', async () => {
+		const instance = new ExtensionManager();
+		const owner = settingsOwner('preview', 'cairncms-extension-preview');
+		(instance as any).getExtensions = async () => [owner];
+
+		await (instance as any).load();
+
+		expect((instance as any).isSettingsEligible(owner)).toBe(true);
+		expect((instance as any).extensions).toContain(owner);
+	});
+
+	it('refuses an invalid settings subject without failing the extension, warning instead', async () => {
+		const warn = vi.spyOn(logger, 'warn');
+		const instance = new ExtensionManager();
+		const owner = settingsOwner('bad', 'bad-subject');
+		(instance as any).getExtensions = async () => [owner];
+
+		await (instance as any).load();
+
+		expect((instance as any).isSettingsEligible(owner)).toBe(false);
+		expect((instance as any).extensions).toContain(owner);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('bad-subject'));
+	});
+
+	it('refuses every owner on a subject collision', async () => {
+		const instance = new ExtensionManager();
+		const first = settingsOwner('dup-a', 'cairncms-extension-dup');
+		const second = settingsOwner('dup-b', 'cairncms-extension-dup');
+		(instance as any).getExtensions = async () => [first, second];
+
+		await (instance as any).load();
+
+		expect((instance as any).isSettingsEligible(first)).toBe(false);
+		expect((instance as any).isSettingsEligible(second)).toBe(false);
+	});
+
+	it('does not treat an extension without a settings declaration as an owner', async () => {
+		const instance = new ExtensionManager();
+		const plain = endpointExtension('plain-owner', 'cairncms-extension-plain', false);
+		(instance as any).getExtensions = async () => [plain];
+
+		await (instance as any).load();
+
+		expect((instance as any).isSettingsEligible(plain)).toBe(false);
+	});
+
+	it('refuses a non-owner that shares an owner name, keying eligibility by identity not name', async () => {
+		const instance = new ExtensionManager();
+		const owner = settingsOwner('shared-owner', 'cairncms-extension-shared');
+		const nonOwner = endpointExtension('shared-plain', 'cairncms-extension-shared', false);
+		(instance as any).getExtensions = async () => [owner, nonOwner];
+
+		await (instance as any).load();
+
+		expect((instance as any).isSettingsEligible(owner)).toBe(true);
+		expect((instance as any).isSettingsEligible(nonOwner)).toBe(false);
+	});
+});

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -64,6 +64,8 @@ import { runConfinedActionHook, runConfinedFilterHook, type ConfinedHookRequest 
 import type { ConfinedLogEntry } from './extensions/confined/broker.js';
 import type { ConfinedHostDispatcher, ConfinedInvocation } from './extensions/confined/types.js';
 import { confinedItemsService } from './extensions/confined/items-service.js';
+import { buildConfinedSettingsAccess } from './extensions/confined/settings-access.js';
+import { readGlobalSettings } from './services/extension-settings-store.js';
 import type { SandboxConfig } from './extensions/confined/sandbox-limits.js';
 import { getAxios } from './request/index.js';
 import logger from './logger.js';
@@ -714,6 +716,11 @@ export class ExtensionManager {
 			log: (entry: ConfinedLogEntry) => this.logConfinedEntry(entry),
 			getAxios: () => getAxios(),
 			itemsService: confinedItemsService,
+			settingsAccess: (subject: string) =>
+				buildConfinedSettingsAccess({
+					declaration: this.getSettingsOwner(subject)?.settings,
+					readRows: (signal) => readGlobalSettings(getDatabase(), subject, signal),
+				}),
 			brokerLimits: {
 				settingsValueBytes: config.sandbox.settingsValueBytes,
 				httpResponseBytes: config.sandbox.httpResponseBytes,

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -591,7 +591,7 @@ export class ExtensionManager {
 			if (status.eligible) {
 				this.settingsEligible.add(extension);
 			} else {
-				logger.warn(`Settings disabled for extension "${extension.name}": ${status.reason.detail}`);
+				logger.warn(`Settings disabled: ${status.reason.detail}`);
 			}
 		}
 	}

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -76,6 +76,7 @@ import {
 	type ConfinedGateVerdict,
 	type ConfinedLoadGateDeps,
 } from './extensions/confined/load-gate.js';
+import { resolveSettingsSubjects, type ConfinedSettingsCapabilities } from './extensions/settings-subjects.js';
 import { resolveConfinedRuntime, type ConfinedSupervisor } from './extensions/confined/supervisor.js';
 import { describePosture, type SandboxPosture } from './extensions/confined/sandbox-hardening.js';
 import getModuleDefault from './utils/get-module-default.js';
@@ -214,6 +215,8 @@ export class ExtensionManager {
 	// recomputed on every load, never persisted, and carrying no public diagnostic
 	// row until registration.
 	private confinedEligible = new Map<Extension, ConfinedEligibleEntry>();
+
+	private settingsEligible = new Set<Extension>();
 
 	// Test seam for the gate's scanner, probe, and limits dependencies. Overrides
 	// the production-resolved deps below, so a test can drive the gate directly.
@@ -365,6 +368,10 @@ export class ExtensionManager {
 
 			return copy;
 		});
+	}
+
+	public isSettingsEligible(extension: Extension): boolean {
+		return this.settingsEligible.has(extension);
 	}
 
 	/**
@@ -558,6 +565,33 @@ export class ExtensionManager {
 				this.confinedEligible.set(extension, entry);
 			} else {
 				this.recordFailed(extension, verdict.error);
+			}
+		}
+	}
+
+	/**
+	 * Gates each settings owner's durable subject after confined gating, so any confined
+	 * capabilities it reads are already validated. A bad or colliding subject is refused
+	 * settings only, never failing the extension's load.
+	 */
+	private gateSettingsSubjects(): void {
+		const statuses = resolveSettingsSubjects(this.extensions, (extension) => {
+			const eligible = this.confinedEligible.get(extension);
+			if (eligible === undefined) return undefined;
+
+			const capabilities: ConfinedSettingsCapabilities = {};
+			if (eligible.capabilities !== undefined) capabilities.self = eligible.capabilities;
+			if (eligible.entryCapabilities !== undefined) capabilities.entries = eligible.entryCapabilities;
+			return capabilities;
+		});
+
+		this.settingsEligible = new Set();
+
+		for (const [extension, status] of statuses) {
+			if (status.eligible) {
+				this.settingsEligible.add(extension);
+			} else {
+				logger.warn(`Settings disabled for extension "${extension.name}": ${status.reason.detail}`);
 			}
 		}
 	}
@@ -1240,6 +1274,7 @@ export class ExtensionManager {
 		this.serverExtensions = [];
 		this.confinedEligible.clear();
 		this.confinedOperationBlocks.clear();
+		this.settingsEligible.clear();
 		this.confinedRuntimeDeps = {};
 		this.confinedRuntimeUnavailable = false;
 		this.confinedRuntime = undefined;
@@ -1261,6 +1296,7 @@ export class ExtensionManager {
 
 		await this.prepareConfinedRuntime();
 		await this.gateConfinedExtensions();
+		this.gateSettingsSubjects();
 
 		await this.registerHooks();
 		await this.registerEndpoints();
@@ -1291,6 +1327,7 @@ export class ExtensionManager {
 
 		this.serverExtensions = [];
 		this.confinedEligible.clear();
+		this.settingsEligible.clear();
 		this.confinedRuntimeDeps = {};
 		this.confinedRuntimeUnavailable = false;
 		this.confinedRuntime = undefined;

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -374,6 +374,14 @@ export class ExtensionManager {
 		return this.settingsEligible.has(extension);
 	}
 
+	public getSettingsOwner(subject: string): Extension | undefined {
+		for (const extension of this.settingsEligible) {
+			if (extension.name === subject) return extension;
+		}
+
+		return undefined;
+	}
+
 	/**
 	 * The global confined-runtime metadata for the diagnostics response. Derived from the
 	 * load state, never by resolving the runtime, so a plain-only load (no confined

--- a/api/src/extensions/confined/broker.ts
+++ b/api/src/extensions/confined/broker.ts
@@ -30,14 +30,6 @@ export interface ConfinedSettingsSource {
 	hasSecret(key: string, signal: AbortSignal): boolean | Promise<boolean>;
 }
 
-// Settings ship dark in this milestone: no key is declared, so settings.get always
-// returns null and mints no handle. A later slice defines declaration and storage.
-export const DARK_SETTINGS: ConfinedSettingsSource = {
-	declared: [],
-	value: () => null,
-	hasSecret: () => false,
-};
-
 export interface ConfinedHostBrokerDeps {
 	// The gate-validated capabilities for this invocation's contribution.
 	capabilities: ExtensionCapabilities;

--- a/api/src/extensions/confined/end-to-end.test.ts
+++ b/api/src/extensions/confined/end-to-end.test.ts
@@ -11,6 +11,7 @@ import {
 import { runConfinedEndpoint } from './endpoint.js';
 import { runConfinedActionHook, runConfinedFilterHook } from './hook.js';
 import { runConfinedOperation } from './operation.js';
+import { buildConfinedSettingsAccess, EMPTY_SETTINGS_ACCESS } from './settings-access.js';
 import { ConfinedSupervisor } from './supervisor.js';
 import type { ConfinedHostDispatcher, ConfinedInvocation, ConfinedResult, ConfinedRuntimeLimits } from './types.js';
 
@@ -78,7 +79,13 @@ function baseOperationRequest(entrySource: string, overrides: Record<string, unk
 	};
 }
 
-const deps = { invoke, log, brokerLimits: BROKER_LIMITS, runtimeLimits: LIMITS };
+const deps = {
+	invoke,
+	log,
+	brokerLimits: BROKER_LIMITS,
+	runtimeLimits: LIMITS,
+	settingsAccess: () => EMPTY_SETTINGS_ACCESS,
+};
 
 describe('confined contracts through a real child', () => {
 	it(
@@ -247,7 +254,7 @@ describe('host methods through a real child and the real broker', () => {
 	);
 
 	it(
-		'serves settings dark: denied without the capability, null with it',
+		'an extension with no declared settings: denied without the capability, null with it',
 		async () => {
 			const denied = await runConfinedOperation(
 				baseOperationRequest(operationEntry("async (_input, { host }) => host.settings.get('mode')"), {
@@ -258,8 +265,8 @@ describe('host methods through a real child and the real broker', () => {
 
 			expect(denied.outcome).toMatchObject({ ok: true, value: { ok: false, error: { code: 'denied' } } });
 
-			// The runners hardcode DARK_SETTINGS, so a declared capability still reads null
-			// for every key. This asserts that shipped dark contract through the real child.
+			// An extension that declares no settings reads null for every key, even with the
+			// read capability. The empty settings access is the no-owner shape.
 			const dark = await runConfinedOperation(
 				baseOperationRequest(operationEntry("async (_input, { host }) => host.settings.get('mode')"), {
 					capabilities: { settings: ['read'] },
@@ -471,6 +478,165 @@ describe('brokered request with a real secret through a real child', () => {
 			expect(serializedLogs).toContain(REDACT_TEXT);
 			expect(serializedLogs).not.toContain(secret);
 			expect(serializedLogs).not.toContain(String(handle));
+		},
+		ENGINE_TIMEOUT
+	);
+});
+
+describe('extension settings reads and brokered secret through a real child', () => {
+	let server: http.Server;
+	let origin: string;
+	const authSeen: Array<string | undefined> = [];
+
+	const SETTING_SECRET = 'sk_live_SETTINGS_SECRET_TOKEN';
+	const BASE_URL = 'https://preview.example.com';
+
+	const SETTINGS_DECLARATION: any = {
+		base_url: { type: 'string', scope: 'global' },
+		api_key: { type: 'string', scope: 'global', sensitive: true },
+		unset_key: { type: 'string', scope: 'global', sensitive: true },
+	};
+
+	const SETTINGS_ROWS = [
+		{ key: 'base_url', value: BASE_URL },
+		{ key: 'api_key', value: { source: 'config', name: 'CAIRN_E2E_SETTING_SECRET' } },
+		{ key: 'unset_key', value: { source: 'config', name: 'CAIRN_E2E_NEVER_SET' } },
+	];
+
+	// Subject-aware so a wrong subject yields an empty access. The bundle case passing
+	// proves the bundle's own subject (local.e2e) reaches the settings read.
+	const settingsAccess = (subject: string) =>
+		buildConfinedSettingsAccess({
+			declaration: subject === 'local.e2e' ? SETTINGS_DECLARATION : undefined,
+			readRows: async () => (subject === 'local.e2e' ? SETTINGS_ROWS : []),
+		});
+
+	const settingsDeps = { ...deps, settingsAccess, getAxios: async () => axios.create() };
+
+	beforeAll(async () => {
+		process.env['CAIRN_E2E_SETTING_SECRET'] = SETTING_SECRET;
+		delete process.env['CAIRN_E2E_NEVER_SET'];
+
+		server = http.createServer((request, response) => {
+			authSeen.push(request.headers['authorization']);
+			response.writeHead(200, { 'content-type': 'application/json' });
+			response.end(JSON.stringify({ ok: true }));
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+		origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+	});
+
+	afterAll(() => {
+		server.close();
+		delete process.env['CAIRN_E2E_SETTING_SECRET'];
+	});
+
+	beforeEach(() => {
+		authSeen.length = 0;
+	});
+
+	it(
+		'operation reads a value and a handle, an unset secret and an undeclared key as null, and resolves the handle',
+		async () => {
+			const result = await runConfinedOperation(
+				baseOperationRequest(
+					operationEntry(
+						`async (_input, { host }) => { const baseUrl = (await host.settings.get('base_url')).value; const apiKey = (await host.settings.get('api_key')).value; const unsetKey = (await host.settings.get('unset_key')).value; const undeclared = (await host.settings.get('nope')).value; await host.log.info('handle ' + apiKey.ref); await host.request.send({ url: '${origin}/echo', method: 'GET', auth: { bearer: apiKey } }); return { baseUrl, apiKeyKind: apiKey.kind, unsetKey, undeclared }; }`
+					),
+					{ capabilities: { settings: ['read'], request: { urls: [origin] }, log: true } }
+				),
+				settingsDeps
+			);
+
+			expect(result.outcome).toMatchObject({
+				ok: true,
+				value: { baseUrl: BASE_URL, apiKeyKind: 'secret-reference', unsetKey: null, undeclared: null },
+			});
+
+			expect(authSeen).toContain(`Bearer ${SETTING_SECRET}`);
+			expect(JSON.stringify(result.outcome)).not.toContain(SETTING_SECRET);
+			expect(result.redactionValues).toContain(SETTING_SECRET);
+
+			const serializedLogs = JSON.stringify(logs);
+			expect(serializedLogs).toContain(REDACT_TEXT);
+			expect(serializedLogs).not.toContain(SETTING_SECRET);
+		},
+		ENGINE_TIMEOUT
+	);
+
+	it(
+		'endpoint reads its settings and resolves the handle at brokered use',
+		async () => {
+			const result = await runConfinedEndpoint(
+				{
+					extensionId: 'local.e2e',
+					contributionId: 'e2e-ep',
+					entrySource: endpointEntry(
+						`async (_request, { host }) => { const baseUrl = (await host.settings.get('base_url')).value; const apiKey = (await host.settings.get('api_key')).value; await host.request.send({ url: '${origin}/echo', method: 'GET', auth: { bearer: apiKey } }); return { status: 200, body: { baseUrl } }; }`
+					),
+					capabilities: { endpoint: { access: 'public' }, settings: ['read'], request: { urls: [origin] } },
+					method: 'GET',
+					path: '/run',
+					query: {},
+					body: null,
+					accountability: null,
+				},
+				settingsDeps
+			);
+
+			expect(result).toMatchObject({ ok: true, status: 200, body: { baseUrl: BASE_URL } });
+			expect(authSeen).toContain(`Bearer ${SETTING_SECRET}`);
+			expect(JSON.stringify(result)).not.toContain(SETTING_SECRET);
+		},
+		ENGINE_TIMEOUT
+	);
+
+	it(
+		'action hook reads its settings and resolves the handle at brokered use',
+		async () => {
+			const result = await runConfinedActionHook(
+				{
+					extensionId: 'local.e2e',
+					contributionId: 'e2e-hook',
+					entrySource: hookEntry(
+						'actions',
+						'e2e.settings',
+						`async (_meta, { host }) => { const baseUrl = (await host.settings.get('base_url')).value; await host.log.info('base ' + baseUrl); const apiKey = (await host.settings.get('api_key')).value; await host.request.send({ url: '${origin}/echo', method: 'GET', auth: { bearer: apiKey } }); return { done: true }; }`
+					),
+					capabilities: { log: true, settings: ['read'], request: { urls: [origin] } },
+					event: 'e2e.settings',
+					meta: {},
+					accountability: null,
+				},
+				settingsDeps
+			);
+
+			expect(result).toEqual({ ok: true });
+			expect(authSeen).toContain(`Bearer ${SETTING_SECRET}`);
+			expect(JSON.stringify(logs)).toContain(`base ${BASE_URL}`);
+			expect(JSON.stringify(logs)).not.toContain(SETTING_SECRET);
+		},
+		ENGINE_TIMEOUT
+	);
+
+	it(
+		'bundle operation entry reads settings under the bundle subject and resolves the handle',
+		async () => {
+			const artifact = `var CairnBundle = (() => ({ default: { 'operation:settings-op': { id: 'settings-op', handler: async (_input, { host }) => { const baseUrl = (await host.settings.get('base_url')).value; const apiKey = (await host.settings.get('api_key')).value; await host.request.send({ url: '${origin}/echo', method: 'GET', auth: { bearer: apiKey } }); return { baseUrl }; } } } }))();`;
+
+			const result = await runConfinedOperation(
+				baseOperationRequest(artifact, {
+					contributionId: 'settings-op',
+					bundleEntryKey: 'operation:settings-op',
+					capabilities: { settings: ['read'], request: { urls: [origin] } },
+				}),
+				settingsDeps
+			);
+
+			expect(result.outcome).toMatchObject({ ok: true, value: { baseUrl: BASE_URL } });
+			expect(authSeen).toContain(`Bearer ${SETTING_SECRET}`);
+			expect(JSON.stringify(result.outcome)).not.toContain(SETTING_SECRET);
 		},
 		ENGINE_TIMEOUT
 	);

--- a/api/src/extensions/confined/endpoint.test.ts
+++ b/api/src/extensions/confined/endpoint.test.ts
@@ -13,6 +13,7 @@ import {
 	SETTINGS_VALUE_BYTES,
 	TEMPLATE_OUTPUT_BYTES,
 } from './sandbox-limits.js';
+import { EMPTY_SETTINGS_ACCESS } from './settings-access.js';
 import type { ConfinedInvocation } from './types.js';
 
 const RUNTIME_LIMITS = {
@@ -54,6 +55,7 @@ function deps(overrides: Partial<ConfinedEndpointDeps> = {}): ConfinedEndpointDe
 		log: () => undefined,
 		brokerLimits: BROKER_LIMITS,
 		runtimeLimits: RUNTIME_LIMITS,
+		settingsAccess: () => EMPTY_SETTINGS_ACCESS,
 		...overrides,
 	};
 }

--- a/api/src/extensions/confined/endpoint.ts
+++ b/api/src/extensions/confined/endpoint.ts
@@ -1,12 +1,8 @@
 import type { Accountability, ExtensionCapabilities } from '@cairncms/types';
-import {
-	createConfinedHostBroker,
-	DARK_SETTINGS,
-	type ConfinedHostBrokerDeps,
-	type ConfinedLogEntry,
-} from './broker.js';
+import { createConfinedHostBroker, type ConfinedHostBrokerDeps, type ConfinedLogEntry } from './broker.js';
 import { toConfinedAccountability } from './operation.js';
 import { ConfinedSecretScope } from './secret-scope.js';
+import type { ConfinedSettingsAccess } from './settings-access.js';
 import type { ConfinedHostDispatcher, ConfinedInvocation, ConfinedResult, ConfinedRuntimeLimits } from './types.js';
 
 export const ENDPOINT_PATH_MAX = 2048;
@@ -41,6 +37,7 @@ export interface ConfinedEndpointDeps {
 	log: (entry: ConfinedLogEntry) => void;
 	getAxios?: ConfinedHostBrokerDeps['getAxios'];
 	itemsService?: ConfinedHostBrokerDeps['itemsService'];
+	settingsAccess: (subject: string) => ConfinedSettingsAccess;
 	brokerLimits: ConfinedHostBrokerDeps['limits'];
 	runtimeLimits: ConfinedRuntimeLimits;
 }
@@ -142,14 +139,23 @@ export async function runConfinedEndpoint(
 	try {
 		const scope = new ConfinedSecretScope();
 
+		const access = deps.settingsAccess(request.extensionId);
+
 		const brokerDeps: ConfinedHostBrokerDeps = {
 			capabilities: request.capabilities,
 			log: deps.log,
-			settings: DARK_SETTINGS,
+			settings: access.source,
 			accountability: request.accountability,
 			limits: deps.brokerLimits,
-			// Endpoints mint no option handles, so no reference ever resolves.
-			resolveSecret: async () => null,
+			resolveSecret: async (binding, signal) => {
+				if (signal.aborted) return null;
+
+				if (binding.kind === 'extension-setting') {
+					return access.resolveExtensionSecret(binding, signal);
+				}
+
+				return null;
+			},
 		};
 
 		if (deps.getAxios !== undefined) brokerDeps.getAxios = deps.getAxios;

--- a/api/src/extensions/confined/hook.test.ts
+++ b/api/src/extensions/confined/hook.test.ts
@@ -14,6 +14,7 @@ import {
 	SETTINGS_VALUE_BYTES,
 	TEMPLATE_OUTPUT_BYTES,
 } from './sandbox-limits.js';
+import { EMPTY_SETTINGS_ACCESS } from './settings-access.js';
 import type { ConfinedInvocation } from './types.js';
 
 const RUNTIME_LIMITS = {
@@ -67,6 +68,7 @@ function deps(overrides: Partial<ConfinedHookDeps> = {}): ConfinedHookDeps {
 		log: () => undefined,
 		brokerLimits: BROKER_LIMITS,
 		runtimeLimits: RUNTIME_LIMITS,
+		settingsAccess: () => EMPTY_SETTINGS_ACCESS,
 		...overrides,
 	};
 }

--- a/api/src/extensions/confined/hook.ts
+++ b/api/src/extensions/confined/hook.ts
@@ -1,12 +1,8 @@
 import type { Accountability, ExtensionCapabilities } from '@cairncms/types';
-import {
-	createConfinedHostBroker,
-	DARK_SETTINGS,
-	type ConfinedHostBrokerDeps,
-	type ConfinedLogEntry,
-} from './broker.js';
+import { createConfinedHostBroker, type ConfinedHostBrokerDeps, type ConfinedLogEntry } from './broker.js';
 import { toConfinedAccountability } from './operation.js';
 import { ConfinedSecretScope } from './secret-scope.js';
+import type { ConfinedSettingsAccess } from './settings-access.js';
 import type { ConfinedHostDispatcher, ConfinedInvocation, ConfinedResult, ConfinedRuntimeLimits } from './types.js';
 
 export const HOOK_PAYLOAD_BYTES_MAX = 1024 * 1024;
@@ -38,6 +34,7 @@ export interface ConfinedHookDeps {
 	log: (entry: ConfinedLogEntry) => void;
 	getAxios?: ConfinedHostBrokerDeps['getAxios'];
 	itemsService?: ConfinedHostBrokerDeps['itemsService'];
+	settingsAccess: (subject: string) => ConfinedSettingsAccess;
 	brokerLimits: ConfinedHostBrokerDeps['limits'];
 	runtimeLimits: ConfinedRuntimeLimits;
 }
@@ -91,14 +88,23 @@ function buildInvocation(
 }
 
 function buildDispatcher(request: ConfinedHookRequest, deps: ConfinedHookDeps): ConfinedHostDispatcher {
+	const access = deps.settingsAccess(request.extensionId);
+
 	const brokerDeps: ConfinedHostBrokerDeps = {
 		capabilities: request.capabilities,
 		log: deps.log,
-		settings: DARK_SETTINGS,
+		settings: access.source,
 		accountability: request.accountability,
 		limits: deps.brokerLimits,
-		// Hooks mint no option handles, so no reference ever resolves.
-		resolveSecret: async () => null,
+		resolveSecret: async (binding, signal) => {
+			if (signal.aborted) return null;
+
+			if (binding.kind === 'extension-setting') {
+				return access.resolveExtensionSecret(binding, signal);
+			}
+
+			return null;
+		},
 	};
 
 	if (deps.getAxios !== undefined) brokerDeps.getAxios = deps.getAxios;

--- a/api/src/extensions/confined/operation.test.ts
+++ b/api/src/extensions/confined/operation.test.ts
@@ -8,6 +8,7 @@ import {
 	SETTINGS_VALUE_BYTES,
 	TEMPLATE_OUTPUT_BYTES,
 } from './sandbox-limits.js';
+import { EMPTY_SETTINGS_ACCESS } from './settings-access.js';
 import type { ConfinedHostCallContext, ConfinedInvocation, ConfinedResult } from './types.js';
 
 const RUNTIME_LIMITS = {
@@ -48,6 +49,7 @@ function deps(overrides: Partial<ConfinedOperationDeps> = {}): ConfinedOperation
 		log: () => undefined,
 		brokerLimits: BROKER_LIMITS,
 		runtimeLimits: RUNTIME_LIMITS,
+		settingsAccess: () => EMPTY_SETTINGS_ACCESS,
 		...overrides,
 	};
 }

--- a/api/src/extensions/confined/operation.ts
+++ b/api/src/extensions/confined/operation.ts
@@ -1,12 +1,8 @@
 import type { Accountability, ConfinedOptionDelivery, ExtensionCapabilities } from '@cairncms/types';
-import {
-	createConfinedHostBroker,
-	DARK_SETTINGS,
-	type ConfinedHostBrokerDeps,
-	type ConfinedLogEntry,
-} from './broker.js';
+import { createConfinedHostBroker, type ConfinedHostBrokerDeps, type ConfinedLogEntry } from './broker.js';
 import { prepareOperationOptions } from './operation-options.js';
 import { ConfinedSecretScope } from './secret-scope.js';
+import type { ConfinedSettingsAccess } from './settings-access.js';
 import type {
 	ConfinedAccountability,
 	ConfinedHostDispatcher,
@@ -42,6 +38,7 @@ export interface ConfinedOperationDeps {
 	log: (entry: ConfinedLogEntry) => void;
 	getAxios?: ConfinedHostBrokerDeps['getAxios'];
 	itemsService?: ConfinedHostBrokerDeps['itemsService'];
+	settingsAccess: (subject: string) => ConfinedSettingsAccess;
 	brokerLimits: ConfinedHostBrokerDeps['limits'];
 	runtimeLimits: ConfinedRuntimeLimits;
 }
@@ -113,14 +110,20 @@ export async function runConfinedOperation(
 			};
 		}
 
+		const access = deps.settingsAccess(request.extensionId);
+
 		const brokerDeps: ConfinedHostBrokerDeps = {
 			capabilities: request.capabilities,
 			log: deps.log,
-			settings: DARK_SETTINGS,
+			settings: access.source,
 			accountability: request.accountability,
 			limits: deps.brokerLimits,
 			resolveSecret: async (binding, signal) => {
 				if (signal.aborted) return null;
+
+				if (binding.kind === 'extension-setting') {
+					return access.resolveExtensionSecret(binding, signal);
+				}
 
 				if (binding.kind === 'flow-operation-option' && binding.operationId === request.operationId) {
 					const value = prepared.referenceValues[binding.key];

--- a/api/src/extensions/confined/settings-access.test.ts
+++ b/api/src/extensions/confined/settings-access.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StoredGlobalSetting } from '../../services/extension-settings-store.js';
+import { buildConfinedSettingsAccess } from './settings-access.js';
+
+const declaration: any = {
+	base_url: { type: 'string', scope: 'global' },
+	retries: { type: 'number', scope: 'global' },
+	api_key: { type: 'string', scope: 'global', sensitive: true },
+	preview_url: { type: 'string', scope: 'collection' },
+};
+
+const rows: StoredGlobalSetting[] = [
+	{ key: 'base_url', value: 'https://x' },
+	{ key: 'retries', value: 3 },
+	{ key: 'api_key', value: { source: 'config', name: 'CAIRN_TEST_API_KEY' } },
+];
+
+const access = (rowsOverride: StoredGlobalSetting[] = rows) =>
+	buildConfinedSettingsAccess({ declaration, readRows: async () => rowsOverride });
+
+const live = () => new AbortController().signal;
+const binding = (key: string) => ({ kind: 'extension-setting' as const, extensionId: 'e', contributionId: 'c', key });
+
+describe('buildConfinedSettingsAccess', () => {
+	afterEach(() => {
+		delete process.env['CAIRN_TEST_API_KEY'];
+	});
+
+	it('exposes global keys only, lower-cased', () => {
+		const { source } = access();
+		expect(source.declared.map((d) => d.key).sort()).toEqual(['api_key', 'base_url', 'retries']);
+		expect(source.declared.find((d) => d.key === 'api_key')?.sensitive).toBe(true);
+	});
+
+	it('returns a declared non-secret scalar, normalizing a mixed-case key', async () => {
+		expect(await access().source.value('base_url', live())).toBe('https://x');
+		expect(await access().source.value('retries', live())).toBe(3);
+		expect(await access().source.value('BASE_URL', live())).toBe('https://x');
+	});
+
+	it('returns null for an undeclared or sensitive key', async () => {
+		expect(await access().source.value('nope', live())).toBeNull();
+		expect(await access().source.value('api_key', live())).toBeNull();
+	});
+
+	it('returns null for a stored value that mismatches the current declaration', async () => {
+		expect(await access([{ key: 'retries', value: 'three' }]).source.value('retries', live())).toBeNull();
+
+		expect(
+			await access([{ key: 'base_url', value: { source: 'config', name: 'X' } }]).source.value('base_url', live())
+		).toBeNull();
+
+		expect(await access([{ key: 'retries', value: Infinity }]).source.value('retries', live())).toBeNull();
+	});
+
+	it('resolves a sensitive pointer to the raw env string', async () => {
+		process.env['CAIRN_TEST_API_KEY'] = 'sk_live_123';
+		const a = access();
+		expect(await a.source.hasSecret('api_key', live())).toBe(true);
+		expect(await a.resolveExtensionSecret(binding('api_key'), live())).toBe('sk_live_123');
+	});
+
+	it('hasSecret is false and resolve is null when the env var is unset', async () => {
+		delete process.env['CAIRN_TEST_API_KEY'];
+		const a = access();
+		expect(await a.source.hasSecret('api_key', live())).toBe(false);
+		expect(await a.resolveExtensionSecret(binding('api_key'), live())).toBeNull();
+	});
+
+	it('resolve fails closed for a non-sensitive, undeclared, or collection key', async () => {
+		process.env['CAIRN_TEST_API_KEY'] = 'sk_live_123';
+		const a = access();
+		expect(await a.resolveExtensionSecret(binding('base_url'), live())).toBeNull();
+		expect(await a.resolveExtensionSecret(binding('nope'), live())).toBeNull();
+		expect(await a.resolveExtensionSecret(binding('preview_url'), live())).toBeNull();
+	});
+
+	it('resolve is null for a malformed pointer', async () => {
+		process.env['CAIRN_TEST_API_KEY'] = 'sk_live_123';
+		const a = access([{ key: 'api_key', value: { source: 'env', name: 'X' } }]);
+		expect(await a.resolveExtensionSecret(binding('api_key'), live())).toBeNull();
+	});
+
+	it('does not read or cache on an aborted first call, so a later live read still works', async () => {
+		const aborted = new AbortController();
+		aborted.abort();
+		const readRows = vi.fn(async (sig?: AbortSignal) => (sig?.aborted ? [] : rows));
+		const a = buildConfinedSettingsAccess({ declaration, readRows });
+
+		expect(await a.source.value('base_url', aborted.signal)).toBeNull();
+		expect(readRows).not.toHaveBeenCalled();
+
+		expect(await a.source.value('base_url', live())).toBe('https://x');
+		expect(readRows).toHaveBeenCalledTimes(1);
+	});
+});

--- a/api/src/extensions/confined/settings-access.ts
+++ b/api/src/extensions/confined/settings-access.ts
@@ -1,0 +1,92 @@
+import { ExtensionSecretPointerSchema } from '@cairncms/constants';
+import type { ExtensionSettings } from '@cairncms/types';
+import { readRawConfigSecret } from '../../utils/read-raw-config-secret.js';
+import type { StoredGlobalSetting } from '../../services/extension-settings-store.js';
+import type { ConfinedSettingsSource } from './broker.js';
+import type { ConfinedSecretBinding } from './secret-scope.js';
+
+type ExtensionSettingBinding = Extract<ConfinedSecretBinding, { kind: 'extension-setting' }>;
+
+export interface ConfinedSettingsAccess {
+	source: ConfinedSettingsSource;
+	resolveExtensionSecret(binding: ExtensionSettingBinding, signal: AbortSignal): Promise<string | null>;
+}
+
+/**
+ * Builds the confined settings source and the extension-setting secret resolver for one
+ * subject. It imports neither extensions.ts nor the service. The caller injects the
+ * owner declaration and a row reader, so the runtime path cannot close an import cycle.
+ */
+export function buildConfinedSettingsAccess(deps: {
+	declaration: ExtensionSettings | undefined;
+	readRows: (signal?: AbortSignal) => Promise<StoredGlobalSetting[]>;
+}): ConfinedSettingsAccess {
+	const { declaration, readRows } = deps;
+
+	const globalDeclared = new Map<string, { type: string; sensitive: boolean }>();
+
+	for (const [key, decl] of Object.entries(declaration ?? {})) {
+		if (decl.scope === 'global') {
+			globalDeclared.set(key.toLowerCase(), { type: decl.type, sensitive: decl.sensitive === true });
+		}
+	}
+
+	let cache: StoredGlobalSetting[] | undefined;
+
+	async function loadRows(signal?: AbortSignal): Promise<StoredGlobalSetting[]> {
+		if (cache !== undefined) return cache;
+		if (signal?.aborted) return [];
+
+		const rows = await readRows(signal);
+
+		// An aborted or failed read is not cached, so a later live read can still succeed.
+		if (signal?.aborted) return rows;
+
+		cache = rows;
+		return cache;
+	}
+
+	async function storedValue(normalizedKey: string, signal?: AbortSignal): Promise<unknown> {
+		const rows = await loadRows(signal);
+		return rows.find((row) => row.key.toLowerCase() === normalizedKey)?.value;
+	}
+
+	async function resolveSecretForKey(normalizedKey: string, signal?: AbortSignal): Promise<string | null> {
+		const declared = globalDeclared.get(normalizedKey);
+		if (declared === undefined || !declared.sensitive) return null;
+
+		const pointer = ExtensionSecretPointerSchema.safeParse(await storedValue(normalizedKey, signal));
+		if (!pointer.success) return null;
+
+		return readRawConfigSecret(pointer.data.name);
+	}
+
+	const source: ConfinedSettingsSource = {
+		declared: [...globalDeclared].map(([key, decl]) => ({ key, sensitive: decl.sensitive })),
+		async value(key, signal) {
+			const normalizedKey = key.toLowerCase();
+			const declared = globalDeclared.get(normalizedKey);
+			if (declared === undefined || declared.sensitive) return null;
+
+			const value = await storedValue(normalizedKey, signal);
+			if (typeof value !== declared.type) return null;
+			if (declared.type === 'number' && !Number.isFinite(value)) return null;
+
+			return value;
+		},
+		async hasSecret(key, signal) {
+			return (await resolveSecretForKey(key.toLowerCase(), signal)) !== null;
+		},
+	};
+
+	return {
+		source,
+		resolveExtensionSecret: (binding, signal) => resolveSecretForKey(binding.key.toLowerCase(), signal),
+	};
+}
+
+/**
+ * The access for a subject that owns no settings: an empty declaration reads every key as
+ * null and resolves no secret. Derived from the builder so there is one definition of empty.
+ */
+export const EMPTY_SETTINGS_ACCESS = buildConfinedSettingsAccess({ declaration: undefined, readRows: async () => [] });

--- a/api/src/extensions/confined/soak/real-surface.test.ts
+++ b/api/src/extensions/confined/soak/real-surface.test.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { describe, expect, it } from 'vitest';
 import type { ConfinedLogEntry } from '../broker.js';
 import { runConfinedOperation, type ConfinedOperationDeps } from '../operation.js';
+import { EMPTY_SETTINGS_ACCESS } from '../settings-access.js';
 import {
 	HTTP_RESPONSE_BYTES,
 	ITEMS_REPLY_BYTES,
@@ -59,6 +60,7 @@ describe('confined runtime real-surface drain', () => {
 				},
 				brokerLimits: BROKER_LIMITS,
 				runtimeLimits: LIMITS,
+				settingsAccess: () => EMPTY_SETTINGS_ACCESS,
 			};
 
 			const request = {

--- a/api/src/extensions/settings-subjects.test.ts
+++ b/api/src/extensions/settings-subjects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	type ConfinedCapabilitiesLookup,
 	resolveSettingsSubjects,
+	safeExtensionName,
 	SETTINGS_SUBJECT_DUPLICATE,
 	SETTINGS_SUBJECT_INVALID,
 } from './settings-subjects.js';
@@ -38,6 +39,17 @@ describe('resolveSettingsSubjects', () => {
 
 		expect(status?.eligible).toBe(false);
 		expect(status?.eligible === false && status.reason.code).toBe(SETTINGS_SUBJECT_INVALID);
+	});
+
+	it('sanitizes a control-character subject so the refusal reason is safe to log', () => {
+		const owner = makeExtension(`cairncms-extension-${String.fromCharCode(10)}evil`, { settings: declaration });
+
+		const status = resolveSettingsSubjects([owner], noConfined).get(owner);
+
+		expect(status?.eligible).toBe(false);
+		const detail = status?.eligible === false ? status.reason.detail : '';
+		expect(detail.includes(String.fromCharCode(10))).toBe(false);
+		expect(detail).toContain('?');
 	});
 
 	it('marks every owner ineligible on a subject collision', () => {
@@ -90,5 +102,16 @@ describe('resolveSettingsSubjects', () => {
 		const statuses = resolveSettingsSubjects([plain], noConfined);
 
 		expect(statuses.has(plain)).toBe(false);
+	});
+});
+
+describe('safeExtensionName', () => {
+	it('replaces control characters and truncates an overlong name', () => {
+		expect(safeExtensionName(`a${String.fromCharCode(10)}b${String.fromCharCode(0)}c`)).toBe('a?b?c');
+		expect(safeExtensionName('x'.repeat(100))).toBe(`${'x'.repeat(64)}...`);
+	});
+
+	it('leaves a conventional name unchanged', () => {
+		expect(safeExtensionName('cairncms-extension-preview')).toBe('cairncms-extension-preview');
 	});
 });

--- a/api/src/extensions/settings-subjects.test.ts
+++ b/api/src/extensions/settings-subjects.test.ts
@@ -1,0 +1,94 @@
+import type { Extension } from '@cairncms/types';
+import { describe, expect, it } from 'vitest';
+import {
+	type ConfinedCapabilitiesLookup,
+	resolveSettingsSubjects,
+	SETTINGS_SUBJECT_DUPLICATE,
+	SETTINGS_SUBJECT_INVALID,
+} from './settings-subjects.js';
+
+const declaration = { preview_url: { type: 'string', scope: 'global' } } as any;
+
+function makeExtension(name: string, overrides: Partial<Extension> = {}): Extension {
+	return {
+		path: `/extensions/${name}`,
+		name,
+		local: false,
+		type: 'interface',
+		entrypoint: 'index.js',
+		...overrides,
+	} as Extension;
+}
+
+const noConfined: ConfinedCapabilitiesLookup = () => undefined;
+
+describe('resolveSettingsSubjects', () => {
+	it('marks a declared owner with a valid unique subject eligible', () => {
+		const owner = makeExtension('cairncms-extension-preview', { settings: declaration });
+
+		const statuses = resolveSettingsSubjects([owner], noConfined);
+
+		expect(statuses.get(owner)).toEqual({ eligible: true });
+	});
+
+	it('marks an owner with an invalid subject ineligible, and it would still load', () => {
+		const owner = makeExtension('my-extension', { settings: declaration });
+
+		const status = resolveSettingsSubjects([owner], noConfined).get(owner);
+
+		expect(status?.eligible).toBe(false);
+		expect(status?.eligible === false && status.reason.code).toBe(SETTINGS_SUBJECT_INVALID);
+	});
+
+	it('marks every owner ineligible on a subject collision', () => {
+		const first = makeExtension('cairncms-extension-dup', { settings: declaration, path: '/a' });
+		const second = makeExtension('cairncms-extension-dup', { settings: declaration, path: '/b' });
+
+		const statuses = resolveSettingsSubjects([first, second], noConfined);
+
+		const firstStatus = statuses.get(first);
+		const secondStatus = statuses.get(second);
+		expect(firstStatus?.eligible === false && firstStatus.reason.code).toBe(SETTINGS_SUBJECT_DUPLICATE);
+		expect(secondStatus?.eligible === false && secondStatus.reason.code).toBe(SETTINGS_SUBJECT_DUPLICATE);
+	});
+
+	it('ignores a non-owner that shares the owner subject', () => {
+		const owner = makeExtension('cairncms-extension-shared', { settings: declaration, path: '/a' });
+		const nonOwner = makeExtension('cairncms-extension-shared', { path: '/b' });
+
+		const statuses = resolveSettingsSubjects([owner, nonOwner], noConfined);
+
+		expect(statuses.get(owner)).toEqual({ eligible: true });
+		expect(statuses.has(nonOwner)).toBe(false);
+	});
+
+	it('treats a bundle with several settings-capable entries as one owner, never a self-collision', () => {
+		const bundle = makeExtension('cairncms-extension-bundle', {
+			type: 'bundle',
+			entrypoint: { app: 'app.js', api: 'api.js' },
+			entries: [],
+		});
+
+		const confined: ConfinedCapabilitiesLookup = (extension) =>
+			extension === bundle ? { entries: { one: { settings: ['read'] }, two: { settings: ['write'] } } } : undefined;
+
+		expect(resolveSettingsSubjects([bundle], confined).get(bundle)).toEqual({ eligible: true });
+	});
+
+	it('treats a confined capabilities.settings entry as an owner without a declaration', () => {
+		const confinedApi = makeExtension('cairncms-extension-confined', { type: 'endpoint' });
+
+		const confined: ConfinedCapabilitiesLookup = (extension) =>
+			extension === confinedApi ? { self: { settings: ['write'] } } : undefined;
+
+		expect(resolveSettingsSubjects([confinedApi], confined).get(confinedApi)).toEqual({ eligible: true });
+	});
+
+	it('does not treat an extension with neither a declaration nor a settings capability as an owner', () => {
+		const plain = makeExtension('cairncms-extension-plain');
+
+		const statuses = resolveSettingsSubjects([plain], noConfined);
+
+		expect(statuses.has(plain)).toBe(false);
+	});
+});

--- a/api/src/extensions/settings-subjects.ts
+++ b/api/src/extensions/settings-subjects.ts
@@ -1,0 +1,72 @@
+import { ExtensionSettingsSubjectSchema } from '@cairncms/constants';
+import type { Extension, ExtensionCapabilities } from '@cairncms/types';
+
+export const SETTINGS_SUBJECT_INVALID = 'settings-subject-invalid';
+export const SETTINGS_SUBJECT_DUPLICATE = 'settings-subject-duplicate';
+
+export type SettingsSubjectReason = { code: string; detail: string };
+
+export type SettingsSubjectStatus = { eligible: true } | { eligible: false; reason: SettingsSubjectReason };
+
+export type ConfinedSettingsCapabilities = {
+	self?: ExtensionCapabilities;
+	entries?: Record<string, ExtensionCapabilities>;
+};
+
+export type ConfinedCapabilitiesLookup = (extension: Extension) => ConfinedSettingsCapabilities | undefined;
+
+function ownsSettings(extension: Extension, capabilities: ConfinedSettingsCapabilities | undefined): boolean {
+	if (extension.settings !== undefined) return true;
+	if (capabilities?.self?.settings !== undefined) return true;
+
+	if (capabilities?.entries && Object.values(capabilities.entries).some((entry) => entry.settings !== undefined)) {
+		return true;
+	}
+
+	return false;
+}
+
+export function resolveSettingsSubjects(
+	extensions: Extension[],
+	confinedCapabilities: ConfinedCapabilitiesLookup
+): Map<Extension, SettingsSubjectStatus> {
+	const owners = extensions.filter((extension) => ownsSettings(extension, confinedCapabilities(extension)));
+
+	const ownerCountBySubject = new Map<string, number>();
+
+	for (const owner of owners) {
+		ownerCountBySubject.set(owner.name, (ownerCountBySubject.get(owner.name) ?? 0) + 1);
+	}
+
+	const statuses = new Map<Extension, SettingsSubjectStatus>();
+
+	for (const owner of owners) {
+		if (ExtensionSettingsSubjectSchema.safeParse(owner.name).success === false) {
+			statuses.set(owner, {
+				eligible: false,
+				reason: {
+					code: SETTINGS_SUBJECT_INVALID,
+					detail: `the settings subject "${owner.name}" is not a valid extension package name`,
+				},
+			});
+
+			continue;
+		}
+
+		if ((ownerCountBySubject.get(owner.name) ?? 0) > 1) {
+			statuses.set(owner, {
+				eligible: false,
+				reason: {
+					code: SETTINGS_SUBJECT_DUPLICATE,
+					detail: `the settings subject "${owner.name}" is declared by more than one extension`,
+				},
+			});
+
+			continue;
+		}
+
+		statuses.set(owner, { eligible: true });
+	}
+
+	return statuses;
+}

--- a/api/src/extensions/settings-subjects.ts
+++ b/api/src/extensions/settings-subjects.ts
@@ -26,6 +26,20 @@ function ownsSettings(extension: Extension, capabilities: ConfinedSettingsCapabi
 	return false;
 }
 
+/**
+ * Renders an extension name safe for a log line or operator message. A name reaching the
+ * invalid-subject path failed validation, so it is untrusted and may carry control
+ * characters or newlines.
+ */
+export function safeExtensionName(name: string): string {
+	const sanitized = Array.from(name, (char) => {
+		const code = char.charCodeAt(0);
+		return code < 0x20 || (code >= 0x7f && code <= 0x9f) ? '?' : char;
+	}).join('');
+
+	return sanitized.length > 64 ? `${sanitized.slice(0, 64)}...` : sanitized;
+}
+
 export function resolveSettingsSubjects(
 	extensions: Extension[],
 	confinedCapabilities: ConfinedCapabilitiesLookup
@@ -46,7 +60,7 @@ export function resolveSettingsSubjects(
 				eligible: false,
 				reason: {
 					code: SETTINGS_SUBJECT_INVALID,
-					detail: `the settings subject "${owner.name}" is not a valid extension package name`,
+					detail: `the settings subject "${safeExtensionName(owner.name)}" is not a valid extension package name`,
 				},
 			});
 
@@ -58,7 +72,7 @@ export function resolveSettingsSubjects(
 				eligible: false,
 				reason: {
 					code: SETTINGS_SUBJECT_DUPLICATE,
-					detail: `the settings subject "${owner.name}" is declared by more than one extension`,
+					detail: `the settings subject "${safeExtensionName(owner.name)}" is declared by more than one extension`,
 				},
 			});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -10,6 +10,7 @@ import { ALIAS_TYPES } from '../constants.js';
 import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
+import { isInternalTable } from '../database/internal-tables.js';
 import { systemCollectionRows } from '../database/system-data/collections/index.js';
 import emitter from '../emitter.js';
 import env from '../env.js';
@@ -260,6 +261,9 @@ export class CollectionsService {
 		})) as CollectionMeta[];
 
 		meta.push(...systemCollectionRows);
+
+		tablesInDatabase = tablesInDatabase.filter((table) => !isInternalTable(table.name));
+		meta = meta.filter((collectionMeta) => !isInternalTable(collectionMeta.collection));
 
 		if (this.accountability && this.accountability.admin !== true) {
 			const collectionsGroups: { [key: string]: string } = meta.reduce(

--- a/api/src/services/extension-settings-store.test.ts
+++ b/api/src/services/extension-settings-store.test.ts
@@ -1,0 +1,64 @@
+import knex from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readGlobalSettings } from './extension-settings-store.js';
+
+const TABLE = 'cairncms_extension_settings';
+
+class Client_PG extends MockClient {}
+
+describe('readGlobalSettings', () => {
+	let db: any;
+	let tracker: Tracker;
+
+	beforeEach(() => {
+		db = vi.mocked(knex.default({ client: Client_PG }));
+		tracker = createTracker(db);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	it('returns an empty array for a subject with no rows', async () => {
+		tracker.on.select(TABLE).response([]);
+		expect(await readGlobalSettings(db, 'cairncms-extension-x')).toEqual([]);
+	});
+
+	it('returns parsed scalar and pointer values', async () => {
+		tracker.on.select(TABLE).response([
+			{ key: 'base_url', value: '"https://x"' },
+			{ key: 'api_key', value: '{"source":"config","name":"API_KEY"}' },
+		]);
+
+		expect(await readGlobalSettings(db, 'cairncms-extension-x')).toEqual([
+			{ key: 'base_url', value: 'https://x' },
+			{ key: 'api_key', value: { source: 'config', name: 'API_KEY' } },
+		]);
+	});
+
+	it('omits a row whose stored value fails to parse', async () => {
+		tracker.on.select(TABLE).response([
+			{ key: 'good', value: '"ok"' },
+			{ key: 'corrupt', value: 'not json{' },
+		]);
+
+		expect(await readGlobalSettings(db, 'cairncms-extension-x')).toEqual([{ key: 'good', value: 'ok' }]);
+	});
+
+	it('restricts the query to the global scope with an empty scope key', async () => {
+		tracker.on.select(TABLE).response([{ key: 'base_url', value: '"g"' }]);
+
+		await readGlobalSettings(db, 'cairncms-extension-x');
+
+		expect(tracker.history.select[0]?.bindings).toEqual(['cairncms-extension-x', 'global', '']);
+	});
+
+	it('short-circuits an already-aborted signal without querying', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		expect(await readGlobalSettings(db, 'cairncms-extension-x', controller.signal)).toEqual([]);
+		expect(tracker.history.select).toHaveLength(0);
+	});
+});

--- a/api/src/services/extension-settings-store.ts
+++ b/api/src/services/extension-settings-store.ts
@@ -1,0 +1,37 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'cairncms_extension_settings';
+
+export type StoredGlobalSetting = {
+	key: string;
+	value: unknown;
+};
+
+/**
+ * Reads a subject's global-scoped settings for the confined runtime. This is a
+ * system-internal read with no accountability and no admin gate, kept free of any
+ * import of extensions.ts so the runtime path cannot close an import cycle.
+ */
+export async function readGlobalSettings(
+	knex: Knex,
+	subject: string,
+	signal?: AbortSignal
+): Promise<StoredGlobalSetting[]> {
+	if (signal?.aborted) return [];
+
+	const rows = await knex(TABLE).where({ extension: subject, scope: 'global', scope_key: '' }).select('key', 'value');
+
+	if (signal?.aborted) return [];
+
+	const settings: StoredGlobalSetting[] = [];
+
+	for (const row of rows) {
+		try {
+			settings.push({ key: row.key, value: JSON.parse(row.value) });
+		} catch {
+			// A corrupt row is unusable. Omit it so the runtime read never throws.
+		}
+	}
+
+	return settings;
+}

--- a/api/src/services/extension-settings.test.ts
+++ b/api/src/services/extension-settings.test.ts
@@ -1,0 +1,181 @@
+import knex from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { manager } = vi.hoisted(() => ({ manager: { getSettingsOwner: vi.fn() } }));
+
+vi.mock('../extensions.js', () => ({ getExtensionManager: () => manager }));
+
+import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import { ExtensionSettingsService } from './extension-settings.js';
+
+const TABLE = 'cairncms_extension_settings';
+
+class Client_PG extends MockClient {}
+
+const admin = { role: 'admin', admin: true } as any;
+const schema = { collections: { articles: {} }, relations: [] } as any;
+
+const declaration = {
+	preview_url: { type: 'string', scope: 'collection' },
+	count: { type: 'number', scope: 'global' },
+	api_key: { type: 'string', scope: 'global', sensitive: true },
+};
+
+const owner = { name: 'cairncms-extension-preview', settings: declaration } as any;
+
+describe('ExtensionSettingsService', () => {
+	let db: any;
+	let tracker: Tracker;
+
+	beforeEach(() => {
+		db = vi.mocked(knex.default({ client: Client_PG }));
+		tracker = createTracker(db);
+		manager.getSettingsOwner.mockReset();
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	const service = (accountability: any = admin) => new ExtensionSettingsService({ knex: db, schema, accountability });
+
+	describe('set', () => {
+		it('persists a valid value for an eligible owner', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+			tracker.on.insert(TABLE).response([1]);
+
+			await service().set('cairncms-extension-preview', 'collection', 'articles', 'preview_url', 'https://x');
+
+			expect(tracker.history.insert).toHaveLength(1);
+		});
+
+		it('accepts a sensitive secret pointer', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+			tracker.on.insert(TABLE).response([1]);
+
+			await service().set('cairncms-extension-preview', 'global', '', 'api_key', { source: 'config', name: 'API_KEY' });
+
+			expect(tracker.history.insert).toHaveLength(1);
+		});
+
+		it('refuses a non-admin', async () => {
+			await expect(
+				service({ admin: false }).set('cairncms-extension-preview', 'global', '', 'count', 1)
+			).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it('refuses an ineligible or absent subject', async () => {
+			manager.getSettingsOwner.mockReturnValue(undefined);
+
+			await expect(service().set('cairncms-extension-preview', 'global', '', 'count', 1)).rejects.toBeInstanceOf(
+				ForbiddenException
+			);
+		});
+
+		it('refuses an undeclared key', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(service().set('cairncms-extension-preview', 'global', '', 'nope', 1)).rejects.toBeInstanceOf(
+				InvalidPayloadException
+			);
+		});
+
+		it('refuses an unknown scope', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(service().set('cairncms-extension-preview', 'tenant' as any, '', 'count', 1)).rejects.toBeInstanceOf(
+				InvalidPayloadException
+			);
+		});
+
+		it('refuses a global scope with a non-empty scope key', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'global', 'articles', 'count', 1)
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('refuses a collection scope to a missing collection', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'collection', 'ghosts', 'preview_url', 'https://x')
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('refuses a prototype-chain scope key', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'collection', 'constructor', 'preview_url', 'https://x')
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('refuses a value stored under the wrong declared scope', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'global', '', 'preview_url', 'https://x')
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'collection', 'articles', 'count', 1)
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('refuses a non-finite number', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(service().set('cairncms-extension-preview', 'global', '', 'count', NaN)).rejects.toBeInstanceOf(
+				InvalidPayloadException
+			);
+		});
+
+		it('refuses an out-of-shape value', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'global', '', 'count', 'not-a-number')
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+
+		it('refuses a sensitive value that is not a secret pointer', async () => {
+			manager.getSettingsOwner.mockReturnValue(owner);
+
+			await expect(
+				service().set('cairncms-extension-preview', 'global', '', 'api_key', 'raw-secret')
+			).rejects.toBeInstanceOf(InvalidPayloadException);
+		});
+	});
+
+	describe('get and deleteBySubject', () => {
+		it('reads stored rows for any subject and parses the stored value', async () => {
+			manager.getSettingsOwner.mockReturnValue(undefined);
+
+			tracker.on.select(TABLE).response([
+				{ scope: 'collection', scope_key: 'articles', key: 'preview_url', value: '"https://x"' },
+				{ scope: 'global', scope_key: '', key: 'count', value: '42' },
+			]);
+
+			const rows = await service().get('cairncms-extension-preview');
+
+			expect(rows).toEqual([
+				{ scope: 'collection', scope_key: 'articles', key: 'preview_url', value: 'https://x' },
+				{ scope: 'global', scope_key: '', key: 'count', value: 42 },
+			]);
+		});
+
+		it('deletes every row for a subject', async () => {
+			tracker.on.delete(TABLE).response(3);
+
+			expect(await service().deleteBySubject('cairncms-extension-preview')).toBe(3);
+		});
+
+		it('refuses a non-admin read and delete', async () => {
+			await expect(service({ admin: false }).get('x')).rejects.toBeInstanceOf(ForbiddenException);
+			await expect(service({ admin: false }).deleteBySubject('x')).rejects.toBeInstanceOf(ForbiddenException);
+		});
+	});
+});

--- a/api/src/services/extension-settings.ts
+++ b/api/src/services/extension-settings.ts
@@ -1,0 +1,117 @@
+import { ExtensionSecretPointerSchema } from '@cairncms/constants';
+import type { Accountability, SchemaOverview } from '@cairncms/types';
+import type { Knex } from 'knex';
+import { v4 as uuid } from 'uuid';
+import getDatabase from '../database/index.js';
+import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
+import { getExtensionManager } from '../extensions.js';
+import type { AbstractServiceOptions } from '../types/index.js';
+
+const TABLE = 'cairncms_extension_settings';
+
+type SettingsScope = 'global' | 'collection';
+
+export type StoredSetting = {
+	scope: string;
+	scope_key: string;
+	key: string;
+	value: unknown;
+};
+
+export class ExtensionSettingsService {
+	knex: Knex;
+	accountability: Accountability | null;
+	schema: SchemaOverview;
+
+	constructor(options: AbstractServiceOptions) {
+		this.knex = options.knex || getDatabase();
+		this.accountability = options.accountability || null;
+		this.schema = options.schema;
+	}
+
+	async set(subject: string, scope: SettingsScope, scopeKey: string, key: string, value: unknown): Promise<void> {
+		this.requireAdmin();
+
+		const owner = getExtensionManager().getSettingsOwner(subject);
+		if (owner === undefined) throw new ForbiddenException();
+
+		const declared = owner.settings?.[key];
+		if (declared === undefined) throw new InvalidPayloadException(`The setting key "${key}" is not declared.`);
+
+		this.validateScope(scope, scopeKey);
+
+		if (scope !== declared.scope) {
+			throw new InvalidPayloadException(`The setting key "${key}" is declared at "${declared.scope}" scope.`);
+		}
+
+		this.validateValue(declared, value);
+
+		const serialized = JSON.stringify(value);
+
+		await this.knex(TABLE)
+			.insert({ id: uuid(), extension: subject, scope, scope_key: scopeKey, key, value: serialized })
+			.onConflict(['extension', 'scope', 'scope_key', 'key'])
+			.merge({ value: serialized });
+	}
+
+	async get(subject: string, scope?: SettingsScope, scopeKey?: string): Promise<StoredSetting[]> {
+		this.requireAdmin();
+
+		const query = this.knex(TABLE).where({ extension: subject });
+		if (scope !== undefined) query.where({ scope });
+		if (scopeKey !== undefined) query.where({ scope_key: scopeKey });
+
+		const rows = await query.select('scope', 'scope_key', 'key', 'value');
+
+		return rows.map((row) => ({
+			scope: row.scope,
+			scope_key: row.scope_key,
+			key: row.key,
+			value: JSON.parse(row.value),
+		}));
+	}
+
+	async deleteBySubject(subject: string): Promise<number> {
+		this.requireAdmin();
+		return await this.knex(TABLE).where({ extension: subject }).delete();
+	}
+
+	private requireAdmin(): void {
+		if (this.accountability?.admin !== true) throw new ForbiddenException();
+	}
+
+	private validateScope(scope: SettingsScope, scopeKey: string): void {
+		if (scope !== 'global' && scope !== 'collection') {
+			throw new InvalidPayloadException(`The setting scope must be "global" or "collection".`);
+		}
+
+		if (scope === 'global' && scopeKey !== '') {
+			throw new InvalidPayloadException(`A global setting must use an empty scope key.`);
+		}
+
+		if (
+			scope === 'collection' &&
+			(scopeKey === '' || Object.prototype.hasOwnProperty.call(this.schema.collections, scopeKey) === false)
+		) {
+			throw new InvalidPayloadException(`A collection setting must target an existing collection.`);
+		}
+	}
+
+	private validateValue(declared: { type: string; sensitive?: boolean | undefined }, value: unknown): void {
+		if (declared.sensitive === true) {
+			if (ExtensionSecretPointerSchema.safeParse(value).success === false) {
+				throw new InvalidPayloadException(`A sensitive setting must be stored as a secret pointer.`);
+			}
+
+			return;
+		}
+
+		if (typeof value !== declared.type) {
+			throw new InvalidPayloadException(`The setting value does not match the declared type.`);
+		}
+
+		if (declared.type === 'number' && Number.isFinite(value) === false) {
+			throw new InvalidPayloadException(`A number setting must be a finite number.`);
+		}
+	}
+}

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -15,6 +15,7 @@ import StreamArray from 'stream-json/streamers/StreamArray.js';
 import stripBomStream from 'strip-bom-stream';
 import { file as createTmpFile } from 'tmp-promise';
 import getDatabase from '../database/index.js';
+import { isInternalTable } from '../database/internal-tables.js';
 import emitter from '../emitter.js';
 import env from '../env.js';
 import {
@@ -44,6 +45,7 @@ export class ImportService {
 	}
 
 	async import(collection: string, mimetype: string, stream: Readable): Promise<void> {
+		if (isInternalTable(collection)) throw new ForbiddenException();
 		if (this.accountability?.admin !== true && collection.startsWith('directus_')) throw new ForbiddenException();
 
 		const createPermissions = this.accountability?.permissions?.find(
@@ -200,6 +202,8 @@ export class ExportService {
 			file?: Partial<File>;
 		}
 	) {
+		if (isInternalTable(collection)) throw new ForbiddenException();
+
 		try {
 			const mimeTypes = {
 				csv: 'text/csv',

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -8,6 +8,7 @@ import { clearSystemCache, getCache } from '../cache.js';
 import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
+import { isInternalTable } from '../database/internal-tables.js';
 import { systemRelationRows } from '../database/system-data/relations/index.js';
 import emitter from '../emitter.js';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
@@ -73,7 +74,13 @@ export class RelationsService {
 		});
 
 		const schemaRows = await this.schemaInspector.foreignKeys(collection);
-		const results = this.stitchRelations(metaRows, schemaRows);
+
+		const results = this.stitchRelations(metaRows, schemaRows).filter((relation) => {
+			if (isInternalTable(relation.collection)) return false;
+			if (relation.related_collection && isInternalTable(relation.related_collection)) return false;
+			return true;
+		});
+
 		return await this.filterForbidden(results);
 	}
 
@@ -117,7 +124,12 @@ export class RelationsService {
 			(foreignKey) => foreignKey.column === field
 		);
 
-		const stitched = this.stitchRelations(metaRow, schemaRow ? [schemaRow] : []);
+		const stitched = this.stitchRelations(metaRow, schemaRow ? [schemaRow] : []).filter((relation) => {
+			if (isInternalTable(relation.collection)) return false;
+			if (relation.related_collection && isInternalTable(relation.related_collection)) return false;
+			return true;
+		});
+
 		const results = await this.filterForbidden(stitched);
 
 		if (results.length === 0) {

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -7,6 +7,7 @@ import { mapValues } from 'lodash-es';
 import { getSchemaCache, setSchemaCache } from '../cache.js';
 import { ALIAS_TYPES } from '../constants.js';
 import getDatabase from '../database/index.js';
+import { isInternalTable } from '../database/internal-tables.js';
 import { systemCollectionRows } from '../database/system-data/collections/index.js';
 import { systemFieldRows } from '../database/system-data/fields/index.js';
 import env from '../env.js';
@@ -72,6 +73,8 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 	];
 
 	for (const [collection, info] of Object.entries(schemaOverview)) {
+		if (isInternalTable(collection)) continue;
+
 		if (toArray(env['DB_EXCLUDE_TABLES']).includes(collection)) {
 			logger.trace(`Collection "${collection}" is configured to be excluded and will be ignored`);
 			continue;

--- a/api/src/utils/read-raw-config-secret.test.ts
+++ b/api/src/utils/read-raw-config-secret.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readRawConfigSecret } from './read-raw-config-secret.js';
+
+describe('readRawConfigSecret', () => {
+	const original = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...original };
+	});
+
+	it('returns a numeric-looking value as a string, never coerced', () => {
+		process.env['CAIRN_TEST_SECRET'] = '12345';
+
+		const result = readRawConfigSecret('CAIRN_TEST_SECRET');
+
+		expect(result).toBe('12345');
+		expect(typeof result).toBe('string');
+	});
+
+	it('returns null for a missing variable', () => {
+		delete process.env['CAIRN_TEST_MISSING'];
+
+		expect(readRawConfigSecret('CAIRN_TEST_MISSING')).toBeNull();
+	});
+
+	it('returns null for an empty string', () => {
+		process.env['CAIRN_TEST_EMPTY'] = '';
+
+		expect(readRawConfigSecret('CAIRN_TEST_EMPTY')).toBeNull();
+	});
+});

--- a/api/src/utils/read-raw-config-secret.ts
+++ b/api/src/utils/read-raw-config-secret.ts
@@ -1,0 +1,9 @@
+/**
+ * Reads a config variable as a raw secret. Returns the value only when it is a
+ * non-empty string, never the type-coerced view from getEnv(), so a numeric or
+ * boolean-looking secret is never handed back as a number or boolean.
+ */
+export function readRawConfigSecret(name: string): string | null {
+	const raw = process.env[name];
+	return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}

--- a/packages/constants/src/extensions.test.ts
+++ b/packages/constants/src/extensions.test.ts
@@ -578,4 +578,8 @@ describe('ExtensionSettingsSubjectSchema', () => {
 		expect(ExtensionSettingsSubjectSchema.safeParse('my-extension').success).toBe(false);
 		expect(ExtensionSettingsSubjectSchema.safeParse('').success).toBe(false);
 	});
+
+	it('rejects a subject longer than the storage bound', () => {
+		expect(ExtensionSettingsSubjectSchema.safeParse(`cairncms-extension-${'x'.repeat(260)}`).success).toBe(false);
+	});
 });

--- a/packages/constants/src/extensions.test.ts
+++ b/packages/constants/src/extensions.test.ts
@@ -3,6 +3,7 @@ import {
 	ExtensionCapabilitiesSchema,
 	ExtensionManifest,
 	ExtensionOptions,
+	ExtensionSecretPointerSchema,
 	ExtensionSettingsSubjectSchema,
 } from './extensions.js';
 
@@ -581,5 +582,21 @@ describe('ExtensionSettingsSubjectSchema', () => {
 
 	it('rejects a subject longer than the storage bound', () => {
 		expect(ExtensionSettingsSubjectSchema.safeParse(`cairncms-extension-${'x'.repeat(260)}`).success).toBe(false);
+	});
+});
+
+describe('ExtensionSecretPointerSchema', () => {
+	it('accepts a config pointer with a valid variable name', () => {
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: 'MY_API_KEY' }).success).toBe(true);
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: '_private' }).success).toBe(true);
+	});
+
+	it('rejects a non-config source, a malformed name, extra keys, and a raw value', () => {
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'env', name: 'MY_API_KEY' }).success).toBe(false);
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: '1bad' }).success).toBe(false);
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: 'a b' }).success).toBe(false);
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: '' }).success).toBe(false);
+		expect(ExtensionSecretPointerSchema.safeParse({ source: 'config', name: 'OK', extra: true }).success).toBe(false);
+		expect(ExtensionSecretPointerSchema.safeParse('raw-secret-value').success).toBe(false);
 	});
 });

--- a/packages/constants/src/extensions.test.ts
+++ b/packages/constants/src/extensions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { ExtensionCapabilitiesSchema, ExtensionManifest, ExtensionOptions } from './extensions.js';
+import {
+	ExtensionCapabilitiesSchema,
+	ExtensionManifest,
+	ExtensionOptions,
+	ExtensionSettingsSubjectSchema,
+} from './extensions.js';
 
 describe('ExtensionCapabilitiesSchema', () => {
 	it('accepts a brokered request plus log', () => {
@@ -490,5 +495,87 @@ describe('ExtensionManifest', () => {
 		});
 
 		expect(result.success).toBe(true);
+	});
+});
+
+describe('ExtensionOptions settings declaration', () => {
+	it('accepts a settings declaration on an app extension, which cannot declare capabilities', () => {
+		const settings = { preview_url: { type: 'string', scope: 'collection' } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(true);
+	});
+
+	it('accepts a settings declaration on every extension type', () => {
+		const settings = { preview_url: { type: 'string', scope: 'global' } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(true);
+		expect(ExtensionOptions.safeParse({ ...apiOption, settings }).success).toBe(true);
+		expect(ExtensionOptions.safeParse({ ...hybridOption, settings }).success).toBe(true);
+		expect(ExtensionOptions.safeParse({ ...bundleOption, settings }).success).toBe(true);
+	});
+
+	it('accepts an extension that omits settings', () => {
+		expect(ExtensionOptions.safeParse(appOption).success).toBe(true);
+	});
+
+	it('rejects an empty settings declaration so ownership is never ambiguous', () => {
+		expect(ExtensionOptions.safeParse({ ...appOption, settings: {} }).success).toBe(false);
+	});
+
+	it('accepts a sensitive string setting', () => {
+		const settings = { api_key: { type: 'string', scope: 'global', sensitive: true } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(true);
+	});
+
+	it('rejects a sensitive non-string setting', () => {
+		const settings = { api_key: { type: 'number', scope: 'global', sensitive: true } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(false);
+	});
+
+	it('rejects an unknown key inside a setting declaration', () => {
+		const settings = { preview_url: { type: 'string', scope: 'global', surprise: true } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(false);
+	});
+
+	it('rejects an invalid type or scope', () => {
+		expect(
+			ExtensionOptions.safeParse({ ...appOption, settings: { x: { type: 'date', scope: 'global' } } }).success
+		).toBe(false);
+
+		expect(
+			ExtensionOptions.safeParse({ ...appOption, settings: { x: { type: 'string', scope: 'tenant' } } }).success
+		).toBe(false);
+	});
+
+	it('accepts a conventional snake_case key', () => {
+		const settings = { preview_url: { type: 'string', scope: 'global' } };
+		expect(ExtensionOptions.safeParse({ ...appOption, settings }).success).toBe(true);
+	});
+
+	it('rejects unsafe or reserved setting keys', () => {
+		for (const key of [
+			'__proto__',
+			'constructor',
+			'prototype',
+			'Preview',
+			'preview-url',
+			'preview url',
+			'preview.url',
+			'1preview',
+		]) {
+			const settings = { [key]: { type: 'string', scope: 'global' } };
+			expect(ExtensionOptions.safeParse({ ...appOption, settings }).success, key).toBe(false);
+		}
+	});
+});
+
+describe('ExtensionSettingsSubjectSchema', () => {
+	it('accepts the package-name convention', () => {
+		expect(ExtensionSettingsSubjectSchema.safeParse('cairncms-extension-foo').success).toBe(true);
+		expect(ExtensionSettingsSubjectSchema.safeParse('@scope/cairncms-extension-foo').success).toBe(true);
+		expect(ExtensionSettingsSubjectSchema.safeParse('@cairncms/extension-foo').success).toBe(true);
+	});
+
+	it('rejects a name outside the convention', () => {
+		expect(ExtensionSettingsSubjectSchema.safeParse('my-extension').success).toBe(false);
+		expect(ExtensionSettingsSubjectSchema.safeParse('').success).toBe(false);
 	});
 });

--- a/packages/constants/src/extensions.ts
+++ b/packages/constants/src/extensions.ts
@@ -352,7 +352,7 @@ export const ExtensionSettingsSchema = z
 		message: 'a settings declaration must declare at least one key',
 	});
 
-export const ExtensionSettingsSubjectSchema = z.string().regex(EXTENSION_NAME_REGEX);
+export const ExtensionSettingsSubjectSchema = z.string().regex(EXTENSION_NAME_REGEX).max(255);
 
 export const ExtensionOptionsBase = z.object({
 	host: z.string(),

--- a/packages/constants/src/extensions.ts
+++ b/packages/constants/src/extensions.ts
@@ -319,9 +319,45 @@ export const ExtensionOptionsBundleEntry = z.union([
 		}),
 ]);
 
+export const ExtensionSettingDeclaration = z
+	.object({
+		type: z.enum(['string', 'number', 'boolean']),
+		scope: z.enum(['global', 'collection']),
+		sensitive: z.boolean().optional(),
+	})
+	.strict()
+	.superRefine((value, ctx) => {
+		if (value.sensitive === true && value.type !== 'string') {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['type'],
+				message: 'a sensitive setting must be type string',
+			});
+		}
+	});
+
+const RESERVED_SETTING_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+export const ExtensionSettingKeySchema = z
+	.string()
+	.regex(/^[a-z][a-z0-9_]*$/)
+	.max(64)
+	.refine((key) => RESERVED_SETTING_KEYS.includes(key) === false, {
+		message: 'a settings key must not be a reserved property name',
+	});
+
+export const ExtensionSettingsSchema = z
+	.record(ExtensionSettingKeySchema, ExtensionSettingDeclaration)
+	.refine((value) => Object.keys(value).length > 0, {
+		message: 'a settings declaration must declare at least one key',
+	});
+
+export const ExtensionSettingsSubjectSchema = z.string().regex(EXTENSION_NAME_REGEX);
+
 export const ExtensionOptionsBase = z.object({
 	host: z.string(),
 	hidden: z.boolean().optional(),
+	settings: ExtensionSettingsSchema.optional(),
 });
 
 export const ExtensionOptionsApp = z

--- a/packages/constants/src/extensions.ts
+++ b/packages/constants/src/extensions.ts
@@ -354,6 +354,16 @@ export const ExtensionSettingsSchema = z
 
 export const ExtensionSettingsSubjectSchema = z.string().regex(EXTENSION_NAME_REGEX).max(255);
 
+export const ExtensionSecretPointerSchema = z
+	.object({
+		source: z.literal('config'),
+		name: z
+			.string()
+			.regex(/^[A-Za-z_][A-Za-z0-9_]*$/)
+			.max(128),
+	})
+	.strict();
+
 export const ExtensionOptionsBase = z.object({
 	host: z.string(),
 	hidden: z.boolean().optional(),

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -141,6 +141,8 @@ paths:
     $ref: './paths/extensions/diagnostics.yaml'
   /extensions/sources/{chunk}:
     $ref: './paths/extensions/sources.yaml'
+  /extension-settings:
+    $ref: './paths/extension-settings/settings.yaml'
 
   # Fields
   /fields:
@@ -254,6 +256,26 @@ paths:
 
 components:
   schemas:
+    ExtensionSettingValue:
+      description: A scalar setting value, or a secret pointer for a sensitive key.
+      oneOf:
+        - type: string
+        - type: number
+        - type: boolean
+        - type: object
+          required:
+            - source
+            - name
+          additionalProperties: false
+          properties:
+            source:
+              type: string
+              enum:
+                - config
+            name:
+              type: string
+              pattern: '^[A-Za-z_][A-Za-z0-9_]*$'
+              maxLength: 128
     Activity:
       $ref: './components/activity.yaml'
     Presets:

--- a/packages/specs/src/paths/extension-settings/settings.yaml
+++ b/packages/specs/src/paths/extension-settings/settings.yaml
@@ -1,0 +1,133 @@
+get:
+  tags:
+    - Extensions
+  operationId: getExtensionSettings
+  summary: Read Extension Settings
+  description:
+    Returns the stored settings for an extension subject. A secret pointer is returned as stored, never resolved.
+    This route is restricted to administrators.
+  parameters:
+    - name: subject
+      in: query
+      required: true
+      description: The extension's package name.
+      schema:
+        type: string
+    - name: scope
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - global
+          - collection
+    - name: scope_key
+      in: query
+      required: false
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    scope:
+                      type: string
+                    scope_key:
+                      type: string
+                    key:
+                      type: string
+                    value:
+                      $ref: '../../openapi.yaml#/components/schemas/ExtensionSettingValue'
+    '400':
+      description: The request is missing the required subject.
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '403':
+      description: The current user is not an administrator.
+post:
+  tags:
+    - Extensions
+  operationId: setExtensionSetting
+  summary: Write an Extension Setting
+  description:
+    Validates a setting value against the extension's manifest declaration and stores it. A sensitive setting
+    accepts only a secret pointer, never a raw value. This route is restricted to administrators.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - subject
+            - scope
+            - scope_key
+            - key
+            - value
+          properties:
+            subject:
+              type: string
+            scope:
+              type: string
+              enum:
+                - global
+                - collection
+            scope_key:
+              type: string
+            key:
+              type: string
+            value:
+              $ref: '../../openapi.yaml#/components/schemas/ExtensionSettingValue'
+  responses:
+    '200':
+      description: The setting was stored.
+    '400':
+      description: The key is undeclared, the value is out of shape, or the scope does not match the declaration.
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '403':
+      description: The current user is not an administrator, or the subject is not an eligible settings owner.
+delete:
+  tags:
+    - Extensions
+  operationId: deleteExtensionSettings
+  summary: Purge an Extension's Settings
+  description:
+    Removes every stored setting for an extension subject across all scopes. This route is restricted to administrators.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - subject
+          properties:
+            subject:
+              type: string
+  responses:
+    '200':
+      description: The settings were removed.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  removed:
+                    type: integer
+    '400':
+      description: The request is missing the required subject.
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '403':
+      description: The current user is not an administrator.

--- a/packages/types/src/extensions.ts
+++ b/packages/types/src/extensions.ts
@@ -11,6 +11,7 @@ import type {
 	ExtensionOptions,
 	ExtensionOptionsBundleEntries,
 	ExtensionOptionsBundleEntry,
+	ExtensionSettingsSchema,
 	HYBRID_EXTENSION_TYPES,
 	LOCAL_TYPES,
 	NESTED_EXTENSION_TYPES,
@@ -45,6 +46,8 @@ export type ConfinedRuntime = z.infer<typeof ConfinedRuntimeSchema>;
 
 export type ExtensionCapabilities = z.infer<typeof ExtensionCapabilitiesSchema>;
 
+export type ExtensionSettings = z.infer<typeof ExtensionSettingsSchema>;
+
 export type ConfinedOptionDelivery = z.infer<typeof ConfinedOptionDeliverySchema>;
 
 export type ConfinedHookEvents = z.infer<typeof ConfinedHookEventsSchema>;
@@ -56,6 +59,7 @@ type ExtensionBase = {
 	host?: string;
 	local: boolean;
 	runtime?: ConfinedRuntime;
+	settings?: ExtensionSettings;
 };
 
 export type AppExtension = ExtensionBase & {

--- a/packages/utils/node/get-extensions.ts
+++ b/packages/utils/node/get-extensions.ts
@@ -54,6 +54,7 @@ async function parsePackageExtension(extensionName: string, extensionPath: strin
 			host: extensionOptions.host,
 			local,
 			...(extensionOptions.runtime !== undefined && { runtime: extensionOptions.runtime }),
+			...(extensionOptions.settings !== undefined && { settings: extensionOptions.settings }),
 		};
 	} else if (isTypeIn(extensionOptions, HYBRID_EXTENSION_TYPES)) {
 		return {
@@ -68,6 +69,7 @@ async function parsePackageExtension(extensionName: string, extensionPath: strin
 			host: extensionOptions.host,
 			local,
 			...(extensionOptions.runtime !== undefined && { runtime: extensionOptions.runtime }),
+			...(extensionOptions.settings !== undefined && { settings: extensionOptions.settings }),
 		};
 	} else {
 		return {
@@ -79,6 +81,7 @@ async function parsePackageExtension(extensionName: string, extensionPath: strin
 			host: extensionOptions.host,
 			local,
 			...(extensionOptions.runtime !== undefined && { runtime: extensionOptions.runtime }),
+			...(extensionOptions.settings !== undefined && { settings: extensionOptions.settings }),
 		};
 	}
 }

--- a/tests/blackbox/extensions/cairncms-extension-bad-subject/index.js
+++ b/tests/blackbox/extensions/cairncms-extension-bad-subject/index.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/tests/blackbox/extensions/cairncms-extension-bad-subject/package.json
+++ b/tests/blackbox/extensions/cairncms-extension-bad-subject/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "bad-subject",
+	"version": "1.0.0",
+	"type": "module",
+	"private": true,
+	"cairncms:extension": {
+		"type": "endpoint",
+		"path": "index.js",
+		"source": "index.js",
+		"host": "^1.0.0",
+		"settings": {
+			"some_key": { "type": "string", "scope": "global" }
+		}
+	}
+}

--- a/tests/blackbox/extensions/cairncms-extension-settings-fixture/index.js
+++ b/tests/blackbox/extensions/cairncms-extension-settings-fixture/index.js
@@ -1,0 +1,1 @@
+export default () => {};

--- a/tests/blackbox/extensions/cairncms-extension-settings-fixture/package.json
+++ b/tests/blackbox/extensions/cairncms-extension-settings-fixture/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "cairncms-extension-settings-fixture",
+	"version": "1.0.0",
+	"type": "module",
+	"private": true,
+	"cairncms:extension": {
+		"type": "endpoint",
+		"path": "index.js",
+		"source": "index.js",
+		"host": "^1.0.0",
+		"settings": {
+			"base_url": { "type": "string", "scope": "global" },
+			"preview_url": { "type": "string", "scope": "collection" },
+			"api_key": { "type": "string", "scope": "global", "sensitive": true }
+		}
+	}
+}

--- a/tests/blackbox/routes/extensions/confined-items.test.ts
+++ b/tests/blackbox/routes/extensions/confined-items.test.ts
@@ -661,4 +661,21 @@ describe('Confined items host through the real flow binding', () => {
 			60000
 		);
 	});
+
+	describe('host.items cannot reach an internal table', () => {
+		it.each(vendors)(
+			'%s answers a request for cairncms_extension_settings with a host error',
+			async (vendor) => {
+				const reply = await runOperation(
+					vendor,
+					'currentUser',
+					{ collection: 'cairncms_extension_settings' },
+					TENANT_A_TOKEN
+				);
+
+				expect(reply.ok).toBe(false);
+			},
+			60000
+		);
+	});
 });

--- a/tests/blackbox/routes/extensions/settings-internal-table.test.ts
+++ b/tests/blackbox/routes/extensions/settings-internal-table.test.ts
@@ -1,0 +1,115 @@
+import config, { getUrl } from '@common/config';
+import * as common from '@common/index';
+import { requestGraphQL } from '@common/index';
+import vendors from '@common/get-dbs-to-test';
+import knex, { type Knex } from 'knex';
+import request from 'supertest';
+
+const TABLE = 'cairncms_extension_settings';
+const FORBIDDEN = [403, 404];
+const TOKEN = () => common.USER.ADMIN.TOKEN;
+
+describe('internal table cairncms_extension_settings stays hidden from every operator surface', () => {
+	const databases = new Map<string, Knex>();
+
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			const db = knex(config.knexConfig[vendor]!);
+			databases.set(vendor, db);
+			// A directus_collections metadata row pins the metadata-leak path: an internal table
+			// must stay hidden even when it has a collection metadata row, not only a physical table.
+			// Delete-then-insert keeps the seed idempotent and portable across every blackbox vendor.
+			await db('directus_collections').del().where({ collection: TABLE });
+			await db('directus_collections').insert({ collection: TABLE });
+		}
+	});
+
+	afterAll(async () => {
+		for (const [, db] of databases) {
+			await db('directus_collections').del().where({ collection: TABLE });
+			await db.destroy();
+		}
+	});
+
+	it.each(vendors)('%s: absent from /collections, /collections/:collection, and GraphQL', async (vendor) => {
+		const url = getUrl(vendor);
+
+		const list = await request(url).get('/collections').set('Authorization', `Bearer ${TOKEN()}`);
+		expect(list.body.data.map((collection: any) => collection.collection)).not.toContain(TABLE);
+
+		const one = await request(url).get(`/collections/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`);
+		expect(FORBIDDEN).toContain(one.status);
+
+		const gql = await requestGraphQL(url, true, TOKEN(), { query: { collections: { collection: true } } });
+		expect(gql.body.data.collections.map((collection: any) => collection.collection)).not.toContain(TABLE);
+
+		const itemGql = await requestGraphQL(url, false, TOKEN(), { query: { [TABLE]: { id: true } } });
+		expect(itemGql.body.errors).toBeDefined();
+		expect(itemGql.body.data?.[TABLE]).toBeUndefined();
+	});
+
+	it.each(vendors)('%s: absent from /fields and /relations', async (vendor) => {
+		const url = getUrl(vendor);
+
+		const fields = await request(url).get('/fields').set('Authorization', `Bearer ${TOKEN()}`);
+		expect(fields.body.data.some((field: any) => field.collection === TABLE)).toBe(false);
+
+		const scopedFields = await request(url).get(`/fields/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`);
+		expect(FORBIDDEN).toContain(scopedFields.status);
+
+		const relations = await request(url).get('/relations').set('Authorization', `Bearer ${TOKEN()}`);
+		expect(
+			relations.body.data.some(
+				(relation: any) => relation.collection === TABLE || relation.related_collection === TABLE
+			)
+		).toBe(false);
+	});
+
+	it.each(vendors)('%s: absent from the schema snapshot', async (vendor) => {
+		const snapshot = await request(getUrl(vendor)).get('/schema/snapshot').set('Authorization', `Bearer ${TOKEN()}`);
+		const { collections, fields, relations } = snapshot.body.data;
+
+		expect(collections.map((collection: any) => collection.collection)).not.toContain(TABLE);
+		expect(fields.some((field: any) => field.collection === TABLE)).toBe(false);
+		expect(
+			relations.some((relation: any) => relation.collection === TABLE || relation.related_collection === TABLE)
+		).toBe(false);
+	});
+
+	it.each(vendors)('%s: generic /items is forbidden for every collection and item route', async (vendor) => {
+		const url = getUrl(vendor);
+
+		const responses = await Promise.all([
+			request(url).get(`/items/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`),
+			request(url).search(`/items/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`).send({ query: {} }),
+			request(url).post(`/items/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`).send({}),
+			request(url).patch(`/items/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`).send({}),
+			request(url).delete(`/items/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`).send([]),
+			request(url).get(`/items/${TABLE}/1`).set('Authorization', `Bearer ${TOKEN()}`),
+			request(url).patch(`/items/${TABLE}/1`).set('Authorization', `Bearer ${TOKEN()}`).send({}),
+			request(url).delete(`/items/${TABLE}/1`).set('Authorization', `Bearer ${TOKEN()}`),
+		]);
+
+		for (const response of responses) expect(FORBIDDEN).toContain(response.status);
+	});
+
+	it.each(vendors)('%s: generic import and export are forbidden', async (vendor) => {
+		const url = getUrl(vendor);
+
+		const importResponse = await request(url).post(`/utils/import/${TABLE}`).set('Authorization', `Bearer ${TOKEN()}`);
+
+		const exportResponse = await request(url)
+			.post(`/utils/export/${TABLE}`)
+			.set('Authorization', `Bearer ${TOKEN()}`)
+			.send({ query: {}, format: 'json' });
+
+		expect(FORBIDDEN).toContain(importResponse.status);
+		expect(FORBIDDEN).toContain(exportResponse.status);
+	});
+
+	it.each(vendors)('%s: absent from the OpenAPI spec', async (vendor) => {
+		const spec = await request(getUrl(vendor)).get('/server/specs/oas').set('Authorization', `Bearer ${TOKEN()}`);
+		expect(spec.status).toBe(200);
+		expect(JSON.stringify(spec.body)).not.toContain(TABLE);
+	});
+});

--- a/tests/blackbox/routes/extensions/settings-service.test.ts
+++ b/tests/blackbox/routes/extensions/settings-service.test.ts
@@ -1,0 +1,187 @@
+import config, { getUrl } from '@common/config';
+import { CreateCollection, DeleteCollection } from '@common/functions';
+import * as common from '@common/index';
+import vendors from '@common/get-dbs-to-test';
+import knex, { type Knex } from 'knex';
+import request from 'supertest';
+
+const TABLE = 'cairncms_extension_settings';
+const SUBJECT = 'cairncms-extension-settings-fixture';
+const BAD_SUBJECT = 'bad-subject';
+const ORPHAN_SUBJECT = 'cairncms-extension-uninstalled';
+const PREVIEW_COLLECTION = 'settings_preview_target';
+const TOKEN = () => common.USER.ADMIN.TOKEN;
+
+describe('the extension settings service over /extension-settings', () => {
+	const databases = new Map<string, Knex>();
+
+	beforeAll(async () => {
+		for (const vendor of vendors) {
+			databases.set(vendor, knex(config.knexConfig[vendor]!));
+			await CreateCollection(vendor, { collection: PREVIEW_COLLECTION });
+		}
+	});
+
+	afterAll(async () => {
+		for (const [vendor, db] of databases) {
+			await db(TABLE).whereIn('extension', [SUBJECT, BAD_SUBJECT, ORPHAN_SUBJECT]).del();
+			await DeleteCollection(vendor, { collection: PREVIEW_COLLECTION });
+			await db.destroy();
+		}
+	});
+
+	it.each(vendors)('%s: round-trips a value, stores a secret pointer unresolved, and purges', async (vendor) => {
+		const url = getUrl(vendor);
+		const auth = `Bearer ${TOKEN()}`;
+
+		const set = await request(url)
+			.post('/extension-settings')
+			.set('Authorization', auth)
+			.send({ subject: SUBJECT, scope: 'global', scope_key: '', key: 'base_url', value: 'https://preview.example.com' });
+
+		expect(set.status).toBe(200);
+
+		const setSecret = await request(url)
+			.post('/extension-settings')
+			.set('Authorization', auth)
+			.send({
+				subject: SUBJECT,
+				scope: 'global',
+				scope_key: '',
+				key: 'api_key',
+				value: { source: 'config', name: 'MY_API_KEY' },
+			});
+
+		expect(setSecret.status).toBe(200);
+
+		const read = await request(url).get(`/extension-settings?subject=${SUBJECT}`).set('Authorization', auth);
+		expect(read.status).toBe(200);
+
+		const byKey = Object.fromEntries(read.body.data.map((row: any) => [row.key, row.value]));
+		expect(byKey.base_url).toBe('https://preview.example.com');
+		expect(byKey.api_key).toEqual({ source: 'config', name: 'MY_API_KEY' });
+
+		const removed = await request(url)
+			.delete('/extension-settings')
+			.set('Authorization', auth)
+			.send({ subject: SUBJECT });
+
+		expect(removed.status).toBe(200);
+		expect(removed.body.data.removed).toBeGreaterThanOrEqual(2);
+
+		const afterPurge = await request(url).get(`/extension-settings?subject=${SUBJECT}`).set('Authorization', auth);
+		expect(afterPurge.body.data).toEqual([]);
+	});
+
+	it.each(vendors)('%s: round-trips a collection-scoped value against a real collection', async (vendor) => {
+		const url = getUrl(vendor);
+		const auth = `Bearer ${TOKEN()}`;
+
+		const set = await request(url)
+			.post('/extension-settings')
+			.set('Authorization', auth)
+			.send({
+				subject: SUBJECT,
+				scope: 'collection',
+				scope_key: PREVIEW_COLLECTION,
+				key: 'preview_url',
+				value: 'https://preview.example.com/article',
+			});
+
+		expect(set.status).toBe(200);
+
+		const read = await request(url)
+			.get(`/extension-settings?subject=${SUBJECT}&scope=collection&scope_key=${PREVIEW_COLLECTION}`)
+			.set('Authorization', auth);
+
+		expect(read.status).toBe(200);
+		expect(read.body.data).toEqual([
+			{
+				scope: 'collection',
+				scope_key: PREVIEW_COLLECTION,
+				key: 'preview_url',
+				value: 'https://preview.example.com/article',
+			},
+		]);
+	});
+
+	it.each(vendors)('%s: refuses every invalid write with a 400', async (vendor) => {
+		const url = getUrl(vendor);
+		const post = (body: any) =>
+			request(url).post('/extension-settings').set('Authorization', `Bearer ${TOKEN()}`).send(body);
+
+		expect((await post({ subject: SUBJECT, scope: 'global', scope_key: '', key: 'nope', value: 'x' })).status).toBe(400);
+		expect((await post({ subject: SUBJECT, scope: 'global', scope_key: '', key: 'api_key', value: 'raw' })).status).toBe(
+			400
+		);
+		expect(
+			(await post({ subject: SUBJECT, scope: 'global', scope_key: '', key: 'preview_url', value: 'x' })).status
+		).toBe(400);
+		expect(
+			(await post({ subject: SUBJECT, scope: 'collection', scope_key: 'ghosts', key: 'preview_url', value: 'x' }))
+				.status
+		).toBe(400);
+		expect((await post({ scope: 'global', scope_key: '', key: 'base_url', value: 'x' })).status).toBe(400);
+	});
+
+	it.each(vendors)('%s: refuses an ineligible or absent subject while the extension still loads', async (vendor) => {
+		const url = getUrl(vendor);
+		const auth = `Bearer ${TOKEN()}`;
+
+		const diagnostics = await request(url).get('/extensions').set('Authorization', auth);
+		const byName = Object.fromEntries(diagnostics.body.data.map((row: any) => [row.name, row]));
+		expect(byName[BAD_SUBJECT]?.status).toBe('loaded');
+
+		const ineligible = await request(url)
+			.post('/extension-settings')
+			.set('Authorization', auth)
+			.send({ subject: BAD_SUBJECT, scope: 'global', scope_key: '', key: 'some_key', value: 'x' });
+
+		expect(ineligible.status).toBe(403);
+
+		const absent = await request(url)
+			.post('/extension-settings')
+			.set('Authorization', auth)
+			.send({ subject: 'cairncms-extension-not-installed', scope: 'global', scope_key: '', key: 'base_url', value: 'x' });
+
+		expect(absent.status).toBe(403);
+	});
+
+	it.each(vendors)('%s: reads and purges orphaned rows for an uninstalled subject', async (vendor) => {
+		const url = getUrl(vendor);
+		const auth = `Bearer ${TOKEN()}`;
+		const db = databases.get(vendor)!;
+
+		await db(TABLE).where({ extension: ORPHAN_SUBJECT }).del();
+
+		await db(TABLE).insert({
+			id: '00000000-0000-4000-8000-000000000001',
+			extension: ORPHAN_SUBJECT,
+			scope: 'global',
+			scope_key: '',
+			key: 'leftover',
+			value: JSON.stringify('orphan-value'),
+		});
+
+		const read = await request(url).get(`/extension-settings?subject=${ORPHAN_SUBJECT}`).set('Authorization', auth);
+		expect(read.status).toBe(200);
+		expect(read.body.data).toEqual([{ scope: 'global', scope_key: '', key: 'leftover', value: 'orphan-value' }]);
+
+		const removed = await request(url)
+			.delete('/extension-settings')
+			.set('Authorization', auth)
+			.send({ subject: ORPHAN_SUBJECT });
+
+		expect(removed.status).toBe(200);
+		expect(removed.body.data.removed).toBe(1);
+
+		const after = await request(url).get(`/extension-settings?subject=${ORPHAN_SUBJECT}`).set('Authorization', auth);
+		expect(after.body.data).toEqual([]);
+	});
+
+	it.each(vendors)('%s: forbids a request without administrator access', async (vendor) => {
+		const url = getUrl(vendor);
+		const res = await request(url).get(`/extension-settings?subject=${SUBJECT}`);
+		expect([401, 403]).toContain(res.status);
+	});
+});

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -22,6 +22,7 @@ exports.list = {
 		{ testFilePath: '/routes/extensions/confined-hooks.test.ts' },
 		{ testFilePath: '/routes/extensions/confined-bundle.test.ts' },
 		{ testFilePath: '/routes/extensions/settings-internal-table.test.ts' },
+		{ testFilePath: '/routes/extensions/settings-service.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/items/relational-presets.test.ts' },

--- a/tests/blackbox/setup/sequentialTests.js
+++ b/tests/blackbox/setup/sequentialTests.js
@@ -21,6 +21,7 @@ exports.list = {
 		{ testFilePath: '/routes/extensions/confined-endpoints.test.ts' },
 		{ testFilePath: '/routes/extensions/confined-hooks.test.ts' },
 		{ testFilePath: '/routes/extensions/confined-bundle.test.ts' },
+		{ testFilePath: '/routes/extensions/settings-internal-table.test.ts' },
 		{ testFilePath: '/routes/collections/schema-cache.test.ts' },
 		{ testFilePath: '/routes/permissions/cache-purge.test.ts' },
 		{ testFilePath: '/routes/items/relational-presets.test.ts' },


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds the foundation for declared extension configuration, including secrets. An extension can now declare a `settings` block in its manifest, the values are stored and validated, and a sandboxed extension reads its own settings at runtime. A sensitive value is stored only as a pointer to a platform config variable, and the secret is resolved server-side at the moment it is used. The way an operator manages these values lives in the admin app and is a later step, so for now they are reached through an admin-only API.

Progress so far:

- The internal-table framework: A new class of platform-owned table, hidden from every operator surface. This is the foundation the settings store is built on, and it is deny-by-default, so registered internal tables are hidden from generic schema and item surfaces.
- Declaring settings: An extension declares a `settings` block in its manifest: typed keys that are a string, a number, or a boolean, each scoped globally or to a collection, and a key can be marked sensitive. A malformed or duplicate declaration disables settings for that extension with a sanitized reason, and the extension still loads.
- Storage: Settings live in the hidden internal table, keyed by the extension's package name. A sensitive value is stored only as a pointer to a platform config variable.
- Validation, behind an interim API: Until the admin app gains a settings UI, the values are reached through an admin-only API that sets, reads, and purges an extension's settings. It is the programmatic layer the management screen will later sit on, not how an operator is meant to manage settings. Every write is validated against the extension's current declaration. An undeclared key, a value of the wrong type, a non-finite number, a scope that does not match the declaration, or a sensitive value that is not a config pointer are all refused.
- Confined reads: A sandboxed extension reads its own global settings at runtime. An extension can only ever read its own settings.

The settings management screen in the admin app, the app-side read for collection-scoped settings, the cleanup of a collection's settings when the collection is deleted, and the operator-facing "settings unavailable" notice are the remaining follow-ups.

### Testing / verification

The hidden-table guarantee and the admin API are exercised over real HTTP against a live server and database, with the blackbox suite covering the hidden-table and admin-API cases across the supported databases. The confined reads and secret resolution are proven end to end through a real sandboxed child, for an operation, an endpoint, a hook, and a bundle entry.

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
