### PR TITLE
Add expand/collapse for collection items in the data model

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -503,7 +503,8 @@ enable_select_button: Enable Select Button
 allow_duplicates: Allow Duplicates
 comments: Comments
 no_comments: No Comments Yet
-click_to_expand: Click to Expand
+expand: Expand
+collapse: Collapse
 select_item: Select Item
 no_items: No items
 search_items: Search items...

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -76,7 +76,7 @@
 						<span class="collection-name">{{ collection.name }}</span>
 					</router-link>
 
-					<collection-options :collection="collection" />
+					<collection-options :collection="collection" :has-nested-collections="false" />
 				</v-list-item>
 			</v-list>
 

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-item.vue
@@ -22,51 +22,53 @@
 				<span ref="collectionName" class="collection-name">{{ collection.collection }}</span>
 				<span v-if="collection.meta?.note" class="collection-note">{{ collection.meta.note }}</span>
 			</div>
-			<template v-if="collection.type === 'alias' || nestedCollections.length">
-				<v-progress-circular v-if="collapseLoading" small indeterminate />
-				<v-icon
-					v-else-if="nestedCollections.length"
-					v-tooltip="collapseTooltip"
-					:name="collapseIcon"
-					:clickable="nestedCollections.length > 0"
-					@click.stop.prevent="toggleCollapse"
-				/>
-				<v-icon v-else :name="collapseIcon" />
-			</template>
-			<collection-options :collection="collection" />
+
+			<v-icon
+				v-if="nestedCollections?.length"
+				v-tooltip="isCollectionExpanded ? t('collapse') : t('expand')"
+				:name="isCollectionExpanded ? 'unfold_less' : 'unfold_more'"
+				clickable
+				@click.stop.prevent="toggleCollapse"
+			/>
+			<collection-options
+				:has-nested-collections="nestedCollections.length > 0"
+				:collection="collection"
+				@collection-toggle="toggleCollapse"
+			/>
 		</v-list-item>
 
-		<draggable
-			:force-fallback="true"
-			:model-value="nestedCollections"
-			:group="{ name: 'collections' }"
-			:swap-threshold="0.3"
-			class="drag-container"
-			item-key="collection"
-			handle=".drag-handle"
-			@update:model-value="onGroupSortChange"
-		>
-			<template #item="{ element }">
-				<collection-item
-					:collection="element"
-					:collections="collections"
-					@edit-collection="$emit('editCollection', $event)"
-					@set-nested-sort="$emit('setNestedSort', $event)"
-				/>
-			</template>
-		</draggable>
+		<transition-expand class="collection-items">
+			<draggable
+				v-if="isCollectionExpanded"
+				:force-fallback="true"
+				:model-value="nestedCollections"
+				:group="{ name: 'collections' }"
+				:swap-threshold="0.3"
+				class="drag-container"
+				item-key="collection"
+				handle=".drag-handle"
+				@update:model-value="onGroupSortChange"
+			>
+				<template #item="{ element }">
+					<collection-item
+						:collection="element"
+						:collections="collections"
+						@edit-collection="$emit('editCollection', $event)"
+						@set-nested-sort="$emit('setNestedSort', $event)"
+					/>
+				</template>
+			</draggable>
+		</transition-expand>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import CollectionOptions from './collection-options.vue';
+import { useLocalStorage } from '@/composables/use-local-storage';
 import { Collection } from '@/types/collections';
-import Draggable from 'vuedraggable';
-import { useCollectionsStore } from '@/stores/collections';
-import { DeepPartial } from '@cairncms/types';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { unexpectedError } from '@/utils/unexpected-error';
+import Draggable from 'vuedraggable';
+import CollectionOptions from './collection-options.vue';
 
 const props = defineProps<{
 	collection: Collection;
@@ -76,66 +78,16 @@ const props = defineProps<{
 
 const emit = defineEmits(['setNestedSort', 'editCollection']);
 
-const collectionsStore = useCollectionsStore();
 const { t } = useI18n();
+const { data: isCollectionExpanded } = useLocalStorage(`settings-collapsed-${props.collection.collection}`, true);
+
+const toggleCollapse = () => {
+	isCollectionExpanded.value = !isCollectionExpanded.value;
+};
 
 const nestedCollections = computed(() =>
 	props.collections.filter((collection) => collection.meta?.group === props.collection.collection)
 );
-
-const collapseIcon = computed(() => {
-	switch (props.collection.meta?.collapse) {
-		case 'open':
-			return 'folder_open';
-		case 'closed':
-			return 'folder';
-		case 'locked':
-			return 'folder_lock';
-	}
-
-	return undefined;
-});
-
-const collapseTooltip = computed(() => {
-	switch (props.collection.meta?.collapse) {
-		case 'open':
-			return t('start_open');
-		case 'closed':
-			return t('start_collapsed');
-		case 'locked':
-			return t('always_open');
-	}
-
-	return undefined;
-});
-
-const collapseLoading = ref(false);
-
-async function toggleCollapse() {
-	if (collapseLoading.value === true) return;
-
-	collapseLoading.value = true;
-
-	let newCollapse: 'open' | 'closed' | 'locked' = 'open';
-
-	if (props.collection.meta?.collapse === 'open') {
-		newCollapse = 'closed';
-	} else if (props.collection.meta?.collapse === 'closed') {
-		newCollapse = 'locked';
-	}
-
-	try {
-		await update({ meta: { collapse: newCollapse } });
-	} catch (err: any) {
-		unexpectedError(err);
-	} finally {
-		collapseLoading.value = false;
-	}
-}
-
-async function update(updates: DeepPartial<Collection>) {
-	await collectionsStore.updateCollection(props.collection.collection, updates);
-}
 
 function onGroupSortChange(collections: Collection[]) {
 	const updates = collections.map((collection) => ({

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.test.ts
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.test.ts
@@ -1,0 +1,76 @@
+import { i18n } from '@/lang';
+import { useCollectionsStore } from '@/stores/collections';
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CollectionOptions from './collection-options.vue';
+
+const stubs = {
+	'v-menu': { template: '<div><slot /></div>' },
+	'v-list': { template: '<div><slot /></div>' },
+	'v-list-item': { template: '<div class="v-list-item" @click="$emit(\'click\')"><slot /></div>', emits: ['click'] },
+	'v-list-item-icon': { template: '<div><slot /></div>' },
+	'v-list-item-content': { template: '<div class="v-list-item-content"><slot /></div>' },
+	'v-icon': { props: ['name'], template: '<i :data-icon="name"></i>' },
+	'v-divider': true,
+	'v-dialog': true,
+	'v-card': true,
+	'v-card-title': true,
+	'v-card-text': true,
+	'v-card-actions': true,
+	'v-button': true,
+	'v-notice': true,
+};
+
+function mountOptions(collection: Record<string, unknown>, hasNestedCollections: boolean) {
+	return mount(CollectionOptions, {
+		props: { collection, hasNestedCollections } as never,
+		global: { plugins: [i18n], stubs },
+	});
+}
+
+function collapseItem(wrapper: ReturnType<typeof mountOptions>, label: string) {
+	return wrapper.findAll('.v-list-item').find((item) => item.text().includes(label));
+}
+
+describe('collection-options collapse settings', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+	});
+
+	it('shows the three collapse settings for a collection with nested collections', () => {
+		const wrapper = mountOptions({ collection: 'articles', type: 'normal', schema: {}, meta: {} }, true);
+
+		expect(collapseItem(wrapper, 'Start Open')).toBeTruthy();
+		expect(collapseItem(wrapper, 'Start Collapsed')).toBeTruthy();
+		expect(collapseItem(wrapper, 'Always Open')).toBeTruthy();
+	});
+
+	it('shows the collapse settings for an alias collection even without nested collections', () => {
+		const wrapper = mountOptions({ collection: 'group', type: 'alias', meta: {} }, false);
+
+		expect(collapseItem(wrapper, 'Start Open')).toBeTruthy();
+	});
+
+	it('hides the collapse settings for a leaf collection with no nested collections', () => {
+		const wrapper = mountOptions({ collection: 'articles', type: 'normal', schema: {}, meta: {} }, false);
+
+		expect(collapseItem(wrapper, 'Start Open')).toBeFalsy();
+		expect(collapseItem(wrapper, 'Always Open')).toBeFalsy();
+	});
+
+	it('writes the matching meta.collapse value for each setting', async () => {
+		const wrapper = mountOptions({ collection: 'articles', type: 'normal', schema: {}, meta: {} }, true);
+		const store = useCollectionsStore();
+
+		await collapseItem(wrapper, 'Start Open')!.trigger('click');
+		expect(store.updateCollection).toHaveBeenCalledWith('articles', { meta: { collapse: 'open' } });
+
+		await collapseItem(wrapper, 'Start Collapsed')!.trigger('click');
+		expect(store.updateCollection).toHaveBeenCalledWith('articles', { meta: { collapse: 'closed' } });
+
+		await collapseItem(wrapper, 'Always Open')!.trigger('click');
+		expect(store.updateCollection).toHaveBeenCalledWith('articles', { meta: { collapse: 'locked' } });
+	});
+});

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -29,6 +29,51 @@
 					</template>
 				</v-list-item>
 
+				<template v-if="collection.type === 'alias' || hasNestedCollections">
+					<v-divider />
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'open'"
+						clickable
+						@click="update({ meta: { collapse: 'open' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder_open" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('start_open') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'closed'"
+						clickable
+						@click="update({ meta: { collapse: 'closed' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('start_collapsed') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-list-item
+						:active="collection.meta?.collapse === 'locked'"
+						clickable
+						@click="update({ meta: { collapse: 'locked' } })"
+					>
+						<v-list-item-icon>
+							<v-icon name="folder_lock" />
+						</v-list-item-icon>
+						<v-list-item-content>
+							{{ t('always_open') }}
+						</v-list-item-content>
+					</v-list-item>
+
+					<v-divider />
+				</template>
+
 				<v-list-item clickable class="danger" @click="deleteActive = true">
 					<v-list-item-icon>
 						<v-icon name="delete" />
@@ -75,15 +120,17 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import { computed, ref } from 'vue';
-import { Collection } from '@/types/collections';
 import { useCollectionsStore } from '@/stores/collections';
-import { useRelationsStore } from '@/stores/relations';
 import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
+import { Collection } from '@/types/collections';
+import type { DeepPartial } from '@cairncms/types';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type Props = {
 	collection: Collection;
+	hasNestedCollections: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {});
@@ -111,10 +158,6 @@ const peerDependencies = computed(() => {
 		}));
 });
 
-async function update(updates: Partial<Collection>) {
-	await collectionsStore.updateCollection(props.collection.collection, updates);
-}
-
 function useDelete() {
 	const deleting = ref(false);
 	const deleteActive = ref(false);
@@ -135,6 +178,10 @@ function useDelete() {
 			deleting.value = false;
 		}
 	}
+}
+
+async function update(updates: DeepPartial<Collection>) {
+	await collectionsStore.updateCollection(props.collection.collection, updates);
 }
 </script>
 


### PR DESCRIPTION
## Related Issue or Discussion

- n/a

## Scope

- What problem does this PR solve?

Adds a per-user expand/collapse control for nested collections in the data model view. Also makes the db-only collection options caller pass the required nested-collections flag explicitly, so all callers satisfy the component contract.

### Testing / verification

Added a test covering:
- collapse menu actions render for alias collections
- collapse menu actions render for collections with nested children
- collapse menu actions do not render for leaf collections
- Start Open / Start Collapsed / Always Open write the matching `meta.collapse` values

Also verified against a live instance and confirmed:
- the data model tree toggle hides and shows nested children
- the expanded/collapsed state persists under `directus-settings-collapsed-<collection>`
- the moved menu setting updates `meta.collapse` end to end

## Checklist

Before submitting a PR, please complete the following checklist.

- [x] I have read the [contribution guide](https://github.com/CairnCMS/cairncms/blob/main/CONTRIBUTING.md)
- [x] I have run tests with `pnpm test` and lint with `pnpm lint`
- [x] I have added test cases as necessary

## AI Policy

Complete the following checklist if AI assistance was used for this PR.

- [x] I have read the [AI Policy](https://github.com/CairnCMS/cairncms/blob/main/AI_POLICY.md)
- [x] All submitted code is human-reviewed
- [x] All submitted documentation/comments are human-reviewed and human-edited

***

✒️ I contribute this code under the Developer Certificate of Origin.
